### PR TITLE
refactor(i18n): STRAT#29 — lightweight useTranslation adapter (react-i18next compatible API)

### DIFF
--- a/frontend/src/i18n/__tests__/adapter.test.js
+++ b/frontend/src/i18n/__tests__/adapter.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { useTranslation, t, tInterpolate, i18n } from '../adapter';
+
+describe('i18n adapter (STRAT#29)', () => {
+  describe('useTranslation hook', () => {
+    it('returns t function and i18n instance', () => {
+      const result = useTranslation();
+      expect(result.t).toBeDefined();
+      expect(typeof result.t).toBe('function');
+      expect(result.i18n).toBeDefined();
+      expect(result.ready).toBe(true);
+    });
+
+    it('t() returns Russian string for valid key', () => {
+      const { t } = useTranslation();
+      expect(t('common.save')).toBe('Сохранить');
+      expect(t('common.cancel')).toBe('Отмена');
+    });
+
+    it('t() with params uses tInterpolate for {param} substitution', () => {
+      const { t } = useTranslation();
+      const result = t('confirm.delete_section_message', { name: 'Гемограмма' });
+      expect(result).toContain('Гемограмма');
+      expect(result).toContain('будет удалена');
+    });
+
+    it('t() returns key itself for missing translations', () => {
+      const { t } = useTranslation();
+      expect(t('nonexistent.key')).toBe('nonexistent.key');
+    });
+  });
+
+  describe('i18n instance', () => {
+    it('has language set to ru', () => {
+      expect(i18n.language).toBe('ru');
+      expect(i18n.languages).toContain('ru');
+    });
+
+    it('exists() returns true for valid keys', () => {
+      expect(i18n.exists('common.save')).toBe(true);
+      expect(i18n.exists('status.draft')).toBe(true);
+    });
+
+    it('exists() returns false for invalid keys', () => {
+      expect(i18n.exists('nonexistent.key')).toBe(false);
+    });
+
+    it('i18n.t() works as standalone function', () => {
+      expect(i18n.t('common.save')).toBe('Сохранить');
+      expect(i18n.t('confirm.delete_section_message', { name: 'Test' })).toContain('Test');
+    });
+
+    it('changeLanguage is a no-op that returns the language', async () => {
+      const result = await i18n.changeLanguage('en');
+      expect(result).toBe('en');
+      expect(i18n.language).toBe('ru');
+    });
+  });
+
+  describe('raw exports', () => {
+    it('exports t function', () => {
+      expect(t('common.save')).toBe('Сохранить');
+    });
+
+    it('exports tInterpolate function', () => {
+      const result = tInterpolate('confirm.delete_section_message', { name: 'Test' });
+      expect(result).toContain('Test');
+    });
+  });
+
+  describe('react-i18next API compatibility', () => {
+    it('useTranslation returns { t, i18n, ready } — matches react-i18next signature', () => {
+      const result = useTranslation();
+      expect(Object.keys(result).sort()).toEqual(['i18n', 'ready', 't']);
+    });
+
+    it('t() accepts (key) and (key, params) — matches react-i18next signature', () => {
+      const { t } = useTranslation();
+      expect(t('common.save')).toBe('Сохранить');
+      const result = t('confirm.delete_section_message', { name: 'Test' });
+      expect(result).toContain('Test');
+    });
+  });
+});

--- a/frontend/src/i18n/adapter.js
+++ b/frontend/src/i18n/adapter.js
@@ -1,0 +1,87 @@
+/**
+ * STRAT#29: i18n adapter — lightweight useTranslation hook compatible with
+ * react-i18next API, backed by labTranslations.js dictionary.
+ *
+ * react-i18next НЕ установлен в проекте. Этот модуль предоставляет
+ * совместимый API (useTranslation().t), чтобы другие модули могли
+ * начать миграцию на translation pattern без новой зависимости.
+ *
+ * Когда react-i18next будет установлен, этот файл заменяется на:
+ *   import { useTranslation } from 'react-i18next';
+ *   export { useTranslation };
+ * — все call sites продолжат работать без изменений.
+ *
+ * Current implementation:
+ *   - t(key) — возвращает перевод из labTranslations TRANSLATIONS dictionary
+ *   - tInterpolate(key, params) — подстановка {param} плейсхолдеров
+ *   - i18n.language — всегда 'ru' (пока нет locale switcher)
+ *   - i18n.changeLanguage(lang) — no-op (заглушка для будущего locale switcher)
+ *
+ * Usage:
+ *   import { useTranslation } from '../../i18n/adapter';
+ *   const { t } = useTranslation();
+ *   <Button>{t('common.save')}</Button>
+ */
+
+import { t, tInterpolate, TRANSLATIONS } from '../components/laboratory/utils/labTranslations';
+
+// Stub i18n object — compatible with react-i18next's i18n interface.
+// When react-i18next is adopted, this is replaced by the real i18n instance.
+const i18n = {
+  language: 'ru',
+  languages: ['ru'],
+  changeLanguage: async (lang) => {
+    // STRAT#31: when locale switcher is added, this will dispatch
+    // a language change event that updates the TRANSLATIONS dictionary.
+    // For now, it's a no-op — only Russian is supported.
+    console.warn('[i18n] changeLanguage is a no-op — only "ru" is supported');
+    return lang;
+  },
+  exists: (key) => {
+    const parts = key.split('.');
+    let current = TRANSLATIONS;
+    for (const part of parts) {
+      if (current && typeof current === 'object' && part in current) {
+        current = current[part];
+      } else {
+        return false;
+      }
+    }
+    return typeof current === 'string';
+  },
+  t: (key, params) => {
+    if (params) return tInterpolate(key, params);
+    return t(key);
+  },
+};
+
+/**
+ * useTranslation — React hook compatible with react-i18next.
+ *
+ * Returns { t, i18n } where:
+ *   - t(key, params?) — translation function with optional interpolation
+ *   - i18n — i18n instance (language, changeLanguage, exists)
+ *
+ * When react-i18next is installed, replace this file with:
+ *   export { useTranslation } from 'react-i18next';
+ */
+export function useTranslation() {
+  const tFunc = (key, params) => {
+    if (params) return tInterpolate(key, params);
+    return t(key);
+  };
+
+  return {
+    t: tFunc,
+    i18n,
+    // react-i18next compatibility: ready flag
+    ready: true,
+  };
+}
+
+// Export raw t and tInterpolate for non-hook contexts (module-level constants,
+// PropTypes defaults, etc.)
+export { t, tInterpolate };
+
+// Export i18n instance for app-level configuration
+export { i18n };

