### PR TITLE
fix(lab): UX-AUDIT-FIX11 — strengthen MaskedPhone affordance with icon + hover/focus states

### DIFF
--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -32,11 +32,26 @@ function maskPhone(phone) {
 // P-05 fix: компонент-обёртка для переключения маска/открыто.
 // L-H-4 fix: миграция inline-стилей в CSS (.lqw-masked-phone*).
 // Раскрытие может быть ограничено ролью через prop canReveal.
+//
+// UX-AUDIT-FIX11: усилена аффорданса кликабельности. Ранее пользователь
+// не понимал, что маску можно раскрыть кликом — title появлялся только
+// при hover, на тач-устройствах не показывался вовсе. Теперь:
+//   1) Добавлена иконка eye/eye.slash перед номером — визуальный cue
+//      «здесь есть действие».
+//   2) CSS-класс .lqw-masked-phone с hover-эффектом (color shift).
+//   3) :focus-visible для keyboard-навигации.
+//   4) title показывает действие («Показать» / «Скрыть»).
+// Соответствует Nielsen Heuristic #6 (Recognition rather than Recall).
 function MaskedPhone({ phone, canReveal = true }) {
   const [revealed, setRevealed] = useState(false);
   if (!phone) return <span className="lqw-masked-phone-empty">не указан</span>;
   if (!canReveal) {
-    return <span>{maskPhone(phone)}</span>;
+    return (
+      <span className="lqw-masked-phone-readonly" title="Доступ к номеру ограничен ролью">
+        <Icon name="eye.slash" size={12} aria-hidden="true" />
+        <span className="lqw-masked-phone-text">{maskPhone(phone)}</span>
+      </span>
+    );
   }
   return (
     <button
@@ -47,9 +62,11 @@ function MaskedPhone({ phone, canReveal = true }) {
       }}
       title={revealed ? 'Скрыть номер' : 'Показать номер (доступ ограничен)'}
       aria-label={revealed ? 'Скрыть номер телефона' : 'Показать номер телефона'}
-      className="lqw-masked-phone"
+      aria-pressed={revealed}
+      className={`lqw-masked-phone ${revealed ? 'lqw-masked-phone-revealed' : ''}`}
     >
-      {revealed ? phone : maskPhone(phone)}
+      <Icon name={revealed ? 'eye.slash' : 'eye'} size={12} aria-hidden="true" />
+      <span className="lqw-masked-phone-text">{revealed ? phone : maskPhone(phone)}</span>
     </button>
   );
 }

--- a/frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { fileURLToPath } from 'node:url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../../..');
+
+const source = fs.readFileSync(
+  path.join(ROOT, 'components/laboratory/LabQueueWorkbench.jsx'),
+  'utf8'
+);
+
+const cssSource = fs.readFileSync(
+  path.join(ROOT, 'pages/lab.css'),
+  'utf8'
+);
+
+describe('LabQueueWorkbench UX-AUDIT-FIX11 — MaskedPhone affordance', () => {
+  it('uses eye/eye.slash icons in MaskedPhone component', () => {
+    // FIX11: иконка глаза — визуальный cue кликабельности.
+    expect(source).toContain('<Icon name={revealed ? \'eye.slash\' : \'eye\'}');
+    expect(source).toContain('<Icon name="eye.slash"');
+  });
+
+  it('adds aria-pressed to indicate toggle state', () => {
+    expect(source).toContain('aria-pressed={revealed}');
+  });
+
+  it('adds revealed CSS class for visual state', () => {
+    expect(source).toContain('lqw-masked-phone-revealed');
+  });
+
+  it('adds read-only variant when canReveal=false', () => {
+    expect(source).toContain('lqw-masked-phone-readonly');
+    expect(source).toContain('title="Доступ к номеру ограничен ролью"');
+  });
+
+  it('registers hover/focus styles in lab.css', () => {
+    expect(cssSource).toContain('.lqw-masked-phone:hover');
+    expect(cssSource).toContain('.lqw-masked-phone:focus-visible');
+    expect(cssSource).toContain('.lqw-masked-phone-revealed');
+    expect(cssSource).toContain('.lqw-masked-phone-readonly');
+    expect(cssSource).toContain('.lqw-masked-phone-text');
+    // UX-AUDIT-FIX11 marker
+    expect(cssSource).toContain('UX-AUDIT-FIX11');
+  });
+});

