### PR TITLE
refactor(lab): STRAT#8 — wire LabQueueWorkbench to server-side pagination props

### DIFF
--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -120,7 +120,14 @@ export default function LabQueueWorkbench({
   onRefresh,
   onOpenAppointment,
   selectedAppointment = null,
-  reportHistory = []
+  reportHistory = [],
+  // STRAT#8: server-side pagination props (от LabPanel, добавлены в STRAT#7).
+  // Когда hasMore=true, кнопка «Показать ещё» вызывает onLoadMore (server-side).
+  // Когда hasMore=false, fallback на client-side visibleCount (FIX#13).
+  onLoadMore,
+  hasMore = false,
+  loadingMore = false,
+  queueTotal = 0,
 }) {
   // QW-8 fix: локальный state поиска и фильтра статусов.
   const [searchQuery, setSearchQuery] = useState('');
@@ -376,21 +383,47 @@ export default function LabQueueWorkbench({
                   </div>
                 );
               })}
-              {/* UX-AUDIT-FIX13: кнопка «Показать ещё» — увеличивает
-                  visibleCount на PAGE_SIZE. Показывается только если
-                  есть ещё записи для отображения. */}
-              {sortedAppointments.length > visibleCount && (
-                <div className="lqw-load-more">
-                  <Button
-                    variant="outline"
-                    onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
-                    aria-label={`Показать ещё ${Math.min(PAGE_SIZE, sortedAppointments.length - visibleCount)} записей`}
-                  >
-                    <Icon name="arrow.down" size={14} />
-                    Показать ещё ({sortedAppointments.length - visibleCount} осталось)
-                  </Button>
-                </div>
-              )}
+              {/* UX-AUDIT-FIX13 / STRAT#8: кнопка «Показать ещё».
+                  STRAT#8: когда hasMore=true (server-side pagination активна),
+                  вызываем onLoadMore для догрузки следующей страницы с сервера.
+                  Когда hasMore=false — fallback на client-side visibleCount
+                  (FIX#13 pattern, для случаев когда server-side не настроен). */}
+              {(() => {
+                // Server-side load-more: приоритетный путь
+                if (hasMore && onLoadMore) {
+                  return (
+                    <div className="lqw-load-more">
+                      <Button
+                        variant="outline"
+                        onClick={onLoadMore}
+                        disabled={loadingMore}
+                        aria-label="Загрузить ещё записи с сервера"
+                      >
+                        <Icon name={loadingMore ? 'arrow.clockwise' : 'arrow.down'} size={14} />
+                        {loadingMore
+                          ? 'Загрузка…'
+                          : `Показать ещё (${queueTotal - appointments.length} осталось)`}
+                      </Button>
+                    </div>
+                  );
+                }
+                // Client-side load-more: fallback (FIX#13)
+                if (sortedAppointments.length > visibleCount) {
+                  return (
+                    <div className="lqw-load-more">
+                      <Button
+                        variant="outline"
+                        onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+                        aria-label={`Показать ещё ${Math.min(PAGE_SIZE, sortedAppointments.length - visibleCount)} записей`}
+                      >
+                        <Icon name="arrow.down" size={14} />
+                        Показать ещё ({sortedAppointments.length - visibleCount} осталось)
+                      </Button>
+                    </div>
+                  );
+                }
+                return null;
+              })()}
             </div>
           )}
         </CardContent>
@@ -446,5 +479,10 @@ LabQueueWorkbench.propTypes = {
   onRefresh: PropTypes.func.isRequired,
   onOpenAppointment: PropTypes.func.isRequired,
   selectedAppointment: PropTypes.object,
-  reportHistory: PropTypes.array
+  reportHistory: PropTypes.array,
+  // STRAT#8: server-side pagination props
+  onLoadMore: PropTypes.func,
+  hasMore: PropTypes.bool,
+  loadingMore: PropTypes.bool,
+  queueTotal: PropTypes.number,
 };

--- a/frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx
@@ -67,4 +67,31 @@ describe('LabQueueWorkbench UX-AUDIT-FIX11 — MaskedPhone affordance', () => {
     expect(cssSource).toContain('.lqw-load-more');
     expect(cssSource).toContain('UX-AUDIT-FIX13');
   });
