### PR TITLE
fix(lab): UX-AUDIT-FIX14 — replace hardcoded datalist IDs with useId()

### DIFF
--- a/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabTemplateWorkbench.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useId } from 'react';
 import PropTypes from 'prop-types';
 import {
   Alert, Badge, Button, Card, CardContent, CardHeader, CardTitle, Icon,
@@ -38,6 +38,14 @@ export default function LabTemplateWorkbench({
   // Согласованность с LabReportWorkbench — единый стилизованный portal-dialog
   // с focus-trap, Esc-to-cancel, явным описанием последствий.
   const [confirm, confirmDialog] = useConfirm();
+
+  // UX-AUDIT-FIX14: useId() для уникальных ID <datalist>. Ранее ID были
+  // захардкожены как 'lab-analyte-catalog' / 'lab-unit-catalog' —
+  // глобальные, что вызывало бы коллизию при множественном монтировании
+  // LabTemplateWorkbench (например, в тестах или будущих admin-панелях).
+  // Теперь React генерирует уникальные ID на каждый instance компонента.
+  const analyteCatalogId = useId();
+  const unitCatalogId = useId();
 
   // Phase 4+: New Template dialog state (was always-visible form).
   const [showNewTemplateDialog, setShowNewTemplateDialog] = useState(false);
@@ -667,6 +675,9 @@ export default function LabTemplateWorkbench({
                   onUpdateField={updateField}
                   onUpdateFieldCatalog={updateFieldCatalog}
                   onLoadCatalogReferenceRange={loadCatalogReferenceRange}
+                  // UX-AUDIT-FIX14: передаём уникальные ID для <datalist>
+                  analyteCatalogId={analyteCatalogId}
+                  unitCatalogId={unitCatalogId}
                 />
               )}
               {editorTab === 'design' && (
@@ -700,14 +711,15 @@ export default function LabTemplateWorkbench({
         existingTemplates={templates}
       />
 
-      <datalist id="lab-analyte-catalog">
+      {/* UX-AUDIT-FIX14: ID datalist теперь уникальны per-instance (useId) */}
+      <datalist id={analyteCatalogId}>
         {catalogAnalytes.map((analyte) => (
           <option key={analyte.code} value={analyte.code}>
             {analyte.name}
           </option>
         ))}
       </datalist>
-      <datalist id="lab-unit-catalog">
+      <datalist id={unitCatalogId}>
         {catalogUnits.map((unit) => (
           <option key={unit.code} value={unit.code}>
             {unit.symbol}

--- a/frontend/src/components/laboratory/templateEditor/ContentTab.jsx
+++ b/frontend/src/components/laboratory/templateEditor/ContentTab.jsx
@@ -45,6 +45,10 @@ function ContentTab({
   onUpdateField,
   onUpdateFieldCatalog,
   onLoadCatalogReferenceRange,
+  // UX-AUDIT-FIX14: уникальные ID для <datalist> от parent (useId()).
+  // Ранее были захардкожены как 'lab-analyte-catalog' / 'lab-unit-catalog'.
+  analyteCatalogId = 'lab-analyte-catalog',
+  unitCatalogId = 'lab-unit-catalog',
 }) {
   // UX-AUDIT-FIX4: useConfirm для деструктивных действий (удаление секции/поля).
   const [confirm] = useConfirm();
@@ -264,7 +268,7 @@ function ContentTab({
                                 <input
                                   className="macos-input"
                                   aria-label="Код анализируемого показателя"
-                                  list="lab-analyte-catalog"
+                                  list={analyteCatalogId}
                                   value={field.analyte_code || ''}
                                   onChange={(event) => onUpdateFieldCatalog(sectionIndex, fieldIndex, 'analyte_code', event.target.value)}
                                 />
@@ -274,7 +278,7 @@ function ContentTab({
                                 <input
                                   className="macos-input"
                                   aria-label="Код единицы измерения"
-                                  list="lab-unit-catalog"
+                                  list={unitCatalogId}
                                   value={field.unit_code || ''}
                                   onChange={(event) => onUpdateField(sectionIndex, fieldIndex, 'unit_code', event.target.value)}
                                 />
@@ -374,6 +378,9 @@ ContentTab.propTypes = {
   onUpdateField: PropTypes.func.isRequired,
   onUpdateFieldCatalog: PropTypes.func.isRequired,
   onLoadCatalogReferenceRange: PropTypes.func.isRequired,
+  // UX-AUDIT-FIX14: уникальные ID для <datalist> от parent (useId).
+  analyteCatalogId: PropTypes.string,
+  unitCatalogId: PropTypes.string,
 };
 
 export default ContentTab;

--- a/frontend/src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx
+++ b/frontend/src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx
@@ -91,4 +91,22 @@ describe('ContentTab UX-AUDIT-FIX4 — confirm dialog on field/section delete', 
     // Иконка square.and.arrow.down.on.square
     expect(source).toContain('square.and.arrow.down.on.square');
   });
+
+  it('UX-AUDIT-FIX14: uses parent-provided datalist IDs instead of hardcoded', () => {
+    // FIX14: ID для <datalist> ранее были захардкожены как
+    // 'lab-analyte-catalog' / 'lab-unit-catalog'. Теперь принимаются
+    // через props analyteCatalogId / unitCatalogId (значения по умолчанию
+    // сохранены для backward compat).
+    expect(source).toContain('analyteCatalogId');
+    expect(source).toContain('unitCatalogId');
+    // Используются в input list=...
+    expect(source).toContain('list={analyteCatalogId}');
+    expect(source).toContain('list={unitCatalogId}');
+    // Больше нет хардкоженных строковых ID в list=
+    expect(source).not.toContain('list="lab-analyte-catalog"');
+    expect(source).not.toContain('list="lab-unit-catalog"');
+    // PropTypes добавлены
+    expect(source).toContain('analyteCatalogId: PropTypes.string');
+    expect(source).toContain('unitCatalogId: PropTypes.string');
+  });
 });


### PR DESCRIPTION
## Summary

- Replace hardcoded `<datalist>` IDs (`lab-analyte-catalog`, `lab-unit-catalog`) with React's `useId()` hook in `LabTemplateWorkbench.jsx`, passed down to `ContentTab.jsx` via props.
- Previously the IDs were global strings — if multiple `LabTemplateWorkbench` instances ever mounted (in tests, future admin panels, or storybook stories), the second instance's `<datalist>` would collide with the first, breaking the autocomplete for analyte/unit codes.
- Backward compatible: `ContentTab` accepts `analyteCatalogId` / `unitCatalogId` props with the old hardcoded strings as defaults, so existing direct usages (without parent-provided IDs) continue to work.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/ux-audit-fix14-datalist-useid` from `origin/main` at `dff2aae2` (post-FIX13).
- Clean workspace: inspected before edits; only `LabTemplateWorkbench.jsx`, `ContentTab.jsx`, and ContentTab contract test changed.
- Branch: `fix/ux-audit-fix14-datalist-useid`
- Scope gate: allowed `frontend/src/components/laboratory/LabTemplateWorkbench.jsx`, `frontend/src/components/laboratory/templateEditor/ContentTab.jsx`, `frontend/src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted test fails, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only component refactor. No API, websocket, event, or backend contract changed. The same `<datalist>` content (analyte codes + unit codes) is rendered; only the HTML `id` attribute values change from static strings to React-generated unique IDs.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: when `catalogAnalytes` / `catalogUnits` are empty, `<datalist>` renders with no `<option>` children — same as before.
- Partial data proof: `useId()` returns a stable string for the component's lifetime; even if `templates` re-render, the ID stays the same.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: `<datalist>` is always rendered (even when no template is selected); IDs are stable.
- Stale route/deep-link behavior: not applicable, IDs are local to the component instance.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabTemplateWorkbench.jsx`, `frontend/src/components/laboratory/templateEditor/ContentTab.jsx`, `frontend/src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one new test added (7 total tests in ContentTab contract file)
- Rollback note: revert all three files; hardcoded `lab-analyte-catalog` / `lab-unit-catalog` IDs restored

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/templateEditor/__tests__/ContentTab.contract.test.jsx src/components/laboratory/__tests__/LabTemplateWorkbench.contract.test.jsx`
- Result: passed (9/9 tests across 2 files, 1.03s)
- Not checked: visual regression snapshot — autocomplete dropdown UI is unchanged