--- a/frontend/src/pages/lab.css
+++ b/frontend/src/pages/lab.css
@@ -458,14 +458,50 @@
 
 /* MaskedPhone button (L-H-4 + L-M-5 fix) */
 .lqw-masked-phone {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mac-spacing-1);
   background: none;
   border: none;
-  padding: 0;
+  padding: 2px 4px;
   cursor: pointer;
-  color: inherit;
+  color: var(--mac-text-secondary);
   font: inherit;
   text-decoration: underline dotted;
   text-underline-offset: 2px;
+  border-radius: 4px;
+  transition: color var(--mac-duration-fast) var(--mac-ease),
+              background-color var(--mac-duration-fast) var(--mac-ease);
+}
+
+/* UX-AUDIT-FIX11: усиленная аффорданса — hover/focus визуальный cue */
+.lqw-masked-phone:hover {
+  color: var(--mac-accent);
+  background-color: var(--mac-bg-accent);
+  text-decoration: underline;
+}
+
+.lqw-masked-phone:focus-visible {
+  outline: 2px solid var(--mac-accent);
+  outline-offset: 1px;
+}
+
+.lqw-masked-phone-revealed {
+  color: var(--mac-text-primary);
+  font-weight: 500;
+}
+
+.lqw-masked-phone-text {
+  white-space: nowrap;
+}
+
+/* Read-only mode (canReveal=false) */
+.lqw-masked-phone-readonly {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mac-spacing-1);
+  color: var(--mac-text-tertiary);
+  opacity: 0.7;
 }
 
 .lqw-masked-phone-empty {


### PR DESCRIPTION
## Summary

- Strengthen the affordance of the `MaskedPhone` component in `LabQueueWorkbench.jsx` so users can see it is clickable.
- Previously the only cue was `text-decoration: underline dotted` on hover — invisible on touch devices, easy to miss on desktop. Users did not realize they could click to reveal the phone number.
- Now adds: (1) `eye`/`eye.slash` icon prefix that visually signals «here is an action»; (2) hover and focus-visible CSS states; (3) `aria-pressed` for screen readers; (4) explicit read-only variant with eye.slash icon when `canReveal=false`. Aligns with Nielsen Heuristic #6 (Recognition rather than Recall).

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ux-audit-fix11-masked-phone-affordance` from `origin/main` at `daa615a3` (post-FIX10).
- Clean workspace: inspected before edits; only `LabQueueWorkbench.jsx`, `lab.css`, and new contract test changed.
- Branch: `fix/ux-audit-fix11-masked-phone-affordance`
- Scope gate: allowed `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/pages/lab.css`, `frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted test fails, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only visual/affordance change. No API, websocket, event, or backend contract changed. Phone reveal behavior (toggle masked/revealed locally) is unchanged.

## RBAC / Permissions

not applicable - `canReveal` prop semantics are preserved: when `false`, the button is replaced by a read-only span with eye.slash icon and a tooltip explaining role-based restriction.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: when `phone` is null/empty, existing `lqw-masked-phone-empty` span renders «не указан» (unchanged).
- Partial data proof: `maskPhone()` handles short strings (<4 digits) by returning '***' (unchanged).
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: not applicable, phone comes from queue entry prop.
- Stale route/deep-link behavior: not applicable, MaskedPhone is local component state.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/pages/lab.css`, `frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one contract test file added (5 tests)
- Rollback note: revert all three files; MaskedPhone reverts to dotted-underline-only affordance

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`
- Result: passed (5/5 tests, 1.09s)
- Not checked: visual regression snapshot — new hover/focus styles will be caught by next visual regression run