### PR TITLE
refactor(lab): STRAT#4 — server-side pagination support in listQueueToday

### DIFF
--- a/frontend/src/api/__tests__/labReporting.contract.test.js
+++ b/frontend/src/api/__tests__/labReporting.contract.test.js
@@ -36,4 +36,16 @@ describe('labReportingApi UX-AUDIT-FIX12 — AbortController support', () => {
     // signal должен быть опциональным — если не передан, fetch работает без него.
     expect(source).toContain("...(options.signal ? { signal: options.signal } : {})");
   });
+
+  it('STRAT#4: listQueueToday accepts server-side pagination params', () => {
+    // FIX: listQueueToday ранее принимал только targetDate. Теперь принимает
+    // второй аргумент params = { limit, offset } для server-side pagination.
+    expect(source).toContain('STRAT#4');
+    expect(source).toContain('listQueueToday(targetDate = null, params = {})');
+    // limit и offset пробрасываются в query string
+    expect(source).toContain("params.limit !== undefined");
+    expect(source).toContain("search.set('limit', String(params.limit))");
+    expect(source).toContain("params.offset !== undefined");
+    expect(source).toContain("search.set('offset', String(params.offset))");
+  });
 });

--- a/frontend/src/api/labReporting.js
+++ b/frontend/src/api/labReporting.js
@@ -57,10 +57,24 @@ export const labReportingApi = {
   // Теперь использует этот метод — собственный контракт, собственная RBAC,
   // нормализация в lab-специфичный формат на backend.
   // Возвращает { entries: [...], total, date, timezone }.
-  listQueueToday(targetDate = null) {
+  //
+  // STRAT#4: добавлена поддержка server-side pagination через limit/offset.
+  // Backend уже принимает эти query params (default limit=100, offset=0).
+  // Frontend ранее не передавал их — загружал все записи сразу. Теперь
+  // callers могут передать { limit, offset } для chunked loading, что
+  // критично для крупных клиник с 1000+ анализов в день.
+  // Backward compat: если params не передан, поведение не меняется.
+  listQueueToday(targetDate = null, params = {}) {
     const search = new URLSearchParams();
     if (targetDate) {
       search.set('target_date', targetDate);
+    }
+    // STRAT#4: server-side pagination params
+    if (params.limit !== undefined && params.limit !== null) {
+      search.set('limit', String(params.limit));
+    }
+    if (params.offset !== undefined && params.offset !== null) {
+      search.set('offset', String(params.offset));
     }
     const suffix = search.size ? `?${search.toString()}` : '';
     return request(`/lab/queue/today${suffix}`);


### PR DESCRIPTION
## Summary

- Add server-side pagination support to `labReportingApi.listQueueToday()` by accepting an optional `params = { limit, offset }` second argument.
- Backend already accepts `limit`/`offset` query params on `/lab/queue/today` (default limit=100, offset=0). Frontend previously ignored them and loaded all entries at once — fine for small clinics, but a 1000+ entry day caused slow initial load and high memory footprint.
- Backward compatible: existing call sites without `params` continue to work unchanged. New callers can pass `{ limit: 50, offset: 0 }` for chunked loading.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat4-server-side-pagination-api` from `origin/main` at `4f429b72` (post-STRAT#3).
- Clean workspace: inspected before edits; only `labReporting.js` and its contract test changed.
- Branch: `refactor/strat4-server-side-pagination-api`
- Scope gate: allowed `frontend/src/api/labReporting.js`, `frontend/src/api/__tests__/labReporting.contract.test.js`; denied backend (already supports the params), migrations, other lab components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/lab/queue/today` — UNCHANGED. Backend already accepts `limit`, `offset`, `target_date` query params.
- Request shape: authenticated GET, optional query params. No request body.
- Response shape: `{ entries: [...], total: number, date: string, timezone: string }` — UNCHANGED.
- Status codes: 200 for allowed roles, 401 unauthenticated, 403 forbidden — UNCHANGED.
- Frontend consumer: `LabPanel.jsx` calls `labReportingApi.listQueueToday()` — still works without params (backward compat).
- Compatibility path or alias: callers that pass `{ limit, offset }` get chunked results; callers that don't get default backend behavior (limit=100, offset=0).
- Contract proof: backend `/lab/queue/today` endpoint definition with `limit: int = Query(default=100, ge=1, le=500)` and `offset: int = Query(default=0, ge=0)` is unchanged.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. Backend RBAC on `/lab/queue/today` is unchanged; same roles see same data, just optionally paginated.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR changes a REST API call shape, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection. `listQueueToday` is a one-shot REST call; if it fails, the caller's `catch` block handles it (unchanged).

## Frontend Resilience

- Empty data proof: when `params` is `{}` or undefined, no `limit`/`offset` query params are added — backend defaults apply. Behavior identical to pre-PR.
- Partial data proof: caller can pass `{ limit: 50 }` without `offset`, or `{ offset: 100 }` without `limit`. Each is added to query string independently.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: `listQueueToday` is a stateless fetch; no resource lifecycle.
- Stale route/deep-link behavior: not applicable; pagination state is owned by the caller (typically `LabPanel.jsx` useEffect), not by the API client.

## Scope Gate

- Allowed paths: `frontend/src/api/labReporting.js`, `frontend/src/api/__tests__/labReporting.contract.test.js`
- Denied paths: backend runtime (already supports params), other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; one new test added (5 total tests in file)
- Rollback note: revert both files; `listQueueToday` reverts to single-arg signature, no pagination support

## Validation

- Targeted tests or smoke run: `npx vitest run src/api/__tests__/labReporting.contract.test.js`
- Result: passed (5/5 tests, 895ms)
- Not checked: integration test with real backend pagination — out of scope; backend endpoint is unchanged and already covered by backend tests

## Next Steps (out of scope for this PR)

1. Wire `LabPanel.jsx` to pass `{ limit: 50, offset: 0 }` on initial queue load.
2. Add "Load more" button in `LabQueueWorkbench.jsx` that increments `offset` and fetches the next chunk (currently the load-more button in FIX#13 only paginates client-side rendered entries).
3. Add server-side filter/sort params (`status`, `search`, `sort_by`) — backend may need extensions.