### PR TITLE
refactor(lab): STRAT#6 — migrate LabStatusStepper to t() for aria-label and titles

### DIFF
--- a/frontend/src/components/laboratory/LabStatusStepper.jsx
+++ b/frontend/src/components/laboratory/LabStatusStepper.jsx
@@ -4,6 +4,7 @@ import {
   LAB_REPORT_STATUS_CONFIG,
   getLabReportStepIndex,
 } from './utils/labStatusConfig';
+import { t } from './utils/labTranslations';
 
 /**
  * P-04 fix: LabStatusStepper выделен в отдельный файл.
@@ -27,6 +28,10 @@ import {
  * индекс вычисляется по полной конфигурации, поэтому READY всё равно
  * корректно отрисуется как current step. Скрытие влияет только на
  * будущее/прошлое отображение шага, когда текущий статус — другой.
+ *
+ * STRAT#6: все русские строки мигрированы на t() из labTranslations.
+ * step.label всё ещё берётся из labStatusConfig (SSOT для статус-маппинга),
+ * но вспомогательные тексты (aria-label, title-атрибуты) теперь через t().
  */
 const HIDDEN_STEPPER_STATUSES = new Set(['READY']);
 
@@ -53,7 +58,7 @@ export default function LabStatusStepper({ status }) {
   return (
     <div
       role="navigation"
-      aria-label="Прогресс бланка"
+      aria-label={t('workbench.progress_aria_label')}
       style={{
         display: 'flex',
         alignItems: 'center',
@@ -68,6 +73,13 @@ export default function LabStatusStepper({ status }) {
         const isFuture = index > currentIndex;
         const isLast = index === VISIBLE_STEPPER_STEPS.length - 1;
 
+        // STRAT#6: title-атрибуты через t() для i18n
+        const titleSuffix = isCompleted
+          ? t('workbench.step_completed')
+          : isCurrent
+            ? t('workbench.step_current')
+            : t('workbench.step_upcoming');
+
         return (
           <div
             key={step.key}
@@ -76,13 +88,7 @@ export default function LabStatusStepper({ status }) {
             <div
               className={`lab-status-step ${isCurrent ? 'lab-status-step-current' : ''} ${isCompleted ? 'lab-status-step-completed' : ''} ${isFuture ? 'lab-status-step-future' : ''}`}
               aria-current={isCurrent ? 'step' : undefined}
-              title={
-                isCompleted
-                  ? `${step.label} — пройден`
-                  : isCurrent
-                    ? `${step.label} — текущий шаг`
-                    : `${step.label} — предстоит`
-              }
+              title={`${step.label} — ${titleSuffix}`}
             >
               {isCompleted && (
                 <Icon name="checkmark.circle.fill" size={12} />

--- a/frontend/src/components/laboratory/__tests__/LabStatusStepper.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabStatusStepper.contract.test.jsx
@@ -36,4 +36,25 @@ describe('LabStatusStepper UX-AUDIT-QW3 — hide unreachable READY step', () => 
     expect(source).toContain('LAB_REPORT_STATUS_CONFIG');
     expect(source).toContain('getLabReportStepIndex');
   });
+
+  it('STRAT#6: uses t() for aria-label and title attributes', () => {
+    // Все вспомогательные строки мигрированы на t() из labTranslations
+    expect(source).toContain("from './utils/labTranslations'");
+    expect(source).toContain('import { t }');
+    // aria-label через t()
+    expect(source).toContain("aria-label={t('workbench.progress_aria_label')}");
+    // title-атрибуты через t()
+    expect(source).toContain("t('workbench.step_completed')");
+    expect(source).toContain("t('workbench.step_current')");
+    expect(source).toContain("t('workbench.step_upcoming')");
+    // Больше нет хардкоженных русских строк
+    expect(source).not.toContain('aria-label="Прогресс бланка"');
+    expect(source).not.toContain('— пройден');
+    expect(source).not.toContain('— текущий шаг');
+    expect(source).not.toContain('— предстоит');
+  });
+
+  it('has STRAT#6 marker in JSDoc', () => {
+    expect(source).toContain('STRAT#6');
+  });
 });

--- a/frontend/src/components/laboratory/utils/labTranslations.js
+++ b/frontend/src/components/laboratory/utils/labTranslations.js
@@ -83,6 +83,10 @@ const TRANSLATIONS = {
     saved_at: 'сохранено',
     signatures: 'Подписи',
     signatures_readonly_hint: 'только для чтения — отчёт утверждён',
+    progress_aria_label: 'Прогресс бланка',
+    step_completed: 'пройден',
+    step_current: 'текущий шаг',
+    step_upcoming: 'предстоит',
   },
 
   // ─── Actions bar ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Migrate `LabStatusStepper.jsx` to use `t()` from `labTranslations.js` for `aria-label` and `title` attributes — second component in the i18n migration series.
- Previously the stepper had 4 hardcoded Russian strings: `aria-label="Прогресс бланка"` and 3 title suffixes (`пройден`, `текущий шаг`, `предстоит`). Now all route through the dictionary.
- `step.label` (the status names like «Черновик», «Заполняется») still comes from `labStatusConfig.js` (SSOT for status mapping) — that's intentional, since the labels need to stay coupled to the status keys for `getLabStatusConfig()` consumers.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat6-migrate-status-stepper-to-t` from `origin/main` at `5e060718` (post-STRAT#5).
- Clean workspace: inspected before edits; only `LabStatusStepper.jsx`, `labTranslations.js` (4 new keys), and existing contract test changed.
- Branch: `refactor/strat6-migrate-status-stepper-to-t`
- Scope gate: allowed `frontend/src/components/laboratory/LabStatusStepper.jsx`, `frontend/src/components/laboratory/utils/labTranslations.js`, `frontend/src/components/laboratory/__tests__/LabStatusStepper.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only string refactor. No API, websocket, event, or backend contract changed. The same Russian text renders in `aria-label` and `title` attributes; only the source path (hardcoded string → dictionary lookup) changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR migrates UI strings to a translation dictionary, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection.

## Frontend Resilience

- Empty data proof: when `status` is null/unknown, `getLabReportStepIndex` returns -1 and component returns null — same as before; no `t()` call fires.
- Partial data proof: `t('workbench.*')` keys are independent; missing one returns the key itself (debugging-friendly).
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: `t()` is a pure function with no resource lifecycle.
- Stale route/deep-link behavior: not applicable, `t()` is stateless.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabStatusStepper.jsx`, `frontend/src/components/laboratory/utils/labTranslations.js`, `frontend/src/components/laboratory/__tests__/LabStatusStepper.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; 4 new translation keys added (`progress_aria_label`, `step_completed`, `step_current`, `step_upcoming`); one new test added (5 total in file)
- Rollback note: revert all three files; hardcoded Russian strings restored in Stepper

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/__tests__/LabStatusStepper.contract.test.jsx`
- Result: passed (5/5 tests, 874ms)
- Not checked: visual regression snapshot — `aria-label` and `title` render identical Russian text via dictionary lookup