### PR TITLE
refactor(lab): STRAT#20 — migrate LabResultsSection empty-state strings to t()

### DIFF
--- a/frontend/src/components/emr-v2/sections/LabResultsSection.jsx
+++ b/frontend/src/components/emr-v2/sections/LabResultsSection.jsx
@@ -155,7 +155,7 @@ export function LabResultsSection({ patientId, visitId, disabled = false }) {
 
   const renderContent = () => {
     if (loading) {
-      return <div style={{ padding: '12px', color: 'var(--mac-text-secondary)' }}>Загрузка результатов анализов…</div>;
+      return <div style={{ padding: '12px', color: 'var(--mac-text-secondary)' }}>{t('empty.loading_results')}</div>;
     }
 
     if (error) {
@@ -165,7 +165,7 @@ export function LabResultsSection({ patientId, visitId, disabled = false }) {
     if (instances.length === 0) {
       return (
         <div style={{ padding: '12px', color: 'var(--mac-text-secondary)', fontSize: '14px' }}>
-          Нет готовых результатов анализов для этого пациента.
+          {t('empty.no_lab_results')}
         </div>
       );
     }
@@ -246,10 +246,10 @@ export function LabResultsSection({ patientId, visitId, disabled = false }) {
           <DialogContent>
             <div style={{ paddingTop: '8px', display: 'grid', gap: '8px' }}>
               {templatesLoading ? (
-                <div style={{ color: 'var(--mac-text-secondary)' }}>Загрузка шаблонов…</div>
+                <div style={{ color: 'var(--mac-text-secondary)' }}>{t('empty.loading_templates')}</div>
               ) : templates.length === 0 ? (
                 <div style={{ color: 'var(--mac-text-secondary)' }}>
-                  Нет опубликованных шаблонов анализов.
+                  {t('empty.no_templates')}
                 </div>
               ) : (
                 templates.map((template) => (

--- a/frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx
+++ b/frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx
@@ -104,4 +104,18 @@ describe('LabResultsSection UX-AUDIT-FIX6 — migrate lucide-react to macos Icon
     expect(source).not.toContain("confirmLabel: 'Заказать'");
     expect(source).not.toContain("cancelLabel: 'Отмена'");
   });
+
+  it('STRAT#20: empty-state strings use t() from labTranslations', () => {
+    // STRAT#20: empty-state strings мигрированы на t('empty.*')
+    expect(source).toContain("t('empty.loading_results')");
+    expect(source).toContain("t('empty.no_lab_results')");
+    expect(source).toContain("t('empty.loading_templates')");
+    expect(source).toContain("t('empty.no_templates')");
+
+    // Больше нет хардкоженных русских строк для empty states
+    expect(source).not.toContain('Загрузка результатов анализов…');
+    expect(source).not.toContain('Нет готовых результатов анализов для этого пациента.');
+    expect(source).not.toContain('Загрузка шаблонов…');
+    expect(source).not.toContain('Нет опубликованных шаблонов анализов.');
+  });
 });


### PR DESCRIPTION
## Summary

- Migrate 4 empty-state strings in `LabResultsSection.jsx` to use `t()` from `labTranslations.js` `empty.*` namespace.
- Strings migrated: `loading_results` (Загрузка результатов анализов…), `no_lab_results` (Нет готовых результатов…), `loading_templates` (Загрузка шаблонов…), `no_templates` (Нет опубликованных шаблонов…).
- All 4 keys were already defined in `labTranslations.js` from STRAT#3 — no new keys needed.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat20-migrate-empty-state-strings` from `origin/main` at `9fd88fd7` (post-STRAT#19).
- Clean workspace: inspected before edits; only `LabResultsSection.jsx` and existing test changed. `t()` was already imported (STRAT#12).
- Branch: `refactor/strat20-migrate-empty-state-strings`
- Scope gate: allowed `frontend/src/components/emr-v2/sections/LabResultsSection.jsx`, `frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only string refactor. No API, websocket, event, or backend contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR migrates UI strings, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection.

## Frontend Resilience

- Empty data proof: when `t()` key is missing, returns the key itself (debugging-friendly).
- Partial data proof: each empty-state key is independent; missing one doesn't break the others.
- Forbidden secondary path behavior: not applicable, no secondary path used.
- Missing draft/resource behavior: `t()` is a pure function with no resource lifecycle.
- Stale route/deep-link behavior: not applicable, `t()` is stateless.

## Scope Gate

- Allowed paths: `frontend/src/components/emr-v2/sections/LabResultsSection.jsx`, `frontend/src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; no new translation keys (all 4 already defined in STRAT#3); 1 new test added (8 total in file)
- Rollback note: revert both files; hardcoded Russian strings restored in empty states

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/emr-v2/sections/__tests__/LabResultsSection.contract.test.jsx`
- Result: passed (8/8 tests, 1.05s)
- Not checked: visual regression snapshot — empty-state text renders identical Russian text via dictionary lookup