--- a/frontend/src/i18n/adapter.js
+++ b/frontend/src/i18n/adapter.js
@@ -34,7 +34,10 @@ const i18n = {
     // STRAT#31: when locale switcher is added, this will dispatch
     // a language change event that updates the TRANSLATIONS dictionary.
     // For now, it's a no-op — only Russian is supported.
-    console.warn('[i18n] changeLanguage is a no-op — only "ru" is supported');
+    if (typeof window !== 'undefined' && window.console) {
+      // eslint-disable-next-line no-console
+      console.warn('[i18n] changeLanguage is a no-op — only "ru" is supported');
+    }
     return lang;
   },
   exists: (key) => {


### PR DESCRIPTION
## Summary

- Add lightweight `useTranslation` hook in `i18n/adapter.js` — API-compatible with `react-i18next` but backed by the existing `labTranslations.js` dictionary (no new dependency).
- `react-i18next` is NOT installed in the project. This adapter allows other modules (registrar, doctor, admin) to start migrating to the translation pattern without installing a new package. When `react-i18next` is eventually adopted, the adapter file is replaced with a single re-export — all call sites continue working unchanged.
- API: `useTranslation()` returns `{ t, i18n, ready }` — same shape as react-i18next. `t(key)` and `t(key, params)` both supported. `i18n.language` is `'ru'`, `i18n.exists(key)` checks dictionary, `i18n.changeLanguage()` is a no-op stub for STRAT#31 locale switcher.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat29-i18n-adapter` from `origin/main` at `8d27739f` (post-STRAT#27).
- Clean workspace: inspected before edits; only new `i18n/adapter.js` and new test file added. No existing files modified.
- Branch: `refactor/strat29-i18n-adapter`
- Scope gate: allowed `frontend/src/i18n/adapter.js`, `frontend/src/i18n/__tests__/adapter.test.js`; denied backend, migrations, existing frontend components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - new infrastructure module. No API, websocket, event, or backend contract changed. The adapter is a pure JavaScript module with no side effects.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR adds an i18n utility module, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection.

## Frontend Resilience

- Empty data proof: when `t()` key is missing, returns the key itself (debugging-friendly). Same behavior as the underlying `labTranslations.js` t() function.
- Partial data proof: each namespace is independent; missing keys don't break others.
- Forbidden secondary path behavior: not applicable - the adapter is a pure function with no secondary path.
- Missing draft/resource behavior: the adapter is stateless; no resource lifecycle.
- Stale route/deep-link behavior: not applicable; the adapter has no routing dependency.

## Scope Gate

- Allowed paths: `frontend/src/i18n/adapter.js`, `frontend/src/i18n/__tests__/adapter.test.js`
- Denied paths: backend runtime, existing frontend components, migrations, generated output
- Migration/docs/test impact: no migration; 1 new utility module (80 lines); 1 new test file (13 tests)
- Rollback note: revert both new files; no existing code depends on them yet

## Validation

- Targeted tests or smoke run: `npx vitest run src/i18n/__tests__/adapter.test.js`
- Result: passed (13/13 tests, 853ms)
- Not checked: integration with actual components — out of scope; this PR only adds infrastructure, STRAT#30 will wire it to other modules

## Next Steps

1. **STRAT#30**: Migrate registrar/doctor/admin panels to use `useTranslation()` from this adapter
2. **STRAT#31**: Implement locale switcher — when `i18n.changeLanguage()` is called, swap the TRANSLATIONS dictionary
3. **Future**: Install `react-i18next` and replace `i18n/adapter.js` with `export { useTranslation } from 'react-i18next'`