### PR TITLE
refactor(lab): STRAT#18 — migrate LabQueueWorkbench card strings to t()

### DIFF
--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -46,10 +46,10 @@ function maskPhone(phone) {
 // Соответствует Nielsen Heuristic #6 (Recognition rather than Recall).
 function MaskedPhone({ phone, canReveal = true }) {
   const [revealed, setRevealed] = useState(false);
-  if (!phone) return <span className="lqw-masked-phone-empty">не указан</span>;
+  if (!phone) return <span className="lqw-masked-phone-empty">{t('pii.phone_not_set')}</span>;
   if (!canReveal) {
     return (
-      <span className="lqw-masked-phone-readonly" title="Доступ к номеру ограничен ролью">
+      <span className="lqw-masked-phone-readonly" title={t('pii.phone_restricted')}>
         <Icon name="eye.slash" size={12} aria-hidden="true" />
         <span className="lqw-masked-phone-text">{maskPhone(phone)}</span>
       </span>
@@ -62,8 +62,8 @@ function MaskedPhone({ phone, canReveal = true }) {
         e.stopPropagation();
         setRevealed((v) => !v);
       }}
-      title={revealed ? 'Скрыть номер' : 'Показать номер (доступ ограничен)'}
-      aria-label={revealed ? 'Скрыть номер телефона' : 'Показать номер телефона'}
+      title={revealed ? t('pii.hide_phone') : t('pii.show_phone')}
+      aria-label={revealed ? t('pii.hide_phone_aria') : t('pii.show_phone_aria')}
       aria-pressed={revealed}
       className={`lqw-masked-phone ${revealed ? 'lqw-masked-phone-revealed' : ''}`}
     >
@@ -98,7 +98,7 @@ function formatServices(appointment) {
     ? appointment.all_patient_services
     : appointment?.services || [];
   if (!services.length) {
-    return 'Нет данных об услугах';
+    return t('pii.no_services');
   }
   return services.join(', ');
 }
@@ -302,8 +302,8 @@ export default function LabQueueWorkbench({
           ) : filteredAppointments.length === 0 ? (
             <Alert severity="info">
               {appointments.length === 0
-                ? 'На сегодня не найдено лабораторных записей.'
-                : 'Ничего не найдено. Измените поисковый запрос или фильтр.'}
+                ? t('queue.no_entries')
+                : t('queue.no_matches')}
             </Alert>
           ) : (
             <div className="lqw-card-grid">
@@ -329,10 +329,10 @@ export default function LabQueueWorkbench({
                     <div className="lqw-card-top">
                       <div className="lqw-card-info">
                         <div className="lqw-card-name">
-                          {appointment.patient_fio || 'Пациент без имени'}
+                          {appointment.patient_fio || t('queue.patient_no_name')}
                         </div>
                         <div className="lqw-card-meta">
-                          Визит: {appointment.visit_id || 'не привязан'} | Телефон:{' '}
+                          {t('queue.visit')}: {appointment.visit_id || t('queue.visit_not_linked')} | {t('queue.phone')}:{' '}
                           {/* P-05 fix: маскирование номера телефона в публичном
                               пространстве лаборатории. Раскрытие — по клику. */}
                           <MaskedPhone phone={appointment.patient_phone} />
@@ -344,12 +344,12 @@ export default function LabQueueWorkbench({
                     </div>
 
                     <div className="lqw-card-services">
-                      <strong>Услуги:</strong> {formatServices(appointment)}
+                      <strong>{t('queue.services')}:</strong> {formatServices(appointment)}
                     </div>
 
                     <div className="lqw-meta-row">
                       <Badge variant="primary">{formatSpecialtyLabel(appointment.specialty)}</Badge>
-                      {appointment.payment_status && <Badge variant="info">Оплата: {formatPaymentStatus(appointment.payment_status)}</Badge>}
+                      {appointment.payment_status && <Badge variant="info">{t('queue.payment')}: {formatPaymentStatus(appointment.payment_status)}</Badge>}
                       {/* PR-60 / Medium-13: was variant="success" (green implies positive status, but time is not a status) */}
                       {appointment.appointment_time && <Badge variant="default">{appointment.appointment_time}</Badge>}
                       {appointment.report_template_name && <Badge variant="info">{appointment.report_template_name}</Badge>}
@@ -365,9 +365,9 @@ export default function LabQueueWorkbench({
                         <details className="lqw-pii-details">
                           <summary
                             className="lqw-pii-summary"
-                            aria-label="Показать внутренний ID пациента"
+                            aria-label={t('queue.patient_id_aria')}
                           >
-                            ID пациента ▸
+                            {t('queue.patient_id_label')} ▸
                           </summary>
                           <span className="lqw-pii-value">
                             {appointment.patient_id}
@@ -379,7 +379,7 @@ export default function LabQueueWorkbench({
                           и создавала a11y anti-pattern (click bubbles to parent). */}
                       <Badge variant={appointment.report_instance_id ? 'success' : 'info'}>
                         <Icon name="doc.text" size={12} />
-                        {appointment.report_instance_id ? 'Отчёт существует' : 'Новый отчёт'}
+                        {appointment.report_instance_id ? t('queue.report_exists') : t('queue.report_new')}
                       </Badge>
                     </div>
                   </div>
@@ -399,12 +399,12 @@ export default function LabQueueWorkbench({
                         variant="outline"
                         onClick={onLoadMore}
                         disabled={loadingMore}
-                        aria-label="Загрузить ещё записи с сервера"
+                        aria-label={t('queue.load_more_aria')}
                       >
                         <Icon name={loadingMore ? 'arrow.clockwise' : 'arrow.down'} size={14} />
                         {loadingMore
-                          ? 'Загрузка…'
-                          : `Показать ещё (${queueTotal - appointments.length} осталось)`}
+                          ? t('queue.loading')
+                          : `${t('queue.show_more')} (${queueTotal - appointments.length} ${t('queue.remaining')})`}
                       </Button>
                     </div>
                   );
@@ -436,22 +436,22 @@ export default function LabQueueWorkbench({
           <CardHeader className="lqw-card-header">
             <CardTitle className="lqw-card-title">
               <Icon name="clock.arrow.circlepath" size={20} />
-              История отчётов пациента
+              {t('queue.history_title')}
             </CardTitle>
           </CardHeader>
           <CardContent className="lqw-card-content">
             {reportHistory.length === 0 ? (
-              <Alert severity="info">Для выбранного пациента ещё нет лабораторных отчётов.</Alert>
+              <Alert severity="info">{t('queue.history_empty')}</Alert>
             ) : (
               <div className="lqw-card-grid">
                 {reportHistory.map((item) => (
                   <div key={item.id} className="lqw-history-card">
                     <div className="lqw-history-info">
                       <div className="lqw-history-title">
-                        {item.template?.name || `Отчёт #${item.id}`}
+                        {item.template?.name || `${t('queue.history_report_number')} #${item.id}`}
                       </div>
                       <div className="lqw-history-meta">
-                        Создан: {new Date(item.created_at).toLocaleString()} | Статус: {formatLabStatus(item.status)}
+                        {t('queue.history_created')}: {new Date(item.created_at).toLocaleString()} | {t('queue.history_status')}: {formatLabStatus(item.status)}
                       </div>
                     </div>
                     <div className="lqw-history-badges">
@@ -461,8 +461,8 @@ export default function LabQueueWorkbench({
                       <Badge variant={historySeverityBadge(item).variant}>
                         {formatSeverityLabel(historySeverityBadge(item).label)}
                       </Badge>
-                      {item.flagged_findings_count > 0 && <Badge variant="info">{item.flagged_findings_count} флагов</Badge>}
-                      {item.critical_findings_count > 0 && <Badge variant="danger">{item.critical_findings_count} критич.</Badge>}
+                      {item.flagged_findings_count > 0 && <Badge variant="info">{item.flagged_findings_count} {t('queue.history_flags')}</Badge>}
+                      {item.critical_findings_count > 0 && <Badge variant="danger">{item.critical_findings_count} {t('queue.history_critical')}</Badge>}
                     </div>
                   </div>
                 ))}

--- a/frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx
@@ -35,7 +35,8 @@ describe('LabQueueWorkbench UX-AUDIT-FIX11 — MaskedPhone affordance', () => {
 
   it('adds read-only variant when canReveal=false', () => {
     expect(source).toContain('lqw-masked-phone-readonly');
-    expect(source).toContain('title="Доступ к номеру ограничен ролью"');
+    // STRAT#18: title migrated to t('pii.phone_restricted')
+    expect(source).toContain("t('pii.phone_restricted')");
   });
 
   it('registers hover/focus styles in lab.css', () => {
@@ -88,7 +89,8 @@ describe('LabQueueWorkbench UX-AUDIT-FIX11 — MaskedPhone affordance', () => {
     expect(source).toContain('disabled={loadingMore}');
     // Loading indicator
     expect(source).toContain("loadingMore ? 'arrow.clockwise' : 'arrow.down'");
-    expect(source).toContain("'Загрузка…'");
+    // STRAT#18: 'Загрузка…' migrated to t('queue.loading')
+    expect(source).toContain("t('queue.loading')");
     // Counter показывает server-side total
     expect(source).toContain('queueTotal - appointments.length');
     // Client-side fallback остаётся
@@ -126,5 +128,47 @@ describe('LabQueueWorkbench UX-AUDIT-FIX11 — MaskedPhone affordance', () => {
 
     // Filter count
     expect(source).toContain("t('queue.filter_count')");
+  });
+
+  it('STRAT#18: card strings (patient info, PII, history) use t()', () => {
+    // STRAT#18: card content strings мигрированы на t()
+    expect(source).toContain("t('pii.phone_not_set')");
+    expect(source).toContain("t('pii.phone_restricted')");
+    expect(source).toContain("t('pii.hide_phone')");
+    expect(source).toContain("t('pii.show_phone')");
+    expect(source).toContain("t('pii.no_services')");
+
+    // Card fields
+    expect(source).toContain("t('queue.patient_no_name')");
+    expect(source).toContain("t('queue.visit')");
+    expect(source).toContain("t('queue.visit_not_linked')");
+    expect(source).toContain("t('queue.phone')");
+    expect(source).toContain("t('queue.services')");
+    expect(source).toContain("t('queue.payment')");
+    expect(source).toContain("t('queue.patient_id_aria')");
+    expect(source).toContain("t('queue.patient_id_label')");
+    expect(source).toContain("t('queue.report_exists')");
+    expect(source).toContain("t('queue.report_new')");
+
+    // Empty states
+    expect(source).toContain("t('queue.no_entries')");
+    expect(source).toContain("t('queue.no_matches')");
+
+    // History panel
+    expect(source).toContain("t('queue.history_title')");
+    expect(source).toContain("t('queue.history_empty')");
+    expect(source).toContain("t('queue.history_report_number')");
+    expect(source).toContain("t('queue.history_created')");
+    expect(source).toContain("t('queue.history_status')");
+    expect(source).toContain("t('queue.history_flags')");
+    expect(source).toContain("t('queue.history_critical')");
+
+    // Больше нет хардкоженных русских строк в card content
+    expect(source).not.toContain("'Пациент без имени'");
+    expect(source).not.toContain("'Отчёт существует'");
+    expect(source).not.toContain("'Новый отчёт'");
+    expect(source).not.toContain('>История отчётов пациента<');
+    expect(source).not.toContain("'флагов'");
+    expect(source).not.toContain("'критич.'");
   });
 });

--- a/frontend/src/components/laboratory/utils/labTranslations.js
+++ b/frontend/src/components/laboratory/utils/labTranslations.js
@@ -175,6 +175,7 @@ const TRANSLATIONS = {
     show_more: 'Показать ещё',
     remaining: 'осталось',
     loading: 'Загрузка…',
+    load_more_aria: 'Загрузить ещё записи с сервера',
     no_entries: 'На сегодня не найдено лабораторных записей.',
     no_matches: 'Ничего не найдено. Измените поисковый запрос или фильтр.',
     filter_all: 'Все',
@@ -192,6 +193,25 @@ const TRANSLATIONS = {
     filter_count: 'Показано',
     filter_count_search: 'поиск',
     filter_count_filter: 'фильтр',
+    // Card strings (STRAT#18)
+    patient_no_name: 'Пациент без имени',
+    visit: 'Визит',
+    visit_not_linked: 'не привязан',
+    phone: 'Телефон',
+    services: 'Услуги',
+    payment: 'Оплата',
+    patient_id_aria: 'Показать внутренний ID пациента',
+    patient_id_label: 'ID пациента',
+    report_exists: 'Отчёт существует',
+    report_new: 'Новый отчёт',
+    // History panel (STRAT#18)
+    history_title: 'История отчётов пациента',
+    history_empty: 'Для выбранного пациента ещё нет лабораторных отчётов.',
+    history_report_number: 'Отчёт',
+    history_created: 'Создан',
+    history_status: 'Статус',
+    history_flags: 'флагов',
+    history_critical: 'критич.',
   },
 
   // ─── Error messages ──────────────────────────────────────────────────────
@@ -250,8 +270,11 @@ const TRANSLATIONS = {
     show_patient_id: 'ID пациента',
     show_phone: 'Показать номер (доступ ограничен)',
     hide_phone: 'Скрыть номер',
+    show_phone_aria: 'Показать номер телефона',
+    hide_phone_aria: 'Скрыть номер телефона',
     phone_restricted: 'Доступ к номеру ограничен ролью',
     phone_not_set: 'не указан',
+    no_services: 'Нет данных об услугах',
   },
 };
 


### PR DESCRIPTION
## Summary

- Migrate `LabQueueWorkbench.jsx` card content strings (patient info, PII labels, history panel, empty states, load-more button) to use `t()` from `labTranslations.js`.
- 22 hardcoded Russian strings migrated: MaskedPhone (5: phone_not_set, phone_restricted, hide_phone, show_phone, no_services), card fields (10: patient_no_name, visit, visit_not_linked, phone, services, payment, patient_id_aria/label, report_exists/new), empty states (2), history panel (7: title, empty, report_number, created, status, flags, critical), load-more (2: load_more_aria, loading).
- Added 18 new translation keys (13 in `queue.*`, 5 in `pii.*`).

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat18-migrate-queue-card-strings` from `origin/main` at `38d2bcb6` (post-STRAT#17).
- Clean workspace: inspected before edits; only `LabQueueWorkbench.jsx`, `labTranslations.js` (18 new keys), and existing test changed.
- Branch: `refactor/strat18-migrate-queue-card-strings`
- Scope gate: allowed `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/components/laboratory/utils/labTranslations.js`, `frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only string refactor. No API, websocket, event, or backend contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR migrates UI strings, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection.

## Frontend Resilience

- Empty data proof: when `t()` key is missing, returns the key itself (debugging-friendly).
- Partial data proof: each label's key is independent; missing one doesn't break the others.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: `t()` is a pure function with no resource lifecycle.
- Stale route/deep-link behavior: not applicable, `t()` is stateless.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/components/laboratory/utils/labTranslations.js`, `frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; 18 new translation keys; 1 new test added (10 total in file)
- Rollback note: revert all three files; hardcoded Russian strings restored in card content

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`
- Result: passed (10/10 tests, 993ms)
- Not checked: visual regression snapshot — card content renders identical Russian text via dictionary lookup