### PR TITLE
fix(lab): UX-AUDIT-FIX8 — collapse signer fields in <details> by default

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -819,22 +819,51 @@ export default function LabReportWorkbench({
                 </div>
               </div>
 
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 'var(--mac-spacing-3)' }}>
-                {['lab_technician_label', 'lab_technician_name', 'approver_label', 'approver_name'].map((key) => (
-                  <label key={key} style={{ display: 'grid', gap: 'var(--mac-spacing-2)' }}>
-                    <span>{signerFieldLabels[key] || key}</span>
-                    <Input
-                      className="macos-input"
-                      aria-label={signerFieldLabels[key] || key}
-                      value={signerSnapshot?.[key] || ''}
-                      onChange={(event) => setSignerSnapshot((prev) => ({ ...prev, [key]: event.target.value }))}
-                      // WF-09 fix: signer fields должны блокироваться на FINALIZED/PRINTED,
-                      // иначе persistDraft вызовет updateInstance → 409 Conflict (silent failure).
-                      disabled={!canEditActiveInstance}
-                    />
-                  </label>
-                ))}
-              </div>
+              {/* UX-AUDIT-FIX8: signer fields свёрнуты в <details>.
+                  Ранее 4 поля (lab_technician_label/name, approver_label/name)
+                  всегда занимали vertical space, даже в DRAFT, когда подпись
+                  ещё не нужна. Это нарушает Nielsen Heuristic #8 (Aesthetic
+                  and Minimalist Design). Теперь по умолчанию свернуты;
+                  раскрываются одним кликом когда нужны.
+
+                  Auto-expand когда отчёт нередактируем (FINALIZED/PRINTED) —
+                  для семантической согласованности (Nielsen Heuristic #2).
+                  Используем canEditActiveInstance (backend-owned action)
+                  вместо прямой проверки status — соответствует SSOT-контракту. */}
+              <details open={!canEditActiveInstance}>
+                <summary
+                  style={{
+                    cursor: 'pointer',
+                    fontWeight: 600,
+                    color: 'var(--mac-text-secondary)',
+                    padding: 'var(--mac-spacing-2) 0',
+                    listStyle: 'none',
+                  }}
+                >
+                  Подписи
+                  {!canEditActiveInstance && (
+                    <span style={{ marginLeft: 'var(--mac-spacing-2)', fontWeight: 400, fontSize: '0.85em', opacity: 0.7 }}>
+                      (только для чтения — отчёт утверждён)
+                    </span>
+                  )}
+                </summary>
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 'var(--mac-spacing-3)', paddingTop: 'var(--mac-spacing-2)' }}>
+                  {['lab_technician_label', 'lab_technician_name', 'approver_label', 'approver_name'].map((key) => (
+                    <label key={key} style={{ display: 'grid', gap: 'var(--mac-spacing-2)' }}>
+                      <span>{signerFieldLabels[key] || key}</span>
+                      <Input
+                        className="macos-input"
+                        aria-label={signerFieldLabels[key] || key}
+                        value={signerSnapshot?.[key] || ''}
+                        onChange={(event) => setSignerSnapshot((prev) => ({ ...prev, [key]: event.target.value }))}
+                        // WF-09 fix: signer fields должны блокироваться на FINALIZED/PRINTED,
+                        // иначе persistDraft вызовет updateInstance → 409 Conflict (silent failure).
+                        disabled={!canEditActiveInstance}
+                      />
+                    </label>
+                  ))}
+                </div>
+              </details>
 
               {printFeedback && (
                 <Alert severity={printFeedback.severity}>{printFeedback.text}</Alert>

--- a/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
@@ -265,4 +265,19 @@ describe('LabReportWorkbench', () => {
     const confirmIndex = fnBody.indexOf('await confirm(');
     expect(postIndex).toBeGreaterThan(confirmIndex);
   });
+
+  it('UX-AUDIT-FIX8: signer fields are collapsed in <details> by default', () => {
+    // FIX8: 4 signer input fields (lab_technician_label/name,
+    // approver_label/name) ранее всегда занимали vertical space.
+    // Теперь свёрнуты в <details> с auto-expand когда отчёт нередактируем.
+    const source = fs.readFileSync(workbenchPath, 'utf8');
+
+    // Должен быть <details> с подсказкой "Подписи"
+    expect(source).toContain('<details open={!canEditActiveInstance}>');
+    expect(source).toContain('Подписи');
+    // Подсказка "только для чтения" когда не editable
+    expect(source).toContain('только для чтения — отчёт утверждён');
+    // Все 4 signer поля внутри details
+    expect(source).toContain("'lab_technician_label', 'lab_technician_name', 'approver_label', 'approver_name'");
+  });
 });


### PR DESCRIPTION
## Summary

- Collapse the 4 signer input fields (`lab_technician_label`, `lab_technician_name`, `approver_label`, `approver_name`) in `LabReportWorkbench` into a `<details>` element.
- Previously these fields were always visible and consumed vertical space, even in DRAFT status when signature is not yet needed — visual noise that violated Nielsen Heuristic #8 (Aesthetic and Minimalist Design).
- The `<details>` auto-expands when `!canEditActiveInstance` (i.e., FINALIZED/PRINTED) so the signer block is immediately visible in the read-only view, where signatures actually matter.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ux-audit-fix8-collapse-signer-fields` from `origin/main` at `2dd6e822` (post-FIX7).
- Clean workspace: inspected before edits; only `LabReportWorkbench.jsx` and its contract test changed.
- Branch: `fix/ux-audit-fix8-collapse-signer-fields`
- Scope gate: allowed `frontend/src/components/laboratory/LabReportWorkbench.jsx` + `__tests__/LabReportWorkbench.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted test fails, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only visual change. No API, websocket, event, or backend contract changed. Signer field values are still saved to the same `signer_snapshot` payload via the existing `setSignerSnapshot` handler. The `disabled={!canEditActiveInstance}` guard (WF-09 fix) is preserved unchanged inside the `<details>`.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. `canEditActiveInstance` is computed from backend-owned `available_actions` via `hasLabReportAction` (SSOT) — no new role gating introduced.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: when `activeInstance` is null, this JSX block is not rendered at all (parent guard).
- Partial data proof: when `signerSnapshot` is `{}`, all 4 inputs render empty strings via `signerSnapshot?.[key] || ''` fallback.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: signer fields are part of the report draft; the existing `initialValuesRef.current.signer` dirty-tracking is unchanged.
- Stale route/deep-link behavior: not applicable, signer state is local to the active instance.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabReportWorkbench.jsx`, `frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one new test added (7 total tests in file)
- Rollback note: revert both files; signer fields render expanded by default again

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/__tests__/LabReportWorkbench.test.jsx`
- Result: passed (7/7 tests, 1.77s)
- Not checked: full browser panel smoke — out of scope for a details-collapse UX fix