### PR TITLE
fix(lab): UX-AUDIT-FIX9 — confirm dialog before creating lab order from doctor side

### DIFF
--- a/frontend/src/components/emr-v2/sections/LabResultsSection.jsx
+++ b/frontend/src/components/emr-v2/sections/LabResultsSection.jsx
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 import EMRSection from './EMRSection';
 import { labReportingApi } from '../../../api/labReporting';
 import { Badge, Button, Dialog, DialogTitle, DialogContent, DialogActions, Icon } from '../../ui/macos';
+import { useConfirm } from '../../common/ConfirmDialog';
 import logger from '../../../utils/logger';
 import notify from '../../../services/notify';
 
@@ -62,6 +63,14 @@ export function LabResultsSection({ patientId, visitId, disabled = false }) {
   const [templates, setTemplates] = useState([]);
   const [templatesLoading, setTemplatesLoading] = useState(false);
   const [ordering, setOrdering] = useState(false);
+
+  // UX-AUDIT-FIX9: useConfirm для подтверждения создания заказа на анализы.
+  // Ранее один клик в модалке «Заказать анализы» мгновенно создавал заказ
+  // через labReportingApi.createOrder — без подтверждения и без возможности
+  // отмены. Лаборатория сразу видела новый заказ в очереди. Если врач
+  // промахивался мимо нужного шаблона — приходилось идти в лабораторию
+  // и просить отменить. Соответствует Nielsen Heuristic #5 (Error Prevention).
+  const [confirm] = useConfirm();
 
   const loadInstances = useCallback(async () => {
     if (!patientId && !visitId) {
@@ -121,6 +130,18 @@ export function LabResultsSection({ patientId, visitId, disabled = false }) {
   };
 
   const handleOrder = async (templateId, templateName) => {
+    // UX-AUDIT-FIX9: подтверждение перед созданием заказа.
+    const ok = await confirm({
+      title: 'Заказать анализы?',
+      message: `Будет создан заказ «${templateName}» для этого пациента.`,
+      description:
+        'Лаборатория увидит заказ в очереди и приступит к выполнению. ' +
+        'Если заказ ошибочный — его придётся отменять через лабораторию.',
+      confirmLabel: 'Заказать',
+      cancelLabel: 'Отмена',
+      intent: 'primary',
+    });
+    if (!ok) return;
     setOrdering(true);
     try {
       await labReportingApi.createOrder({

--- a/frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx
+++ b/frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx
@@ -46,4 +46,26 @@ describe('LabResultsSection UX-AUDIT-FIX6 — migrate lucide-react to macos Icon
     expect(iconSource).toContain("'square.and.arrow.down'");
     expect(iconSource).toContain('UX-AUDIT-FIX6');
   });
+
+  it('UX-AUDIT-FIX9: requires confirm dialog before creating lab order', () => {
+    // FIX9: handleOrder ранее мгновенно создавал заказ через
+    // labReportingApi.createOrder без подтверждения. Теперь обёрнут в
+    // useConfirm() — соответствует Nielsen Heuristic #5 (Error Prevention).
+    expect(source).toContain("from '../../common/ConfirmDialog'");
+    expect(source).toContain('useConfirm');
+
+    // Ищем функцию handleOrder
+    const fnStart = source.indexOf('const handleOrder = async (templateId, templateName) => {');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf('\n  };', fnStart);
+    const fnBody = source.slice(fnStart, fnEnd);
+
+    expect(fnBody).toContain('await confirm(');
+    expect(fnBody).toContain("'Заказать анализы?'");
+    expect(fnBody).toContain('if (!ok) return;');
+    // createOrder должен вызываться ПОСЛЕ confirm
+    const confirmIdx = fnBody.indexOf('await confirm(');
+    const createIdx = fnBody.indexOf('labReportingApi.createOrder(');
+    expect(createIdx).toBeGreaterThan(confirmIdx);
+  });
 });


### PR DESCRIPTION
## Summary

- Add ConfirmDialog to the doctor-side «Заказать анализы» action in `LabResultsSection.jsx`.
- Previously, clicking a template button in the order modal immediately called `labReportingApi.createOrder` — no confirmation, no undo. The lab queue received the order instantly. If the doctor clicked the wrong template, the only recourse was to walk over to the lab and ask for cancellation.
- Aligns with sibling lab-panel fixes (QW1 Notify, QW2 Reset, FIX4 field/section delete) that already use `useConfirm()`. Closes Nielsen Heuristic #5 (Error Prevention) and Heuristic #4 (Consistency & Standards).

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ux-audit-fix9-confirm-doctor-order` from `origin/main` at `493fdff3` (post-patient-PR-AUDIT-P-L-batch-c).
- Clean workspace: inspected before edits; only `LabResultsSection.jsx` and its contract test changed.
- Branch: `fix/ux-audit-fix9-confirm-doctor-order`
- Scope gate: allowed `frontend/src/components/emr-v2/sections/LabResultsSection.jsx` + `__tests__/LabResultsSection.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted test fails, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only UX change. No API, websocket, event, or backend contract changed. `labReportingApi.createOrder` is called with the same payload shape; only its call site is now gated behind a confirm dialog.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. Confirmation dialog is shown to all doctor roles; same roles can still create orders.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed. The success toast after order creation is unchanged.

## Frontend Resilience

- Empty data proof: when no templates exist, the order modal renders an empty-state message; confirm dialog never fires.
- Partial data proof: confirm dialog uses `templateName` prop directly; if name is missing, the title still renders with `template.name` substituted.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: confirm dialog is independent of patient/visit state; `patientId`/`visitId` are still passed through to `createOrder` unchanged.
- Stale route/deep-link behavior: not applicable, modal is local UI state.

## Scope Gate

- Allowed paths: `frontend/src/components/emr-v2/sections/LabResultsSection.jsx`, `frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one new test added (5 total tests in file)
- Rollback note: revert both files; single-click order creation restored

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx`
- Result: passed (5/5 tests, 1.19s)
- Not checked: full browser panel smoke — out of scope for a single-button UX fix