### PR TITLE
refactor(lab): STRAT#27 — virtualized queue rendering via @tanstack/react-virtual

### DIFF
--- a/frontend/src/components/laboratory/LabQueueWorkbench.jsx
+++ b/frontend/src/components/laboratory/LabQueueWorkbench.jsx
@@ -14,6 +14,8 @@ import {
 import { t } from './utils/labTranslations';
 // STRAT#28: QueueCard extracted and wrapped in React.memo for performance.
 import QueueCard from './QueueCard';
+// STRAT#27: VirtualizedQueueList for 1000+ entries via @tanstack/react-virtual.
+import VirtualizedQueueList from './VirtualizedQueueList';
 
 // P-05 fix: маскирование PII (номера телефона) в карточках очереди.
 // Лабораторное помещение — публичное пространство, экран видят другие
@@ -308,60 +310,18 @@ export default function LabQueueWorkbench({
                 : t('queue.no_matches')}
             </Alert>
           ) : (
-            <div className="lqw-card-grid">
-              {/* UX-AUDIT-FIX13: рендерим только visibleCount записей
-                  вместо всего sortedAppointments. Кнопка «Показать ещё»
-                  внизу увеличивает visibleCount на PAGE_SIZE. */}
-              {sortedAppointments.slice(0, visibleCount).map((appointment) => (
-                <QueueCard
-                  key={appointment.id}
-                  appointment={appointment}
-                  isSelected={selectedAppointment?.id === appointment.id}
-                  onOpenAppointment={onOpenAppointment}
-                />
-              ))}
-              {/* UX-AUDIT-FIX13 / STRAT#8: кнопка «Показать ещё».
-                  STRAT#8: когда hasMore=true (server-side pagination активна),
-                  вызываем onLoadMore для догрузки следующей страницы с сервера.
-                  Когда hasMore=false — fallback на client-side visibleCount
-                  (FIX#13 pattern, для случаев когда server-side не настроен). */}
-              {(() => {
-                // Server-side load-more: приоритетный путь
-                if (hasMore && onLoadMore) {
-                  return (
-                    <div className="lqw-load-more">
-                      <Button
-                        variant="outline"
-                        onClick={onLoadMore}
-                        disabled={loadingMore}
-                        aria-label={t('queue.load_more_aria')}
-                      >
-                        <Icon name={loadingMore ? 'arrow.clockwise' : 'arrow.down'} size={14} />
-                        {loadingMore
-                          ? t('queue.loading')
-                          : `${t('queue.show_more')} (${queueTotal - appointments.length} ${t('queue.remaining')})`}
-                      </Button>
-                    </div>
-                  );
-                }
-                // Client-side load-more: fallback (FIX#13)
-                if (sortedAppointments.length > visibleCount) {
-                  return (
-                    <div className="lqw-load-more">
-                      <Button
-                        variant="outline"
-                        onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
-                        aria-label={`Показать ещё ${Math.min(PAGE_SIZE, sortedAppointments.length - visibleCount)} записей`}
-                      >
-                        <Icon name="arrow.down" size={14} />
-                        Показать ещё ({sortedAppointments.length - visibleCount} осталось)
-                      </Button>
-                    </div>
-                  );
-                }
-                return null;
-              })()}
-            </div>
+            /* STRAT#27: virtualized rendering replaces .slice().map() + load-more IIFE.
+               VirtualizedQueueList handles both performance (only visible cards render)
+               and server-side pagination (infinite scroll + manual load-more button). */
+            <VirtualizedQueueList
+              appointments={sortedAppointments}
+              selectedAppointment={selectedAppointment}
+              onOpenAppointment={onOpenAppointment}
+              onLoadMore={onLoadMore}
+              hasMore={hasMore}
+              loadingMore={loadingMore}
+              queueTotal={queueTotal}
+            />
           )}
         </CardContent>
       </Card>

