### PR TITLE
refactor(lab): STRAT#16 — AbortController in LabPanel for request cancellation

### DIFF
--- a/frontend/src/api/labReporting.js
+++ b/frontend/src/api/labReporting.js
@@ -77,7 +77,10 @@ export const labReportingApi = {
       search.set('offset', String(params.offset));
     }
     const suffix = search.size ? `?${search.toString()}` : '';
-    return request(`/lab/queue/today${suffix}`);
+    // STRAT#16: пробрасываем signal в request() для AbortController support.
+    return request(`/lab/queue/today${suffix}`, {
+      ...(params.signal ? { signal: params.signal } : {}),
+    });
   },
 
   listOrders(params = {}) {

--- a/frontend/src/pages/LabPanel.jsx
+++ b/frontend/src/pages/LabPanel.jsx
@@ -96,6 +96,11 @@ export default function LabPanel() {
   const [queueOffset, setQueueOffset] = useState(0);
   const [hasMoreQueue, setHasMoreQueue] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
+  // STRAT#16: ref для AbortController очереди — отменяет предыдущий
+  // запрос при быстром повторном вызове loadLabAppointments.
+  const queueAbortControllerRef = useRef(null);
+  // STRAT#16: отдельный ref для load-more запросов.
+  const loadMoreAbortControllerRef = useRef(null);
   const [templates, setTemplates] = useState([]);
   const [selectedTemplate, setSelectedTemplate] = useState(null);
   const [selectedAppointment, setSelectedAppointment] = useState(null);
@@ -222,6 +227,15 @@ export default function LabPanel() {
   }, [switchTab]);
 
   const loadLabAppointments = useCallback(async () => {
+    // STRAT#16: AbortController для отмены предыдущего запроса при
+    // быстром повторном вызове (refresh, tab switch). Предотвращает
+    // setState-after-unmount и race conditions.
+    if (queueAbortControllerRef.current) {
+      queueAbortControllerRef.current.abort();
+    }
+    const controller = new AbortController();
+    queueAbortControllerRef.current = controller;
+
     setAppointmentsLoading(true);
     try {
       // P-03 fix: используем lab-specific façade endpoint вместо прямого
@@ -234,9 +248,12 @@ export default function LabPanel() {
       // (STRAT#4), но frontend ранее грузил все записи сразу. Теперь
       // initial load получает первые LAB_QUEUE_PAGE_SIZE=50 записей;
       // loadMoreAppointments() догружает следующие.
+      //
+      // STRAT#16: передаём signal для отмены запроса при быстром повторе.
       const payload = await labReportingApi.listQueueToday(null, {
         limit: LAB_QUEUE_PAGE_SIZE,
         offset: 0,
+        signal: controller.signal,
       });
       const queueEntries = normalizeListPayload(payload?.entries ?? []);
       setAppointments(queueEntries);
@@ -257,6 +274,8 @@ export default function LabPanel() {
       });
       logger.info('[LabPanel] loaded lab queue entries', queueEntries.length);
     } catch (error) {
+      // STRAT#16: не показываем error notification для отменённых запросов.
+      if (isAbortLikeError(error)) return;
       logger.error('[LabPanel] loadLabAppointments failed', error);
       notify(
         'error',
@@ -275,11 +294,19 @@ export default function LabPanel() {
   // LabQueueWorkbench (заменит client-side load-more из FIX#13).
   const loadMoreAppointments = useCallback(async () => {
     if (loadingMore || !hasMoreQueue) return;
+    // STRAT#16: AbortController для load-more (аналогично loadLabAppointments).
+    if (loadMoreAbortControllerRef.current) {
+      loadMoreAbortControllerRef.current.abort();
+    }
+    const controller = new AbortController();
+    loadMoreAbortControllerRef.current = controller;
+
     setLoadingMore(true);
     try {
       const payload = await labReportingApi.listQueueToday(null, {
         limit: LAB_QUEUE_PAGE_SIZE,
         offset: queueOffset,
+        signal: controller.signal,
       });
       const newEntries = normalizeListPayload(payload?.entries ?? []);
       setAppointments((current) => [...current, ...newEntries]);
@@ -287,6 +314,8 @@ export default function LabPanel() {
       setHasMoreQueue((payload?.total ?? 0) > queueOffset + newEntries.length);
       logger.info('[LabPanel] loaded more lab queue entries', newEntries.length);
     } catch (error) {
+      // STRAT#16: не показываем error notification для отменённых запросов.
+      if (isAbortLikeError(error)) return;
       logger.error('[LabPanel] loadMoreAppointments failed', error);
       notify('error', getErrorMessage(error, 'Не удалось загрузить дополнительные записи очереди.'));
     } finally {
@@ -462,6 +491,19 @@ export default function LabPanel() {
       }
     }
   }, [loadLabAppointments, loadRecentReports, loadTemplates, searchParams, loadInstance]);
+
+  // STRAT#16: cleanup — отменяем все pending запросы при unmount компонента.
+  // Предотвращает setState-after-unmark warnings и network waste.
+  useEffect(() => {
+    return () => {
+      if (queueAbortControllerRef.current) {
+        queueAbortControllerRef.current.abort();
+      }
+      if (loadMoreAbortControllerRef.current) {
+        loadMoreAbortControllerRef.current.abort();
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (selectedAppointment?.patient_id) {

--- a/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/LabPanel.contract.test.jsx
@@ -79,6 +79,41 @@ describe('LabPanel queue/report status contract', () => {
     expect(source).toContain('queueTotal={queueTotal}');
   });
 
+  it('STRAT#16: AbortController in loadLabAppointments and loadMoreAppointments', () => {
+    const source = readLabPanelSource();
+
+    // Refs for AbortControllers
+    expect(source).toContain('queueAbortControllerRef = useRef(null)');
+    expect(source).toContain('loadMoreAbortControllerRef = useRef(null)');
+
+    // loadLabAppointments: abort previous + create new + pass signal
+    const loadBlock = extractBlock(
+      source,
+      'const loadLabAppointments = useCallback(async () => {',
+      'const loadMoreAppointments = useCallback(async () => {',
+    );
+    expect(loadBlock).toContain('queueAbortControllerRef.current.abort()');
+    expect(loadBlock).toContain('new AbortController()');
+    expect(loadBlock).toContain('signal: controller.signal');
+    // Abort error tolerance
+    expect(loadBlock).toContain('isAbortLikeError(error)');
+
+    // loadMoreAppointments: same pattern
+    const loadMoreBlock = extractBlock(
+      source,
+      'const loadMoreAppointments = useCallback(async () => {',
+      '// H-2 fix: keyboard shortcuts',
+    );
+    expect(loadMoreBlock).toContain('loadMoreAbortControllerRef.current.abort()');
+    expect(loadMoreBlock).toContain('signal: controller.signal');
+    expect(loadMoreBlock).toContain('isAbortLikeError(error)');
+
+    // Cleanup effect on unmount
+    expect(source).toContain('STRAT#16: cleanup');
+    expect(source).toContain('queueAbortControllerRef.current.abort()');
+    expect(source).toContain('loadMoreAbortControllerRef.current.abort()');
+  });
+
   it('relies on backend-provided lab report summary fields without re-inventing status', () => {
     // P-03 fix: backend /lab/queue/today уже возвращает latest_lab_report
     // и связанные поля (lab_report_status, report_instance_id, etc.).


### PR DESCRIPTION
## Summary

- Add `AbortController` integration to `LabPanel.jsx` for `loadLabAppointments` and `loadMoreAppointments` — cancels in-flight requests on rapid re-calls and on component unmount.
- Previously, rapid refresh clicks or tab switches could cause race conditions: a slow first request could resolve after a faster second request, overwriting fresh data with stale data. Now each call aborts the previous `AbortController` before starting a new fetch.
- Updated `labReportingApi.listQueueToday()` to forward `params.signal` to `request()` (completing the AbortSignal support added in STRAT#12/FIX12).
- Abort errors are silently swallowed via `isAbortLikeError()` check — no user-facing error notification for cancelled requests.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat16-abortcontroller-labpanel` from `origin/main` at `05aff92f` (post-STRAT#15).
- Clean workspace: inspected before edits; only `LabPanel.jsx`, `labReporting.js` (signal forwarding), and existing test changed.
- Branch: `refactor/strat16-abortcontroller-labpanel`
- Scope gate: allowed `frontend/src/pages/LabPanel.jsx`, `frontend/src/api/labReporting.js`, `frontend/src/pages/__tests__/LabPanel.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

- Canonical surface: `GET /api/v1/lab/queue/today` — UNCHANGED. No new query params or headers.
- Request shape: authenticated GET, optional `{ limit, offset, signal }`. The `signal` is a browser-level `AbortSignal` — it cancels the underlying `fetch()` but does not change the HTTP request.
- Response shape: `{ entries: [...], total, date, timezone }` — UNCHANGED.
- Status codes: 200 for allowed roles, 401 unauthenticated, 403 forbidden — UNCHANGED.
- Frontend consumer: `LabPanel.jsx` `loadLabAppointments` and `loadMoreAppointments` — both now create + abort `AbortController` instances.
- Compatibility path or alias: callers without `signal` continue to work (backward compat from STRAT#4/FIX12).
- Contract proof: `labReportingApi.listQueueToday(null, { signal: controller.signal })` forwards to `request(path, { signal })` which spreads into `fetch()`.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR adds AbortController to REST calls, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection. Aborted requests are silently discarded; user can retry via refresh button or auto-refresh interval (both call `loadLabAppointments` which creates a new controller).

## Frontend Resilience

- Empty data proof: when component unmounts before any request completes, the cleanup effect aborts both controllers — no setState-after-unmount warnings.
- Partial data proof: if `loadLabAppointments` is called twice rapidly, the first request is aborted; only the second response updates state.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: `isAbortLikeError()` check in catch block prevents false error notifications for aborted requests.
- Stale route/deep-link behavior: not applicable; AbortController is per-call, not per-route.

## Scope Gate

- Allowed paths: `frontend/src/pages/LabPanel.jsx`, `frontend/src/api/labReporting.js`, `frontend/src/pages/__tests__/LabPanel.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; 1 new test added (9 total in file)
- Rollback note: revert all three files; no AbortController, requests are not cancelable

## Validation

- Targeted tests or smoke run: `npx vitest run src/pages/__tests__/LabPanel.contract.test.jsx src/api/__tests__/labReporting.contract.test.js`
- Result: passed (9+5 = 14 tests across 2 files, ~1s)
- Not checked: integration test with real AbortController cancellation — out of scope; contract test verifies the wiring