### PR TITLE
fix(lab): UX-AUDIT-FIX13 — paginate LabQueueWorkbench rendering (load-more button)

### DIFF
--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Badge, Button, Card, CardContent, CardHeader, CardTitle, Icon, Alert,
   Input } from '../ui/macos';
@@ -127,6 +127,19 @@ export default function LabQueueWorkbench({
   const [statusFilter, setStatusFilter] = useState('all');
   // PR-64 / Medium-14: client-side sorting
   const [sortBy, setSortBy] = useState('default'); // default | name | time
+
+  // UX-AUDIT-FIX13: пагинация очереди. Ранее sortedAppointments.map(...)
+  // рендерил ВСЕ записи одновременно — при 100+ анализов в день это
+  // вызывало тормоза рендера и высокий memory footprint. Теперь
+  // показываем по PAGE_SIZE=20 записей, с кнопкой «Показать ещё».
+  // Сбрасываем visibleCount при изменении фильтра/поиска/sortBy.
+  const PAGE_SIZE = 20;
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  // Сбрасываем пагинацию при изменении любого фильтра.
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [searchQuery, statusFilter, sortBy]);
 
   const normalizedSearch = searchQuery.trim().toLowerCase();
   const filteredAppointments = appointments.filter((appointment) => {
@@ -285,7 +298,10 @@ export default function LabQueueWorkbench({
             </Alert>
           ) : (
             <div className="lqw-card-grid">
-              {sortedAppointments.map((appointment) => {
+              {/* UX-AUDIT-FIX13: рендерим только visibleCount записей
+                  вместо всего sortedAppointments. Кнопка «Показать ещё»
+                  внизу увеличивает visibleCount на PAGE_SIZE. */}
+              {sortedAppointments.slice(0, visibleCount).map((appointment) => {
                 const isSelected = selectedAppointment?.id === appointment.id;
                 return (
                   <div
@@ -360,6 +376,21 @@ export default function LabQueueWorkbench({
                   </div>
                 );
               })}
+              {/* UX-AUDIT-FIX13: кнопка «Показать ещё» — увеличивает
+                  visibleCount на PAGE_SIZE. Показывается только если
+                  есть ещё записи для отображения. */}
+              {sortedAppointments.length > visibleCount && (
+                <div className="lqw-load-more">
+                  <Button
+                    variant="outline"
+                    onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+                    aria-label={`Показать ещё ${Math.min(PAGE_SIZE, sortedAppointments.length - visibleCount)} записей`}
+                  >
+                    <Icon name="arrow.down" size={14} />
+                    Показать ещё ({sortedAppointments.length - visibleCount} осталось)
+                  </Button>
+                </div>
+              )}
             </div>
           )}
         </CardContent>

--- a/frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx
@@ -47,4 +47,24 @@ describe('LabQueueWorkbench UX-AUDIT-FIX11 — MaskedPhone affordance', () => {
     // UX-AUDIT-FIX11 marker
     expect(cssSource).toContain('UX-AUDIT-FIX11');
   });
+
+  it('UX-AUDIT-FIX13: paginates queue rendering with PAGE_SIZE + load-more button', () => {
+    // FIX13: рендерим только visibleCount записей через .slice(0, visibleCount)
+    // вместо всего sortedAppointments. Кнопка «Показать ещё» увеличивает count.
+    expect(source).toContain('PAGE_SIZE = 20');
+    expect(source).toContain('visibleCount');
+    expect(source).toContain('setVisibleCount');
+    // .slice для ограничения рендера
+    expect(source).toContain('sortedAppointments.slice(0, visibleCount)');
+    // useEffect для сброса пагинации при смене фильтров
+    expect(source).toContain('useEffect(() => {');
+    expect(source).toContain('setVisibleCount(PAGE_SIZE)');
+    expect(source).toContain('[searchQuery, statusFilter, sortBy]');
+    // Кнопка «Показать ещё» в UI
+    expect(source).toContain('Показать ещё');
+    expect(source).toContain('lqw-load-more');
+    // CSS-класс для контейнера кнопки
+    expect(cssSource).toContain('.lqw-load-more');
+    expect(cssSource).toContain('UX-AUDIT-FIX13');
+  });
 });

--- a/frontend/src/pages/lab.css
+++ b/frontend/src/pages/lab.css
@@ -508,6 +508,15 @@
   color: var(--mac-text-secondary);
 }
 
+/* UX-AUDIT-FIX13: load-more button container */
+.lqw-load-more {
+  display: flex;
+  justify-content: center;
+  padding: var(--mac-spacing-3);
+  margin-top: var(--mac-spacing-2);
+  border-top: 1px dashed var(--mac-border);
+}
+
 /* PII details summary (L-H-4 + L-M-5 fix) */
 .lqw-pii-details {
   display: inline;


### PR DESCRIPTION
## Summary

- Add pagination («load more») to `LabQueueWorkbench` queue card grid: render only `PAGE_SIZE=20` records at a time, with a button to load 20 more.
- Previously `sortedAppointments.map(...)` rendered the entire queue at once — for a busy day with 100+ entries, this caused slow initial render and high memory footprint.
- `visibleCount` resets to `PAGE_SIZE` whenever the user changes `searchQuery`, `statusFilter`, or `sortBy`, so filtered results always start fresh. Aligns with Nielsen Heuristic #7 (Flexibility and Efficiency of Use).

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ux-audit-fix13-queue-pagination` from `origin/main` at `7ea4265e` (post-FIX12).
- Clean workspace: inspected before edits; only `LabQueueWorkbench.jsx`, `lab.css`, and existing contract test changed.
- Branch: `fix/ux-audit-fix13-queue-pagination`
- Scope gate: allowed `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/pages/lab.css`, `frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted test fails, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only rendering optimization. No API, websocket, event, or backend contract changed. `appointments` prop is consumed as before; only its rendering is paginated.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. Same roles see same queue data; only the rendering is chunked.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: when `appointments.length === 0`, existing empty-state Alert renders (unchanged); pagination never fires.
- Partial data proof: when `sortedAppointments.length <= visibleCount`, the «load more» button is hidden via `sortedAppointments.length > visibleCount && (...)` guard.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: `visibleCount` defaults to `PAGE_SIZE=20`; even on a fresh mount, renders up to 20 cards (or fewer if queue is smaller).
- Stale route/deep-link behavior: `useEffect([searchQuery, statusFilter, sortBy])` resets `visibleCount` on filter change, so stale page state is impossible.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/pages/lab.css`, `frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one new test added (6 total tests in file)
- Rollback note: revert both files; full-queue rendering restored (no pagination)

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`
- Result: passed (6/6 tests, 1.17s)
- Not checked: performance benchmark with 100+ queue entries — out of scope for a contract test; visual smoke covered by next Playwright run