--- a/frontend/src/components/laboratory/VirtualizedQueueList.jsx
+++ b/frontend/src/components/laboratory/VirtualizedQueueList.jsx
@@ -1,0 +1,145 @@
+import { useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useVirtualizer } from '@tanstack/react-virtual';
+// STRAT#28: QueueCard already wrapped in React.memo for per-item performance.
+import QueueCard from './QueueCard';
+// STRAT#27: t() for load-more button labels.
+import { t } from './utils/labTranslations';
+import { Button, Icon } from '../ui/macos';
+
+/**
+ * STRAT#27: VirtualizedQueueList — virtualized rendering for 1000+ queue entries.
+ *
+ * Ранее LabQueueWorkbench рендерил все visibleCount записей через .slice().map().
+ * При 100+ записях это вызывало тормоза DOM. Теперь используется
+ * @tanstack/react-virtual (уже установлен в проекте, используется в ChatWindow)
+ * — рендерятся только видимые в viewport карточки + overscan buffer.
+ *
+ * Performance: O(visible_count) вместо O(total_count) DOM nodes.
+ * При 1000 записях рендерится ~15-20 карточек вместо всех 1000.
+ *
+ * Props:
+ *   - appointments: full sorted array (virtualizer handles which to render)
+ *   - selectedAppointment: for isSelected check
+ *   - onOpenAppointment: click handler
+ *   - onLoadMore: server-side pagination callback
+ *   - hasMore: whether more entries can be loaded from server
+ *   - loadingMore: loading state for load-more button
+ *   - queueTotal: total entries on server (for remaining count)
+ */
+const CARD_ESTIMATE_HEIGHT = 180; // average card height with services + badges
+const OVERSCAN = 5; // render 5 extra cards above/below viewport
+
+export default function VirtualizedQueueList({
+  appointments,
+  selectedAppointment,
+  onOpenAppointment,
+  onLoadMore,
+  hasMore = false,
+  loadingMore = false,
+  queueTotal = 0,
+}) {
+  const scrollRef = useRef(null);
+
+  const rowVirtualizer = useVirtualizer({
+    count: appointments.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => CARD_ESTIMATE_HEIGHT,
+    overscan: OVERSCAN,
+  });
+
+  // STRAT#27: auto-load more when user scrolls near the bottom
+  // (infinite scroll pattern — complements the manual load-more button)
+  useEffect(() => {
+    if (!hasMore || loadingMore || !onLoadMore) return;
+    const scrollEl = scrollRef.current;
+    if (!scrollEl) return;
+
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = scrollEl;
+      // Trigger load when user is within 3 card heights of the bottom
+      if (scrollHeight - scrollTop - clientHeight < CARD_ESTIMATE_HEIGHT * 3) {
+        onLoadMore();
+      }
+    };
+
+    scrollEl.addEventListener('scroll', handleScroll, { passive: true });
+    return () => scrollEl.removeEventListener('scroll', handleScroll);
+  }, [hasMore, loadingMore, onLoadMore]);
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+
+  return (
+    <div
+      ref={scrollRef}
+      className="lqw-virtualized-list"
+      style={{
+        height: '100%',
+        maxHeight: '70vh',
+        overflow: 'auto',
+        position: 'relative',
+      }}
+    >
+      {/* Total height spacer — virtualizer positions items absolutely */}
+      <div
+        style={{
+          height: `${rowVirtualizer.getTotalSize()}px`,
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        {virtualItems.map((virtualItem) => {
+          const appointment = appointments[virtualItem.index];
+          if (!appointment) return null;
+          return (
+            <div
+              key={appointment.id}
+              data-index={virtualItem.index}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualItem.start}px)`,
+                paddingBottom: 'var(--mac-spacing-2)',
+              }}
+            >
+              <QueueCard
+                appointment={appointment}
+                isSelected={selectedAppointment?.id === appointment.id}
+                onOpenAppointment={onOpenAppointment}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Server-side load-more button (manual fallback for infinite scroll) */}
+      {hasMore && onLoadMore && (
+        <div className="lqw-load-more">
+          <Button
+            variant="outline"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+            aria-label={t('queue.load_more_aria')}
+          >
+            <Icon name={loadingMore ? 'arrow.clockwise' : 'arrow.down'} size={14} />
+            {loadingMore
+              ? t('queue.loading')
+              : `${t('queue.show_more')} (${queueTotal - appointments.length} ${t('queue.remaining')})`}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+VirtualizedQueueList.propTypes = {
+  appointments: PropTypes.array.isRequired,
+  selectedAppointment: PropTypes.object,
+  onOpenAppointment: PropTypes.func.isRequired,
+  onLoadMore: PropTypes.func,
+  hasMore: PropTypes.bool,
+  loadingMore: PropTypes.bool,
+  queueTotal: PropTypes.number,
+};

--- a/frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx
@@ -49,24 +49,12 @@ describe('LabQueueWorkbench UX-AUDIT-FIX11 — MaskedPhone affordance', () => {
     expect(cssSource).toContain('UX-AUDIT-FIX11');
   });
 
-  it('UX-AUDIT-FIX13: paginates queue rendering with PAGE_SIZE + load-more button', () => {
-    // FIX13: рендерим только visibleCount записей через .slice(0, visibleCount)
-    // вместо всего sortedAppointments. Кнопка «Показать ещё» увеличивает count.
-    expect(source).toContain('PAGE_SIZE = 20');
-    expect(source).toContain('visibleCount');
-    expect(source).toContain('setVisibleCount');
-    // .slice для ограничения рендера
-    expect(source).toContain('sortedAppointments.slice(0, visibleCount)');
-    // useEffect для сброса пагинации при смене фильтров
-    expect(source).toContain('useEffect(() => {');
-    expect(source).toContain('setVisibleCount(PAGE_SIZE)');
-    expect(source).toContain('[searchQuery, statusFilter, sortBy]');
-    // Кнопка «Показать ещё» в UI
-    expect(source).toContain('Показать ещё');
-    expect(source).toContain('lqw-load-more');
-    // CSS-класс для контейнера кнопки
-    expect(cssSource).toContain('.lqw-load-more');
-    expect(cssSource).toContain('UX-AUDIT-FIX13');
+  it('UX-AUDIT-FIX13 / STRAT#27: uses VirtualizedQueueList for rendering (replaces .slice().map())', () => {
+    // STRAT#27: .slice(0, visibleCount).map() replaced with <VirtualizedQueueList>
+    expect(source).toContain('VirtualizedQueueList');
+    expect(source).toContain('appointments={sortedAppointments}');
+    // No more client-side slicing — virtualizer handles what to render
+    expect(source).not.toContain('sortedAppointments.slice(0, visibleCount)');
   });
 
   it('STRAT#8: accepts server-side pagination props (onLoadMore, hasMore, loadingMore, queueTotal)', () => {
@@ -82,19 +70,21 @@ describe('LabQueueWorkbench UX-AUDIT-FIX11 — MaskedPhone affordance', () => {
     expect(source).toContain('queueTotal: PropTypes.number');
   });
 
-  it('STRAT#8: uses server-side onLoadMore when hasMore=true, falls back to client-side otherwise', () => {
-    // Server-side path: приоритетный
-    expect(source).toContain('if (hasMore && onLoadMore)');
-    expect(source).toContain('onClick={onLoadMore}');
-    expect(source).toContain('disabled={loadingMore}');
-    // Loading indicator
-    expect(source).toContain("loadingMore ? 'arrow.clockwise' : 'arrow.down'");
-    // STRAT#18: 'Загрузка…' migrated to t('queue.loading')
-    expect(source).toContain("t('queue.loading')");
-    // Counter показывает server-side total
-    expect(source).toContain('queueTotal - appointments.length');
-    // Client-side fallback остаётся
-    expect(source).toContain('if (sortedAppointments.length > visibleCount)');
+  it('STRAT#8 / STRAT#27: passes server-side pagination props to VirtualizedQueueList', () => {
+    // STRAT#27: load-more logic moved to VirtualizedQueueList component.
+    // LabQueueWorkbench passes props through.
+    expect(source).toContain('onLoadMore={onLoadMore}');
+    expect(source).toContain('hasMore={hasMore}');
+    expect(source).toContain('loadingMore={loadingMore}');
+    expect(source).toContain('queueTotal={queueTotal}');
+    // VirtualizedQueueList handles the actual load-more rendering
+    const virtualListSource = fs.readFileSync(
+      path.join(ROOT, 'components/laboratory/VirtualizedQueueList.jsx'),
+      'utf8'
+    );
+    expect(virtualListSource).toContain('hasMore && onLoadMore');
+    expect(virtualListSource).toContain('onClick={onLoadMore}');
+    expect(virtualListSource).toContain('disabled={loadingMore}');
   });
 
   it('STRAT#14: queue filter/sort/title labels use t() from labTranslations', () => {

--- a/frontend/src/components/laboratory/__tests__/VirtualizedQueueList.contract.test.jsx
+++ b/frontend/src/components/laboratory/__tests__/VirtualizedQueueList.contract.test.jsx
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { fileURLToPath } from 'node:url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../../..');
+
+const source = fs.readFileSync(
+  path.join(ROOT, 'components/laboratory/VirtualizedQueueList.jsx'),
+  'utf8'
+);
+
+describe('VirtualizedQueueList STRAT#27 — @tanstack/react-virtual', () => {
+  it('imports useVirtualizer from @tanstack/react-virtual', () => {
+    expect(source).toContain("from '@tanstack/react-virtual'");
+    expect(source).toContain('useVirtualizer');
+  });
+
+  it('imports QueueCard for per-item rendering', () => {
+    expect(source).toContain("from './QueueCard'");
+    expect(source).toContain('QueueCard');
+  });
+
+  it('imports t from labTranslations for load-more labels', () => {
+    expect(source).toContain("from './utils/labTranslations'");
+    expect(source).toContain('import { t }');
+  });
+
+  it('configures virtualizer with count, estimateSize, overscan', () => {
+    expect(source).toContain('count: appointments.length');
+    expect(source).toContain('estimateSize');
+    expect(source).toContain('CARD_ESTIMATE_HEIGHT');
+    expect(source).toContain('overscan: OVERSCAN');
+  });
+
+  it('renders virtual items with absolute positioning', () => {
+    expect(source).toContain('getVirtualItems()');
+    expect(source).toContain("'absolute'");
+    expect(source).toContain('translateY');
+  });
+
+  it('has infinite scroll via scroll event listener', () => {
+    expect(source).toContain('addEventListener');
+    expect(source).toContain('scroll');
+    expect(source).toContain('onLoadMore()');
+  });
+
+  it('has manual load-more button as fallback', () => {
+    expect(source).toContain('hasMore && onLoadMore');
+    expect(source).toContain('onClick={onLoadMore}');
+    expect(source).toContain('disabled={loadingMore}');
+    expect(source).toContain("t('queue.load_more_aria')");
+    expect(source).toContain("t('queue.loading')");
+    expect(source).toContain("t('queue.show_more')");
+  });
+
+  it('accepts all expected props', () => {
+    const expectedProps = [
+      'appointments',
+      'selectedAppointment',
+      'onOpenAppointment',
+      'onLoadMore',
+      'hasMore',
+      'loadingMore',
+      'queueTotal',
+    ];
+    for (const prop of expectedProps) {
+      expect(source).toContain(prop);
+    }
+  });
+
+  it('has PropTypes for all props', () => {
+    expect(source).toContain('appointments: PropTypes.array.isRequired');
+    expect(source).toContain('onOpenAppointment: PropTypes.func.isRequired');
+    expect(source).toContain('hasMore: PropTypes.bool');
+    expect(source).toContain('loadingMore: PropTypes.bool');
+    expect(source).toContain('queueTotal: PropTypes.number');
+  });
+
+  it('has STRAT#27 marker in JSDoc', () => {
+    expect(source).toContain('STRAT#27');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `VirtualizedQueueList` component using `@tanstack/react-virtual` (already installed, used in ChatWindow) to render only visible queue cards — O(visible_count) instead of O(total_count) DOM nodes.
- Replaces the client-side `.slice(0, visibleCount).map()` rendering (FIX#13) and the dual-path load-more IIFE (STRAT#8) with a single virtualized list that handles both performance and pagination.
- Adds infinite scroll: automatically triggers `onLoadMore` when user scrolls within 3 card heights of the bottom. Manual load-more button preserved as fallback.
- At 1000 queue entries, only ~15-20 cards render in the DOM (vs. all 1000 previously). Combined with `React.memo` on `QueueCard` (STRAT#28), this gives O(visible) render performance for any queue size.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat27-react-window-virtualization` from `origin/main` at `dc073961` (post-STRAT#28).
- Clean workspace: inspected before edits; only `LabQueueWorkbench.jsx` (inline rendering replaced), new `VirtualizedQueueList.jsx`, new contract test, and existing test updated.
- Branch: `refactor/strat27-react-window-virtualization`
- Scope gate: allowed `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/components/laboratory/VirtualizedQueueList.jsx`, `frontend/src/components/laboratory/__tests__/VirtualizedQueueList.contract.test.jsx`, `frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`; denied backend, migrations, other lab components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only performance refactor. No API, websocket, event, or backend contract changed. The same `QueueCard` components render with the same data; only the rendering mechanism changed (inline map → virtualizer).

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR refactors rendering, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection.

## Frontend Resilience

- Empty data proof: when `appointments` is empty, the virtualizer renders 0 items — the parent's empty-state Alert handles the UI. Same as before.
- Partial data proof: each virtual item maps to `appointments[virtualItem.index]` with a null guard (`if (!appointment) return null`).
- Forbidden secondary path behavior: not applicable - VirtualizedQueueList is a pure presentational component.
- Missing draft/resource behavior: `onLoadMore` is optional; when not provided, the infinite scroll and load-more button don't render.
- Stale route/deep-link behavior: not applicable; virtualizer state is component-local and resets on appointments array change.

## Scope Gate

- Allowed paths: `frontend/src/components/laboratory/LabQueueWorkbench.jsx`, `frontend/src/components/laboratory/VirtualizedQueueList.jsx`, `frontend/src/components/laboratory/__tests__/VirtualizedQueueList.contract.test.jsx`, `frontend/src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; 1 new component (130 lines); 1 new contract test (10 tests); 2 existing test assertions updated
- Rollback note: revert all four files; inline .slice().map() rendering with client-side load-more restored

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/laboratory/__tests__/VirtualizedQueueList.contract.test.jsx src/components/laboratory/__tests__/LabQueueWorkbench.contract.test.jsx`
- Result: passed (10+10 = 20 tests across 2 files, ~1s)
- Not checked: performance benchmark with 1000+ entries — out of scope for contract tests; virtualizer correctness is covered by @tanstack/react-virtual's own tests