+
+  it('STRAT#8: accepts server-side pagination props (onLoadMore, hasMore, loadingMore, queueTotal)', () => {
+    // STRAT#8: новые props от LabPanel для server-side pagination
+    expect(source).toContain('onLoadMore,');
+    expect(source).toContain('hasMore = false,');
+    expect(source).toContain('loadingMore = false,');
+    expect(source).toContain('queueTotal = 0,');
+    // PropTypes добавлены
+    expect(source).toContain('onLoadMore: PropTypes.func');
+    expect(source).toContain('hasMore: PropTypes.bool');
+    expect(source).toContain('loadingMore: PropTypes.bool');
+    expect(source).toContain('queueTotal: PropTypes.number');
+  });
+
+  it('STRAT#8: uses server-side onLoadMore when hasMore=true, falls back to client-side otherwise', () => {
+    // Server-side path: приоритетный
+    expect(source).toContain('if (hasMore && onLoadMore)');
+    expect(source).toContain('onClick={onLoadMore}');
+    expect(source).toContain('disabled={loadingMore}');
+    // Loading indicator
+    expect(source).toContain("loadingMore ? 'arrow.clockwise' : 'arrow.down'");
+    expect(source).toContain("'Загрузка…'");
+    // Counter показывает server-side total
+    expect(source).toContain('queueTotal - appointments.length');
+    // Client-side fallback остаётся
+    expect(source).toContain('if (sortedAppointments.length > visibleCount)');
+  });
 });


### PR DESCRIPTION
## Summary

- Wire `LabQueueWorkbench.jsx` to consume the server-side pagination props (`onLoadMore`, `hasMore`, `loadingMore`, `queueTotal`) added in STRAT#7.
- The load-more button now has two paths: (1) **server-side** — when `hasMore=true` and `onLoadMore` is provided, calls server to fetch next page; (2) **client-side fallback** — preserves the FIX#13 pattern (`visibleCount += PAGE_SIZE`) for cases where server-side pagination is not configured.
- Server-side path shows `loadingMore` spinner state and displays `queueTotal - appointments.length` as the remaining count. Client-side fallback displays `sortedAppointments.length - visibleCount`.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat8-wire-queue-workbench-server-pagination` from `origin/main` at `670de76f` (post-STRAT#7).
- Clean workspace: inspected before edits; only `LabQueueWorkbench.jsx` and its contract test changed.
- Branch: `refactor/strat8-wire-queue-workbench-server-pagination`
- Scope gate: allowed `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only prop wiring. No API, websocket, event, or backend contract changed. The component receives 4 new optional props from `LabPanel.jsx` (added in STRAT#7). Existing callers without these props continue to work via the client-side fallback path.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. Same roles see same queue data; only the load-more button behavior changes based on whether server-side props are provided.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR wires UI props, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection. `onLoadMore` is a one-shot REST call delegated to `LabPanel.loadMoreAppointments` (added in STRAT#7); error handling is owned by the parent.

## Frontend Resilience

- Empty data proof: when `hasMore=false` and `onLoadMore` is undefined, falls back to client-side path. When `sortedAppointments.length <= visibleCount`, no load-more button renders (`return null`).
- Partial data proof: when `hasMore=true` but `onLoadMore` is undefined (misconfigured parent), falls back to client-side path via the `&&` guard.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: `loadingMore` prop disables the button during fetch, preventing duplicate requests.
- Stale route/deep-link behavior: not applicable; pagination state is owned by parent `LabPanel.jsx`.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; 2 new tests added (8 total in file)
- Rollback note: revert both files; load-more button reverts to client-side-only (FIX#13) behavior

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`
- Result: passed (8/8 tests, 1.09s)
- Not checked: integration test with real server-side pagination — out of scope; backend endpoint is unchanged and LabPanel wiring is covered by STRAT#7 tests

## Next Steps (out of scope for this PR)

1. Add server-side filter/sort params (`status`, `search`, `sort_by`) — backend may need extensions.
2. Consider `AbortController` integration for cancelable load-more requests.
3. Visual regression snapshot for the load-more button states (idle / loading / disabled).