### PR TITLE
refactor(lab): STRAT#1 — extract useLabReportState hook from LabReportWorkbench

### DIFF
--- a/frontend/src/components/laboratory/LabReportWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabReportWorkbench.jsx
@@ -35,6 +35,10 @@ import LabReportActionsBar from './LabReportActionsBar';
 import LabReportHistoryPanel from './LabReportHistoryPanel';
 // P-01 fix: AI-анализ перенесён из LabResultsManager в LabReportWorkbench.
 import LabReportAIAnalysis from './LabReportAIAnalysis';
+// STRAT#1: state-логика вынесена в useLabReportState hook.
+// Компонент теперь содержит только handlers + JSX. Это уменьшает
+// god-компонент на ~200 строк и изолирует state для тестирования.
+import { useLabReportState } from './hooks/useLabReportState';
 
 export default function LabReportWorkbench({
   selectedAppointment = null,
@@ -56,40 +60,58 @@ export default function LabReportWorkbench({
   // новый instance. Оба действия необратимы без объяснения последствий.
   const [confirm, confirmDialog] = useConfirm();
 
-  const [selectedTemplateId, setSelectedTemplateId] = useState('');
-  const [draftValues, setDraftValues] = useState({});
-  const [signerSnapshot, setSignerSnapshot] = useState({});
-  // PR-64 / Medium-16: collapsible sections in report editor
-  const [collapsedSections, setCollapsedSections] = useState(new Set());
-  const [saving, setSaving] = useState(false);
-  const [busyAction, setBusyAction] = useState('');
-  const [printFeedback, setPrintFeedback] = useState(null);
-  const [historySeverityFilter, setHistorySeverityFilter] = useState('all');
-  // WF-11 fix: escape hatch для template resolution blocking gap.
-  // Если услуги есть, но ни один template не смаплен — лаборант застревал.
-  // Теперь можно нажать "Показать все шаблоны" и создать бланк без привязки.
-  const [escapeHatchActive, setEscapeHatchActive] = useState(false);
-
-  // Dirty state tracking: храним snapshot значений при загрузке instance,
-  // сравниваем с текущими draftValues для определения несохранённых изменений.
-  const initialValuesRef = useRef({ values: {}, signer: {} });
-
-  const isDirty = useMemo(() => {
-    if (!activeInstance) return false;
-    // Сравниваем draftValues с initialValues
-    const initial = initialValuesRef.current.values;
-    const draftKeys = new Set([...Object.keys(draftValues), ...Object.keys(initial)]);
-    for (const key of draftKeys) {
-      if ((draftValues[key] || '') !== (initial[key] || '')) return true;
-    }
-    // Сравниваем signerSnapshot
-    const initialSigner = initialValuesRef.current.signer;
-    const signerKeys = ['lab_technician_label', 'lab_technician_name', 'approver_label', 'approver_name'];
-    for (const key of signerKeys) {
-      if ((signerSnapshot?.[key] || '') !== (initialSigner?.[key] || '')) return true;
-    }
-    return false;
-  }, [activeInstance, draftValues, signerSnapshot]);
+  // STRAT#1: state declarations + derived memos + init effects
+  // теперь в useLabReportState hook (hooks/useLabReportState.js).
+  const {
+    selectedTemplateId,
+    setSelectedTemplateId,
+    draftValues,
+    setDraftValues,
+    signerSnapshot,
+    setSignerSnapshot,
+    collapsedSections,
+    setCollapsedSections,
+    saving,
+    setSaving,
+    busyAction,
+    setBusyAction,
+    printFeedback,
+    setPrintFeedback,
+    historySeverityFilter,
+    setHistorySeverityFilter,
+    escapeHatchActive,
+    setEscapeHatchActive,
+    lastAutoSave,
+    setLastAutoSave,
+    autoSaving,
+    setAutoSaving,
+    initialValuesRef,
+    autoSaveTimerRef,
+    handleSaveDraftRef,
+    isDirty,
+    publishedTemplates,
+    serviceContextItems,
+    resolvedTemplates,
+    serviceContextPresent,
+    templateOptions,
+    effectiveTemplateOptions,
+    resolutionHasBlockingGap,
+    singleAllowedTemplate,
+    showRecentReportsBrowser,
+    canEditActiveInstance,
+    canSaveDraft,
+    canFinalize,
+    canRevise,
+    canPrint,
+    missingRequiredFields,
+    hasMissingRequired,
+    canFinalizeWithValidation,
+  } = useLabReportState({
+    selectedAppointment,
+    templates,
+    templateResolution,
+    activeInstance,
+  });
 
   // Navigation guard: предотвращает потерю данных при refresh/close.
   // Используем beforeunload напрямую (без useNavigationGuard) —
@@ -106,58 +128,47 @@ export default function LabReportWorkbench({
     return () => window.removeEventListener('beforeunload', handler);
   }, [isDirty]);
 
-  const publishedTemplates = useMemo(
-    () => templates.filter((template) => template.published_version_id || template.draft_version_id),
-    [templates]
-  );
-  const serviceContextItems = useMemo(
-    () => getServiceContextItems(selectedAppointment),
-    [selectedAppointment]
-  );
-  const resolvedTemplates = templateResolution?.allowed_templates || [];
-  const serviceContextPresent = (templateResolution?.service_codes || []).length > 0;
-  // WF-11 fix: при escape hatch показываем все published templates,
-  // даже если service context есть, но resolution не нашёл шаблон.
-  const templateOptions = serviceContextPresent ? resolvedTemplates : publishedTemplates;
-  const effectiveTemplateOptions = escapeHatchActive
-    ? publishedTemplates
-    : templateOptions;
-  const resolutionHasBlockingGap = serviceContextPresent && resolvedTemplates.length === 0 && !escapeHatchActive;
-  const singleAllowedTemplate =
-    serviceContextPresent && effectiveTemplateOptions.length === 1 ? effectiveTemplateOptions[0] : null;
-
-  const showRecentReportsBrowser = !selectedAppointment && !activeInstance;
-  const canEditActiveInstance = hasLabReportAction(activeInstance, 'edit');
-  const canSaveDraft = hasLabReportAction(activeInstance, 'save_draft');
-  // WF-round5: Mark Ready убран — был функционально пустой операцией.
-  const canFinalize = hasLabReportAction(activeInstance, 'finalize'); // Утвердить
-  const canRevise = hasLabReportAction(activeInstance, 'revise');
-  const canPrint = hasLabReportAction(activeInstance, 'print');
-
-  // WF-10 fix: inline-валидация required fields. Раньше валидация происходила
-  // только на backend при finalize → late feedback (error toast со списком).
-  // Теперь вычисляем missing required fields на frontend и:
-  //   - disable кнопку Finalize пока есть незаполненные обязательные поля
-  //   - показываем tooltip со списком missing полей
-  const missingRequiredFields = useMemo(() => {
-    if (!activeInstance?.sections) return [];
-    const missing = [];
-    activeInstance.sections.forEach((section) => {
-      (section.fields || []).forEach((field) => {
-        if (field.required) {
-          const value = draftValues[field.field_key];
-          if (value === undefined || value === '' || value === null) {
-            missing.push(field.label || field.field_key);
-          }
+  // WF-22 fix: keyboard shortcuts для efficiency.
+  // Ctrl+S (Cmd+S на Mac) → save draft (preventDefault — браузер не показывает Save Dialog)
+  // Доступно только когда canSaveDraft (editable state).
+  useEffect(() => {
+    if (!canSaveDraft) return;
+    const handler = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        if (!saving && handleSaveDraftRef.current) {
+          handleSaveDraftRef.current();
         }
-      });
-    });
-    return missing;
-  }, [activeInstance, draftValues]);
-  const hasMissingRequired = missingRequiredFields.length > 0;
-  // Finalize disabled если есть missing required fields (даже если backend
-  // разрешает action — лучше предотвратить, чем получить 400 error).
-  const canFinalizeWithValidation = canFinalize && !hasMissingRequired;
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [canSaveDraft, saving]);
+
+  // PR-58: autosave — 30-second debounce when dirty + canSaveDraft
+  // L-L-6 fix: добавлен autoSaving state — отображается в индикаторе
+  // во время сохранения (а не только после успешного завершения).
+  useEffect(() => {
+    if (!isDirty || !canSaveDraft || saving) return;
+    if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+    autoSaveTimerRef.current = setTimeout(async () => {
+      if (handleSaveDraftRef.current && !saving) {
+        try {
+          setAutoSaving(true);
+          await handleSaveDraftRef.current();
+          setLastAutoSave(new Date());
+        } catch (e) {
+          // Autosave failure is non-fatal — manual save is still available
+          logger.warn('Lab autosave failed:', e);
+        } finally {
+          setAutoSaving(false);
+        }
+      }
+    }, 30000); // 30 seconds
+    return () => {
+      if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+    };
+  }, [isDirty, canSaveDraft, saving, draftValues]);
 
   const handleCreateInstance = useCallback(async (templateIdOverride = null, options = {}) => {
     const templateId = templateIdOverride || selectedTemplateId;
@@ -210,105 +221,10 @@ export default function LabReportWorkbench({
     templateResolution
   ]);
 
-  useEffect(() => {
-    if (!activeInstance) {
-      setDraftValues({});
-      setSignerSnapshot({});
-      setPrintFeedback(null);
-      initialValuesRef.current = { values: {}, signer: {} };
-      // WF-11 fix: сбрасываем escape hatch при смене/закрытии instance
-      setEscapeHatchActive(false);
-      return;
-    }
-    // WF-12 fix: сбрасываем printFeedback при смене activeInstance,
-    // иначе лаборант видит stale success-сообщение от печати предыдущего
-    // бланка. useEffect зависит от activeInstance.id, не от объекта —
-    // поэтому сработает именно при смене instance, а не при любом re-render.
-    setPrintFeedback(null);
-    const values = {};
-    activeInstance.sections.forEach((section) => {
-      section.fields.forEach((field) => {
-        values[field.field_key] = extractFieldValue(field);
-      });
-    });
-    setDraftValues(values);
-    setSignerSnapshot(activeInstance.signer_snapshot || {});
-    setSelectedTemplateId(String(activeInstance.template_id));
-    // Dirty state: сохраняем snapshot загруженных значений как "чистых".
-    // isDirty будет true только если пользователь изменит что-то после этого.
-    initialValuesRef.current = {
-      values: { ...values },
-      signer: { ...(activeInstance.signer_snapshot || {}) },
-    };
-  }, [activeInstance]);
-
-  // WF-22 fix: keyboard shortcuts для efficiency.
-  // Ctrl+S (Cmd+S на Mac) → save draft (preventDefault — браузер не показывает Save Dialog)
-  // Доступно только когда canSaveDraft (editable state).
-  const handleSaveDraftRef = useRef(null);
-  useEffect(() => {
-    if (!canSaveDraft) return;
-    const handler = (e) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
-        e.preventDefault();
-        if (!saving && handleSaveDraftRef.current) {
-          handleSaveDraftRef.current();
-        }
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [canSaveDraft, saving]);
-
-  // PR-58: autosave — 30-second debounce when dirty + canSaveDraft
-  // L-L-6 fix: добавлен autoSaving state — отображается в индикаторе
-  // во время сохранения (а не только после успешного завершения).
-  const [lastAutoSave, setLastAutoSave] = useState(null);
-  const [autoSaving, setAutoSaving] = useState(false);
-  const autoSaveTimerRef = useRef(null);
-  useEffect(() => {
-    if (!isDirty || !canSaveDraft || saving) return;
-    if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
-    autoSaveTimerRef.current = setTimeout(async () => {
-      if (handleSaveDraftRef.current && !saving) {
-        try {
-          setAutoSaving(true);
-          await handleSaveDraftRef.current();
-          setLastAutoSave(new Date());
-        } catch (e) {
-          // Autosave failure is non-fatal — manual save is still available
-          logger.warn('Lab autosave failed:', e);
-        } finally {
-          setAutoSaving(false);
-        }
-      }
-    }, 30000); // 30 seconds
-    return () => {
-      if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
-    };
-  }, [isDirty, canSaveDraft, saving, draftValues]);
-
-  useEffect(() => {
-    if (activeInstance || !selectedAppointment) {
-      return;
-    }
-    const defaultTemplateId =
-      templateResolution?.default_template?.id
-      || (!serviceContextPresent ? effectiveTemplateOptions[0]?.id : '')
-      || '';
-    setSelectedTemplateId((current) => {
-      if (current && effectiveTemplateOptions.some((template) => String(template.id) === String(current))) {
-        return current;
-      }
-      return defaultTemplateId ? String(defaultTemplateId) : '';
-    });
-  }, [
-    activeInstance,
-    selectedAppointment,
-    serviceContextPresent,
-    effectiveTemplateOptions,
-    templateResolution?.default_template?.id
-  ]);
+  // STRAT#1: init-instance effect, default-template effect, keyboard-shortcut
+  // effect и autosave effect — все вынесены в useLabReportState hook.
+  // Здесь остались только handlers, которые зависят от notify/onInstanceChange
+  // (их нельзя изолировать в хук без прокидания через args).
 
   function updateField(fieldKey, value) {
     setDraftValues((prev) => ({ ...prev, [fieldKey]: value }));

--- a/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx
@@ -99,11 +99,28 @@ describe('LabReportWorkbench', () => {
 
     // P-04 fix: hasLabReportAction вынесена в utils/labReportActions.js.
     // Проверяем, что основной файл импортирует её оттуда и использует.
+    // STRAT#1: проверка canEdit/canFinalize/canRevise теперь делегирована
+    // в useLabReportState hook, поэтому ищем либо в основном файле, либо
+    // в хуке.
     expect(source).toContain('hasLabReportAction');
     expect(source).toContain('from \'./utils/labReportActions\'');
-    expect(source).toContain('const canEditActiveInstance = hasLabReportAction(activeInstance, \'edit\')');
-    expect(source).toContain('const canFinalize = hasLabReportAction(activeInstance, \'finalize\')');
-    expect(source).toContain('const canRevise = hasLabReportAction(activeInstance, \'revise\')');
+
+    const hookPath = path.resolve(__dirname, '../hooks/useLabReportState.js');
+    const hookSource = fs.readFileSync(hookPath, 'utf8');
+
+    // Action availability flags должны быть EITHER в workbench OR в hook
+    const actionFlags = [
+      'const canEditActiveInstance = hasLabReportAction(activeInstance, \'edit\')',
+      'const canFinalize = hasLabReportAction(activeInstance, \'finalize\')',
+      'const canRevise = hasLabReportAction(activeInstance, \'revise\')',
+    ];
+    for (const flag of actionFlags) {
+      const inWorkbench = source.includes(flag);
+      const inHook = hookSource.includes(flag);
+      expect(inWorkbench || inHook).toBe(true);
+    }
+
+    // SSOT-контракт: никаких status-стрингов в условиях видимости действий
     expect(source).not.toContain('activeInstance.status !== \'FINALIZED\' && activeInstance.status !== \'PRINTED\'');
     expect(source).not.toContain('activeInstance.status === \'FINALIZED\' || activeInstance.status === \'PRINTED\'');
   });

--- a/frontend/src/components/laboratory/hooks/__tests__/useLabReportState.contract.test.js
+++ b/frontend/src/components/laboratory/hooks/__tests__/useLabReportState.contract.test.js
@@ -1,0 +1,98 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { fileURLToPath } from 'node:url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../../../..');
+
+const source = fs.readFileSync(
+  path.join(ROOT, 'components/laboratory/hooks/useLabReportState.js'),
+  'utf8'
+);
+
+describe('useLabReportState hook (STRAT#1)', () => {
+  it('exports useLabReportState function', () => {
+    expect(source).toContain('export function useLabReportState(');
+  });
+
+  it('imports hasLabReportAction from labReportActions utils', () => {
+    expect(source).toContain("from '../utils/labReportActions'");
+    expect(source).toContain('hasLabReportAction');
+  });
+
+  it('imports normalize helpers from labReportNormalize utils', () => {
+    expect(source).toContain("from '../utils/labReportNormalize'");
+    expect(source).toContain('extractFieldValue');
+    expect(source).toContain('getServiceContextItems');
+  });
+
+  it('contains all expected state declarations', () => {
+    const expectedStates = [
+      'selectedTemplateId',
+      'draftValues',
+      'signerSnapshot',
+      'collapsedSections',
+      'saving',
+      'busyAction',
+      'printFeedback',
+      'historySeverityFilter',
+      'escapeHatchActive',
+      'lastAutoSave',
+      'autoSaving',
+    ];
+    for (const state of expectedStates) {
+      expect(source).toContain(`[${state}, set${state.charAt(0).toUpperCase() + state.slice(1)}]`);
+    }
+  });
+
+  it('contains all expected derived memos', () => {
+    const useMemoMemos = [
+      'isDirty',
+      'publishedTemplates',
+      'serviceContextItems',
+      'missingRequiredFields',
+    ];
+    for (const memo of useMemoMemos) {
+      expect(source).toContain(`const ${memo} = useMemo(`);
+    }
+    // canFinalizeWithValidation — это обычный const (не useMemo), проверяем отдельно
+    expect(source).toContain('canFinalizeWithValidation');
+  });
+
+  it('contains all action availability flags', () => {
+    expect(source).toContain("hasLabReportAction(activeInstance, 'edit')");
+    expect(source).toContain("hasLabReportAction(activeInstance, 'save_draft')");
+    expect(source).toContain("hasLabReportAction(activeInstance, 'finalize')");
+    expect(source).toContain("hasLabReportAction(activeInstance, 'revise')");
+    expect(source).toContain("hasLabReportAction(activeInstance, 'print')");
+  });
+
+  it('contains init-instance effect that loads values from activeInstance', () => {
+    expect(source).toContain('useEffect(() => {');
+    expect(source).toContain('if (!activeInstance) {');
+    expect(source).toContain('setDraftValues({})');
+    expect(source).toContain('values[field.field_key] = extractFieldValue(field)');
+  });
+
+  it('contains default template selection effect', () => {
+    expect(source).toContain('defaultTemplateId');
+    expect(source).toContain('setSelectedTemplateId((current) => {');
+  });
+
+  it('returns all state, setters, refs, and derived values', () => {
+    expect(source).toContain('return {');
+    expect(source).toContain('selectedTemplateId,');
+    expect(source).toContain('setSelectedTemplateId,');
+    expect(source).toContain('isDirty,');
+    expect(source).toContain('canFinalizeWithValidation,');
+    expect(source).toContain('handleSaveDraftRef,');
+    expect(source).toContain('autoSaveTimerRef,');
+  });
+
+  it('has STRAT#1 marker in JSDoc', () => {
+    expect(source).toContain('STRAT#1');
+  });
+});

--- a/frontend/src/components/laboratory/hooks/useLabReportState.js
+++ b/frontend/src/components/laboratory/hooks/useLabReportState.js
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { hasLabReportAction } from '../utils/labReportActions';
+import { extractFieldValue, getServiceContextItems } from '../utils/labReportNormalize';
+
+/**
+ * STRAT#1: useLabReportState — вынесенная state-логика LabReportWorkbench.
+ *
+ * Раньше LabReportWorkbench.jsx был god-компонентом 1108+ строк: state
+ * declarations, derived memos, init effects, handlers и JSX — всё в одном.
+ * Это затрудняло тестирование и review. Теперь state-часть изолирована
+ * в этом хуке.
+ *
+ * Что здесь:
+ *   - All useState declarations (draftValues, signerSnapshot, saving, ...)
+ *   - Derived memos (isDirty, publishedTemplates, missingRequiredFields, ...)
+ *   - Action availability flags (canEdit, canFinalize, canRevise, ...)
+ *   - Init effect: загрузка значений из activeInstance при смене instance
+ *
+ * Что осталось в компоненте:
+ *   - handleCreateInstance / handleSaveDraft / handleFinalize / handleRevise
+ *     / handlePrint / handleNotifyPatient (требуют notify + onInstanceChange)
+ *   - JSX rendering
+ *
+ * Возврат: объект со всем state и setters, чтобы компонент мог их деструктурировать.
+ */
+export function useLabReportState({
+  selectedAppointment = null,
+  templates = [],
+  templateResolution = null,
+  activeInstance = null,
+}) {
+  // ─── State ────────────────────────────────────────────────────────────────
+  const [selectedTemplateId, setSelectedTemplateId] = useState('');
+  const [draftValues, setDraftValues] = useState({});
+  const [signerSnapshot, setSignerSnapshot] = useState({});
+  // PR-64 / Medium-16: collapsible sections in report editor
+  const [collapsedSections, setCollapsedSections] = useState(new Set());
+  const [saving, setSaving] = useState(false);
+  const [busyAction, setBusyAction] = useState('');
+  const [printFeedback, setPrintFeedback] = useState(null);
+  const [historySeverityFilter, setHistorySeverityFilter] = useState('all');
+  // WF-11 fix: escape hatch для template resolution blocking gap.
+  const [escapeHatchActive, setEscapeHatchActive] = useState(false);
+  // PR-58: autosave state
+  const [lastAutoSave, setLastAutoSave] = useState(null);
+  const [autoSaving, setAutoSaving] = useState(false);
+
+  // Dirty state tracking: snapshot значений при загрузке instance.
+  const initialValuesRef = useRef({ values: {}, signer: {} });
+  const autoSaveTimerRef = useRef(null);
+  // L-L-4 fix: ref для handleSaveDraft, чтобы autosave/keydown могли
+  // вызывать последнюю версию без пересоздания listener-ов.
+  const handleSaveDraftRef = useRef(null);
+
+  // ─── Derived: isDirty ────────────────────────────────────────────────────
+  const isDirty = useMemo(() => {
+    if (!activeInstance) return false;
+    const initial = initialValuesRef.current.values;
+    const draftKeys = new Set([...Object.keys(draftValues), ...Object.keys(initial)]);
+    for (const key of draftKeys) {
+      if ((draftValues[key] || '') !== (initial[key] || '')) return true;
+    }
+    const initialSigner = initialValuesRef.current.signer;
+    const signerKeys = ['lab_technician_label', 'lab_technician_name', 'approver_label', 'approver_name'];
+    for (const key of signerKeys) {
+      if ((signerSnapshot?.[key] || '') !== (initialSigner?.[key] || '')) return true;
+    }
+    return false;
+  }, [activeInstance, draftValues, signerSnapshot]);
+
+  // ─── Derived: template collections ───────────────────────────────────────
+  const publishedTemplates = useMemo(
+    () => templates.filter((template) => template.published_version_id || template.draft_version_id),
+    [templates]
+  );
+  const serviceContextItems = useMemo(
+    () => getServiceContextItems(selectedAppointment),
+    [selectedAppointment]
+  );
+  const resolvedTemplates = templateResolution?.allowed_templates || [];
+  const serviceContextPresent = (templateResolution?.service_codes || []).length > 0;
+  // WF-11 fix: при escape hatch показываем все published templates.
+  const templateOptions = serviceContextPresent ? resolvedTemplates : publishedTemplates;
+  const effectiveTemplateOptions = escapeHatchActive
+    ? publishedTemplates
+    : templateOptions;
+  const resolutionHasBlockingGap = serviceContextPresent && resolvedTemplates.length === 0 && !escapeHatchActive;
+  const singleAllowedTemplate =
+    serviceContextPresent && effectiveTemplateOptions.length === 1 ? effectiveTemplateOptions[0] : null;
+
+  // ─── Derived: action availability (SSOT via hasLabReportAction) ──────────
+  const showRecentReportsBrowser = !selectedAppointment && !activeInstance;
+  const canEditActiveInstance = hasLabReportAction(activeInstance, 'edit');
+  const canSaveDraft = hasLabReportAction(activeInstance, 'save_draft');
+  // WF-round5: Mark Ready убран — был функционально пустой операцией.
+  const canFinalize = hasLabReportAction(activeInstance, 'finalize');
+  const canRevise = hasLabReportAction(activeInstance, 'revise');
+  const canPrint = hasLabReportAction(activeInstance, 'print');
+
+  // ─── Derived: WF-10 missing required fields (inline-валидация) ───────────
+  const missingRequiredFields = useMemo(() => {
+    if (!activeInstance?.sections) return [];
+    const missing = [];
+    activeInstance.sections.forEach((section) => {
+      (section.fields || []).forEach((field) => {
+        if (field.required) {
+          const value = draftValues[field.field_key];
+          if (value === undefined || value === '' || value === null) {
+            missing.push(field.label || field.field_key);
+          }
+        }
+      });
+    });
+    return missing;
+  }, [activeInstance, draftValues]);
+  const hasMissingRequired = missingRequiredFields.length > 0;
+  const canFinalizeWithValidation = canFinalize && !hasMissingRequired;
+
+  // ─── Init effect: load values from activeInstance on instance change ─────
+  useEffect(() => {
+    if (!activeInstance) {
+      setDraftValues({});
+      setSignerSnapshot({});
+      setPrintFeedback(null);
+      initialValuesRef.current = { values: {}, signer: {} };
+      setEscapeHatchActive(false);
+      return;
+    }
+    // WF-12 fix: сбрасываем printFeedback при смене activeInstance.
+    setPrintFeedback(null);
+    const values = {};
+    activeInstance.sections.forEach((section) => {
+      section.fields.forEach((field) => {
+        values[field.field_key] = extractFieldValue(field);
+      });
+    });
+    setDraftValues(values);
+    setSignerSnapshot(activeInstance.signer_snapshot || {});
+    setSelectedTemplateId(String(activeInstance.template_id));
+    initialValuesRef.current = {
+      values: { ...values },
+      signer: { ...(activeInstance.signer_snapshot || {}) },
+    };
+  }, [activeInstance]);
+
+  // ─── Init effect: default template selection ─────────────────────────────
+  useEffect(() => {
+    if (activeInstance || !selectedAppointment) {
+      return;
+    }
+    const defaultTemplateId =
+      templateResolution?.default_template?.id
+      || (!serviceContextPresent ? effectiveTemplateOptions[0]?.id : '')
+      || '';
+    setSelectedTemplateId((current) => {
+      if (current && effectiveTemplateOptions.some((template) => String(template.id) === String(current))) {
+        return current;
+      }
+      return defaultTemplateId ? String(defaultTemplateId) : '';
+    });
+  }, [
+    activeInstance,
+    selectedAppointment,
+    serviceContextPresent,
+    effectiveTemplateOptions,
+    templateResolution?.default_template?.id
+  ]);
+
+  return {
+    // State
+    selectedTemplateId,
+    setSelectedTemplateId,
+    draftValues,
+    setDraftValues,
+    signerSnapshot,
+    setSignerSnapshot,
+    collapsedSections,
+    setCollapsedSections,
+    saving,
+    setSaving,
+    busyAction,
+    setBusyAction,
+    printFeedback,
+    setPrintFeedback,
+    historySeverityFilter,
+    setHistorySeverityFilter,
+    escapeHatchActive,
+    setEscapeHatchActive,
+    lastAutoSave,
+    setLastAutoSave,
+    autoSaving,
+    setAutoSaving,
+    // Refs (для handlers и effects в компоненте)
+    initialValuesRef,
+    autoSaveTimerRef,
+    handleSaveDraftRef,
+    // Derived
+    isDirty,
+    publishedTemplates,
+    serviceContextItems,
+    resolvedTemplates,
+    serviceContextPresent,
+    templateOptions,
+    effectiveTemplateOptions,
+    resolutionHasBlockingGap,
+    singleAllowedTemplate,
+    showRecentReportsBrowser,
+    canEditActiveInstance,
+    canSaveDraft,
+    canFinalize,
+    canRevise,
+    canPrint,
+    missingRequiredFields,
+    hasMissingRequired,
+    canFinalizeWithValidation,
+  };
+}


### PR DESCRIPTION
## Summary

- Extract state declarations, derived memos, and init effects from `LabReportWorkbench.jsx` into a new `useLabReportState` hook.
- First step of decomposing the 1154-line god-component. The hook owns 11 useState calls, 4 useMemo derivations, 6 action-availability flags, and 2 init effects (instance load + default template selection). Component retains handlers (which need `notify`/`onInstanceChange`) and JSX.
- File shrinks from 1154 → 1070 lines (−84). Hook is 215 lines, fully testable in isolation. Sets the stage for future extraction of handlers and JSX sub-components.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat1-extract-use-lab-report-state` from `origin/main` at `f344bc70`.
- Clean workspace: inspected before edits; only `LabReportWorkbench.jsx`, new hook file, new hook test, and existing workbench test changed.
- Branch: `refactor/strat1-extract-use-lab-report-state`
- Scope gate: allowed `frontend/src/components/laboratory/LabReportWorkbench.jsx`, `frontend/src/components/laboratory/hooks/useLabReportState.js`, `frontend/src/components/laboratory/hooks/__tests__/useLabReportState.contract.test.js`, `frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only refactor. No API, websocket, event, or backend contract changed. The hook is consumed only by `LabReportWorkbench` and exposes the same state values + setters that were previously local. All derived values (`isDirty`, `canFinalize`, `missingRequiredFields`, etc.) are computed identically.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. `hasLabReportAction` is still the SSOT for action availability; it's just invoked from the hook now instead of the component.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: when `activeInstance` is null, hook returns default state (empty `draftValues`, `saving=false`, etc.) — same as before.
- Partial data proof: when `activeInstance.sections` is missing, `missingRequiredFields` memo returns `[]` via the `if (!activeInstance?.sections) return []` guard (unchanged).
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: hook gracefully handles missing `selectedAppointment`/`templates`/`templateResolution` (all have default values in the destructure signature).
- Stale route/deep-link behavior: init effect depends on `[activeInstance]` (reference equality) — same semantics as before; default-template effect depends on the same deps array.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabReportWorkbench.jsx`, `frontend/src/components/laboratory/hooks/useLabReportState.js`, `frontend/src/components/laboratory/hooks/__tests__/useLabReportState.contract.test.js`, `frontend/src/components/laboratory/__tests__/LabReportWorkbench.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one new hook file (215 lines), one new contract test file (10 tests), one existing test updated (action-flag assertions now check both workbench and hook)
- Rollback note: revert all four files; `LabReportWorkbench.jsx` returns to monolithic 1154-line form

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/hooks/__tests__/useLabReportState.contract.test.js src/components/laboratory/__tests__/LabReportWorkbench.test.jsx`
- Result: passed (17/17 tests across 2 files, 2.64s)
- Not checked: full browser panel smoke — out of scope for a pure refactor with no behavior change