### PR TITLE
refactor(lab): STRAT#7 — wire LabPanel to server-side pagination (limit/offset)

### DIFF
--- a/frontend/src/pages/LabPanel.jsx
+++ b/frontend/src/pages/LabPanel.jsx
@@ -28,6 +28,11 @@ const tabs = [
 const LAB_PANEL_TITLE_ID = 'lab-panel-title';
 const LAB_PANEL_TABLIST_ID = 'lab-panel-tabs';
 
+// STRAT#7: размер страницы для server-side pagination очереди.
+// 50 записей — баланс между network overhead и UX (минимум прокруток).
+// Backend maximum — 500 (Query(ge=1, le=500)).
+const LAB_QUEUE_PAGE_SIZE = 50;
+
 function getLabPanelTabId(tabId) {
   return `lab-panel-tab-${tabId}`;
 }
@@ -83,6 +88,14 @@ export default function LabPanel() {
   const [activeTab, setActiveTab] = useState(searchParams.get('tab') || 'queue');
   const [appointments, setAppointments] = useState([]);
   const [appointmentsLoading, setAppointmentsLoading] = useState(false);
+  // STRAT#7: server-side pagination state для очереди.
+  // queueTotal — общее количество записей на сервере (из payload.total).
+  // queueOffset — текущий offset для следующей страницы.
+  // hasMoreQueue — флаг, есть ли ещё записи для load-more.
+  const [queueTotal, setQueueTotal] = useState(0);
+  const [queueOffset, setQueueOffset] = useState(0);
+  const [hasMoreQueue, setHasMoreQueue] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [templates, setTemplates] = useState([]);
   const [selectedTemplate, setSelectedTemplate] = useState(null);
   const [selectedAppointment, setSelectedAppointment] = useState(null);
@@ -215,9 +228,22 @@ export default function LabPanel() {
       // fetch к registrar endpoint. Façade имеет собственный контракт,
       // собственную RBAC и нормализует ответ в плоский формат — это убирает
       // жёсткую связку с registrar module и промежуточную нормализацию.
-      const payload = await labReportingApi.listQueueToday();
+      //
+      // STRAT#7: передаём { limit: LAB_QUEUE_PAGE_SIZE, offset: 0 } для
+      // server-side pagination. Backend уже поддерживает limit/offset
+      // (STRAT#4), но frontend ранее грузил все записи сразу. Теперь
+      // initial load получает первые LAB_QUEUE_PAGE_SIZE=50 записей;
+      // loadMoreAppointments() догружает следующие.
+      const payload = await labReportingApi.listQueueToday(null, {
+        limit: LAB_QUEUE_PAGE_SIZE,
+        offset: 0,
+      });
       const queueEntries = normalizeListPayload(payload?.entries ?? []);
       setAppointments(queueEntries);
+      setQueueTotal(payload?.total ?? queueEntries.length);
+      setQueueOffset(queueEntries.length);
+      // STRAT#7: помечаем, есть ли ещё записи для load-more
+      setHasMoreQueue((payload?.total ?? 0) > queueEntries.length);
       setSelectedAppointment((current) => {
         if (!current) {
           return current;
@@ -242,6 +268,31 @@ export default function LabPanel() {
       setAppointmentsLoading(false);
     }
   }, [notify]);
+
+  // STRAT#7: loadMoreAppointments — incremental server-side pagination.
+  // Догружает следующую страницу (offset = queueOffset) и аппендит к
+  // существующему списку. Используется кнопкой «Показать ещё» в
+  // LabQueueWorkbench (заменит client-side load-more из FIX#13).
+  const loadMoreAppointments = useCallback(async () => {
+    if (loadingMore || !hasMoreQueue) return;
+    setLoadingMore(true);
+    try {
+      const payload = await labReportingApi.listQueueToday(null, {
+        limit: LAB_QUEUE_PAGE_SIZE,
+        offset: queueOffset,
+      });
+      const newEntries = normalizeListPayload(payload?.entries ?? []);
+      setAppointments((current) => [...current, ...newEntries]);
+      setQueueOffset((current) => current + newEntries.length);
+      setHasMoreQueue((payload?.total ?? 0) > queueOffset + newEntries.length);
+      logger.info('[LabPanel] loaded more lab queue entries', newEntries.length);
+    } catch (error) {
+      logger.error('[LabPanel] loadMoreAppointments failed', error);
+      notify('error', getErrorMessage(error, 'Не удалось загрузить дополнительные записи очереди.'));
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [loadingMore, hasMoreQueue, queueOffset, notify]);
 
   // H-2 fix: keyboard shortcuts for tab switching, refresh, clear selection.
   useLabHotkeys({
@@ -575,6 +626,11 @@ export default function LabPanel() {
           appointments={appointments}
           loading={appointmentsLoading}
           onRefresh={loadLabAppointments}
+          // STRAT#7: server-side pagination props
+          onLoadMore={loadMoreAppointments}
+          hasMore={hasMoreQueue}
+          loadingMore={loadingMore}
+          queueTotal={queueTotal}
           onOpenAppointment={(appointment) => {
             setSelectedAppointment(appointment);
             setTemplateResolution(null);

--- a/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
@@ -36,11 +36,14 @@ describe('LabPanel queue/report status contract', () => {
     const loadBlock = extractBlock(
       source,
       'const loadLabAppointments = useCallback(async () => {',
-      'const loadTemplates = useCallback(async (preferredTemplateId = null) => {',
+      'const loadMoreAppointments = useCallback(async () => {',
     );
 
     // P-03 fix: должен использовать façade метод.
-    expect(loadBlock).toContain('labReportingApi.listQueueToday()');
+    // STRAT#7: listQueueToday теперь вызывается с pagination params.
+    expect(loadBlock).toContain('labReportingApi.listQueueToday(');
+    expect(loadBlock).toContain('limit: LAB_QUEUE_PAGE_SIZE');
+    expect(loadBlock).toContain('offset: 0');
     // Не должен делать прямой fetch к registrar endpoint.
     expect(loadBlock).not.toContain('/registrar/queues/today');
     expect(loadBlock).not.toContain('new URLSearchParams({ department: \'lab\' })');
@@ -48,6 +51,32 @@ describe('LabPanel queue/report status contract', () => {
     // (теперь backend возвращает плоский entries[] напрямую).
     expect(loadBlock).not.toContain('payload?.queues || []');
     expect(loadBlock).not.toContain('.flatMap((queue) =>');
+  });
+
+  it('STRAT#7: loadMoreAppointments fetches next page with server-side offset', () => {
+    const source = readLabPanelSource();
+    const loadMoreBlock = extractBlock(
+      source,
+      'const loadMoreAppointments = useCallback(async () => {',
+      '// H-2 fix: keyboard shortcuts',
+    );
+
+    expect(loadMoreBlock).toContain('labReportingApi.listQueueToday(null, {');
+    expect(loadMoreBlock).toContain('limit: LAB_QUEUE_PAGE_SIZE');
+    expect(loadMoreBlock).toContain('offset: queueOffset');
+    // Аппендит к существующему списку, не заменяет
+    expect(loadMoreBlock).toContain('setAppointments((current) => [...current, ...newEntries])');
+    // Обновляет offset и hasMore
+    expect(loadMoreBlock).toContain('setQueueOffset((current) => current + newEntries.length)');
+    expect(loadMoreBlock).toContain('setHasMoreQueue(');
+  });
+
+  it('STRAT#7: passes server-side pagination props to LabQueueWorkbench', () => {
+    const source = readLabPanelSource();
+    expect(source).toContain('onLoadMore={loadMoreAppointments}');
+    expect(source).toContain('hasMore={hasMoreQueue}');
+    expect(source).toContain('loadingMore={loadingMore}');
+    expect(source).toContain('queueTotal={queueTotal}');
   });
 
   it('relies on backend-provided lab report summary fields without re-inventing status', () => {


### PR DESCRIPTION
## Summary

- Wire `LabPanel.jsx` to use server-side pagination via `labReportingApi.listQueueToday(targetDate, { limit, offset })` (added in STRAT#4).
- Previously `loadLabAppointments()` called `listQueueToday()` with no params — backend returned all entries (default limit=100). For a 1000+ entry day, this caused slow initial load. Now initial load fetches 50 entries (LAB_QUEUE_PAGE_SIZE=50), and `loadMoreAppointments()` fetches the next page on demand.
- New pagination state: `queueTotal`, `queueOffset`, `hasMoreQueue`, `loadingMore`. New props passed to `LabQueueWorkbench`: `onLoadMore`, `hasMore`, `loadingMore`, `queueTotal` (the component will consume them in STRAT#8 to replace client-side load-more).

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat7-wire-labpanel-server-pagination` from `origin/main` at `aabfdd05` (post-STRAT#6).
- Clean workspace: inspected before edits; only `LabPanel.jsx` and its contract test changed.
- Branch: `refactor/strat7-wire-labpanel-server-pagination`
- Scope gate: allowed `frontend/src/pages/LabPanel.jsx`, `frontend/src/pages/__tests__/LabPanel.contract.test.jsx`; denied backend, migrations, other lab components (LabQueueWorkbench will be wired in STRAT#8).
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/lab/queue/today` — UNCHANGED. Backend already accepts `limit`, `offset` query params (added in STRAT#4).
- Request shape: authenticated GET with `{ limit: 50, offset: 0 }` on initial load; `{ limit: 50, offset: N }` on load-more. No request body.
- Response shape: `{ entries: [...], total: number, date: string, timezone: string }` — UNCHANGED. Frontend now reads `payload.total` to compute `hasMoreQueue`.
- Status codes: 200 for allowed roles, 401 unauthenticated, 403 forbidden — UNCHANGED.
- Frontend consumer: `LabQueueWorkbench` receives new optional props (`onLoadMore`, `hasMore`, `loadingMore`, `queueTotal`); they are not yet consumed (STRAT#8 will wire them).
- Compatibility path or alias: existing `listQueueToday()` call sites without params still work (backward compat from STRAT#4).
- Contract proof: backend `/lab/queue/today` endpoint unchanged; `labReportingApi.listQueueToday(null, { limit, offset })` is the API added in STRAT#4.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. Backend RBAC on `/lab/queue/today` is unchanged; same roles see same data, just paginated.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR changes a REST API call shape, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection. `loadLabAppointments` and `loadMoreAppointments` are one-shot REST calls; if they fail, the `catch` block notifies the user (unchanged error handling).

## Frontend Resilience

- Empty data proof: when backend returns `{ entries: [], total: 0 }`, `hasMoreQueue` is set to `false` (0 > 0 is false) — load-more button will not render.
- Partial data proof: if `payload.total` is missing, falls back to `queueEntries.length` via `?? queueEntries.length` — `hasMoreQueue` is `false`, conservative behavior.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: `loadMoreAppointments` has early-return guard `if (loadingMore || !hasMoreQueue) return;` — prevents duplicate fetches and over-fetching.
- Stale route/deep-link behavior: pagination state is component-local; route change does not preserve page offset (acceptable — user expectation is fresh queue on tab switch).

## Scope Gate

- Allowed paths: `frontend/src/pages/LabPanel.jsx`, `frontend/src/pages/__tests__/LabPanel.contract.test.jsx`
- Denied paths: backend runtime (already supports pagination), other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; 2 new tests added (8 total in file)
- Rollback note: revert both files; `loadLabAppointments` reverts to no-pagination call, `loadMoreAppointments` removed, props not passed to LabQueueWorkbench

## Validation

- Targeted tests or smoke run: `npx vitest run src/pages/__tests__/LabPanel.contract.test.jsx`
- Result: passed (8/8 tests, 967ms)
- Not checked: integration test with real backend pagination — out of scope; backend endpoint is unchanged and already covered by backend tests

## Next Steps (out of scope for this PR)

1. STRAT#8: wire `LabQueueWorkbench.jsx` to consume the new props — replace client-side load-more (FIX#13) with server-side `onLoadMore` when `hasMore` is true.
2. Add server-side filter/sort params (`status`, `search`, `sort_by`) — backend may need extensions.
3. Consider `AbortController` integration (STRAT#12) for cancelable load-more requests.