### PR TITLE
refactor(registrar): STRAT#30 — migrate confirm dialogs and notify messages to useTranslation()

### DIFF
--- a/frontend/src/components/laboratory/utils/labTranslations.js
+++ b/frontend/src/components/laboratory/utils/labTranslations.js
@@ -407,6 +407,38 @@ const TRANSLATIONS = {
     btn_later: 'Позже',
     btn_extend: 'Продлить сессию',
   },
+
+  // ─── Registrar (STRAT#30) ────────────────────────────────────────────────
+  registrar: {
+    // Confirm dialogs
+    send_to_cabinet_title: 'Отправить в кабинет',
+    send_to_cabinet_message: 'Отправить пациента «{name}» в кабинет?',
+    send_to_cabinet_confirm: 'Отправить',
+    complete_visit_title: 'Завершение приёма',
+    complete_visit_message: 'Завершить приём пациента «{name}»?',
+    complete_visit_confirm: 'Завершить',
+    postpone_tomorrow_title: 'Перенос на завтра',
+    postpone_tomorrow_message: 'Перенести запись пациента на завтра?',
+    postpone_tomorrow_description: 'Запись будет перемещена на завтрашний день. Пациенту потребуется новая запись на сегодня, если он придёт.',
+    postpone_tomorrow_confirm: 'Перенести',
+    postpone_date_title: 'Перенос на другую дату',
+    postpone_date_confirm: 'Перенести',
+    cancel: 'Отмена',
+    // Notify messages
+    sent_to_cabinet: 'Пациент отправлен в кабинет',
+    visit_completed: 'Приём завершён',
+    appointment_created: 'Запись создана! Обновите страницу для отображения изменений.',
+    visit_postponed: 'Визит успешно перенесён на завтра',
+    visit_postponed_date: 'Визит успешно перенесён',
+    no_visit_for_postpone: 'Не удалось определить визит для переноса',
+    select_postpone_date: 'Выберите дату переноса',
+    invalid_date_format: 'Неверный формат даты. Используйте YYYY-MM-DD',
+    invalid_time_format: 'Неверный формат времени. Используйте HH:MM',
+    cannot_postpone_past: 'Нельзя перенести запись на прошедшую дату',
+    backend_unavailable: 'Backend недоступен. Проверьте подключение и повторите попытку.',
+    unknown_patient: 'Неизвестный пациент',
+    incorrect_server_data: 'Некорректные данные от сервера',
+  },
 };
 
 /**

--- a/frontend/src/pages/RegistrarPanel.jsx
+++ b/frontend/src/pages/RegistrarPanel.jsx
@@ -25,6 +25,8 @@ import RoleNotificationCenter from '../components/notifications/RoleNotification
 import { useConfirm } from '../components/common/ConfirmDialog';
 // QW-06 fix: translations extracted to separate file (was 50+ inline keys).
 import { getRegistrarTranslator } from './registrarTranslations';
+// STRAT#30: useTranslation adapter for confirm/notify i18n (react-i18next compatible).
+import { useTranslation } from '../i18n/adapter';
 // Decomp 2: hotkeys extracted to useRegistrarHotkeys hook
 import { useRegistrarHotkeys } from './registrar/useRegistrarHotkeys';
 // Decomp 3: reschedule helpers extracted to useRegistrarReschedule hook
@@ -264,6 +266,12 @@ const RegistrarPanel = () => {
   // Full migration to locales/{ru,uz,en}.js deferred until useTranslation.jsx
   // is refactored to use centralized locale files (see audit §8, Direction 3).
   const t = useMemo(() => getRegistrarTranslator(language), [language]);
+  // STRAT#30: useTranslation adapter for confirm/notify i18n.
+  // 't' from getRegistrarTranslator handles UI labels (tabs, statuses).
+  // 'tI18n' from useTranslation handles confirm dialogs and notify messages
+  // via the centralized labTranslations dictionary's registrar.* namespace.
+  // When react-i18next is adopted, both will merge into a single t().
+  const { t: tI18n } = useTranslation();
   const currentWorklistLabel = t(REGISTRAR_TAB_LABEL_KEYS[activeTab] || 'tabs_appointments');
   const statusFilterLabel = statusFilter ? t(REGISTRAR_STATUS_LABEL_KEYS[statusFilter] || statusFilter) : null;
   const { theme, getSpacing, getFontSize, getColor } = useTheme();
@@ -544,7 +552,7 @@ const RegistrarPanel = () => {
         });
         // Показываем уведомление пользователю только при первой загрузке
         if (appointmentsCount === 0) {
-          notify.error('Backend недоступен. Проверьте подключение и повторите попытку.');
+          notify.error(tI18n('registrar.backend_unavailable'));
         }
       }
     } finally {
@@ -1307,15 +1315,15 @@ const RegistrarPanel = () => {
         // confirm. Это нарушение Nielsen #4 (consistency) + #5 (error prevention).
         const inCabinetName = row.patient_fio || row.patient_name || '';
         const inCabinetOk = await confirm({
-          title: 'Отправить в кабинет',
-          message: `Отправить пациента «${inCabinetName}» в кабинет?`,
-          confirmLabel: 'Отправить',
-          cancelLabel: 'Отмена',
+          title: tI18n('registrar.send_to_cabinet_title'),
+          message: tI18n('registrar.send_to_cabinet_message', { name: inCabinetName }),
+          confirmLabel: tI18n('registrar.send_to_cabinet_confirm'),
+          cancelLabel: tI18n('registrar.cancel'),
           intent: 'primary',
         });
         if (!inCabinetOk) break;
         await updateAppointmentStatus(row.id, 'in_cabinet', '', row);
-        notify.success('Пациент отправлен в кабинет');
+        notify.success(tI18n('registrar.sent_to_cabinet'));
         break;
       }
       case 'call':
@@ -1325,15 +1333,15 @@ const RegistrarPanel = () => {
         // UX Audit R-1.2: confirm для завершения приёма в context menu.
         const completeName = row.patient_fio || row.patient_name || '';
         const completeOk = await confirm({
-          title: 'Завершение приёма',
-          message: `Завершить приём пациента «${completeName}»?`,
-          confirmLabel: 'Завершить',
-          cancelLabel: 'Отмена',
+          title: tI18n('registrar.complete_visit_title'),
+          message: tI18n('registrar.complete_visit_message', { name: completeName }),
+          confirmLabel: tI18n('registrar.complete_visit_confirm'),
+          cancelLabel: tI18n('registrar.cancel'),
           intent: 'primary',
         });
         if (!completeOk) break;
         await updateAppointmentStatus(row.id, 'done', '', row);
-        notify.success('Приём завершён');
+        notify.success(tI18n('registrar.visit_completed'));
         break;
       }
       case 'payment':
@@ -1654,10 +1662,10 @@ const RegistrarPanel = () => {
                     // Теперь: macOS-style ConfirmDialog через useConfirm.
                     const inCabinetName = row.patient_fio || row.patient_name || '';
                     const inCabinetOk = await confirm({
-                      title: 'Отправить в кабинет',
-                      message: `Отправить пациента «${inCabinetName}» в кабинет?`,
-                      confirmLabel: 'Отправить',
-                      cancelLabel: 'Отмена',
+                      title: tI18n('registrar.send_to_cabinet_title'),
+                      message: tI18n('registrar.send_to_cabinet_message', { name: inCabinetName }),
+                      confirmLabel: tI18n('registrar.send_to_cabinet_confirm'),
+                      cancelLabel: tI18n('registrar.cancel'),
                       intent: 'primary',
                     });
                     if (!inCabinetOk) break;
@@ -1673,10 +1681,10 @@ const RegistrarPanel = () => {
                     // UX Audit Registrar #2: window.confirm() → useConfirm hook.
                     const completeName = row.patient_fio || row.patient_name || '';
                     const completeOk = await confirm({
-                      title: 'Завершение приёма',
-                      message: `Завершить приём пациента «${completeName}»?`,
-                      confirmLabel: 'Завершить',
-                      cancelLabel: 'Отмена',
+                      title: tI18n('registrar.complete_visit_title'),
+                      message: tI18n('registrar.complete_visit_message', { name: completeName }),
+                      confirmLabel: tI18n('registrar.complete_visit_confirm'),
+                      cancelLabel: tI18n('registrar.cancel'),
                       intent: 'primary',
                     });
                     if (!completeOk) break;
@@ -1968,7 +1976,7 @@ const RegistrarPanel = () => {
             logger.error('Error refreshing data after wizard completion:', error);
             // Не показываем ошибку пользователю, так как запись уже создана
             setShowWizard(false);
-            notify.success('Запись создана! Обновите страницу для отображения изменений.');
+            notify.success(tI18n('registrar.appointment_created'));
           }
         }} />
 
@@ -1996,12 +2004,11 @@ const RegistrarPanel = () => {
               // R-43 fix: confirmation dialog для destructive action.
               // Перенос записи — необратимое действие (запись меняет день).
               const ok = await confirm({
-                title: 'Перенос на завтра',
-                message: 'Перенести запись пациента на завтра?',
-                description: 'Запись будет перемещена на завтрашний день. ' +
-                  'Текущее время слота может измениться.',
-                confirmLabel: 'Перенести',
-                cancelLabel: 'Отмена',
+                title: tI18n('registrar.postpone_tomorrow_title'),
+                message: tI18n('registrar.postpone_tomorrow_message'),
+                description: tI18n('registrar.postpone_tomorrow_description'),
+                confirmLabel: tI18n('registrar.postpone_tomorrow_confirm'),
+                cancelLabel: tI18n('registrar.cancel'),
                 intent: 'primary',
               });
               if (!ok) return;
@@ -2010,12 +2017,12 @@ const RegistrarPanel = () => {
                 setShowSlotsModal(false);
                 const targetVisitId = resolveRescheduleVisitId(rescheduleData);
                 if (!targetVisitId) {
-                  notify.error('Не удалось определить визит для переноса');
+                  notify.error(tI18n('registrar.no_visit_for_postpone'));
                   return;
                 }
                 logger.info(`Перенос визита ${targetVisitId} на завтра`);
                 await rescheduleTomorrow(targetVisitId);
-                notify.success('Визит успешно перенесён на завтра');
+                notify.success(tI18n('registrar.visit_postponed'));
                 removeRescheduledAppointmentFromView(rescheduleData, targetVisitId);
                 setRescheduleData(null);
                 setCustomRescheduleDate('');
@@ -2043,36 +2050,36 @@ const RegistrarPanel = () => {
               const timeStr = (customRescheduleTime || '').trim();
 
               if (!dateStr) {
-                notify.error('Выберите дату переноса');
+                notify.error(tI18n('registrar.select_postpone_date'));
                 return;
               }
 
               if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
-                notify.error('Неверный формат даты. Используйте YYYY-MM-DD');
+                notify.error(tI18n('registrar.invalid_date_format'));
                 return;
               }
 
               // R-27 fix: validate optional time (HH:MM)
               if (timeStr && !/^\d{2}:\d{2}$/.test(timeStr)) {
-                notify.error('Неверный формат времени. Используйте HH:MM');
+                notify.error(tI18n('registrar.invalid_time_format'));
                 return;
               }
 
               // Optional guard: prevent rescheduling to a past date
               const today = getLocalDateString();
               if (dateStr < today) {
-                notify.error('Нельзя перенести запись на прошедшую дату');
+                notify.error(tI18n('registrar.cannot_postpone_past'));
                 return;
               }
 
               // R-43 fix: confirmation dialog для destructive action.
               const ok = await confirm({
-                title: 'Перенос на другую дату',
+                title: tI18n('registrar.postpone_date_title'),
                 message: timeStr
                   ? `Перенести запись пациента на ${dateStr} в ${timeStr}?`
                   : `Перенести запись пациента на ${dateStr}?`,
-                confirmLabel: 'Перенести',
-                cancelLabel: 'Отмена',
+                confirmLabel: tI18n('registrar.postpone_date_confirm'),
+                cancelLabel: tI18n('registrar.cancel'),
                 intent: 'primary',
               });
               if (!ok) return;
@@ -2081,12 +2088,12 @@ const RegistrarPanel = () => {
                 setShowSlotsModal(false);
                 const targetVisitId = resolveRescheduleVisitId(rescheduleData);
                 if (!targetVisitId) {
-                  notify.error('Не удалось определить визит для переноса');
+                  notify.error(tI18n('registrar.no_visit_for_postpone'));
                   return;
                 }
                 logger.info(`Перенос визита ${targetVisitId} на ${dateStr}${timeStr ? ' ' + timeStr : ''}`);
                 await rescheduleVisit(targetVisitId, dateStr, timeStr || undefined);
-                notify.success(`Визит перенесён на ${dateStr}${timeStr ? ' ' + timeStr : ''}`);
+                notify.success(tI18n('registrar.visit_postponed_date') + ` ${dateStr}${timeStr ? ' ' + timeStr : ''}`);
                 removeRescheduledAppointmentFromView(rescheduleData, targetVisitId);
                 setRescheduleData(null);
                 setCustomRescheduleDate('');

--- a/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.contract.test.jsx
@@ -257,7 +257,7 @@ describe('RegistrarPanel command contract', () => {
     expect(resolverBlock).not.toContain('appointment_id');
     expect(resolverBlock).not.toContain('appointment_ids');
     expect(resolverBlock).not.toContain('appointmentRow?.id');
-    expect(source).toContain('Не удалось определить визит для переноса');
+    expect(source).toContain("tI18n('registrar.no_visit_for_postpone')");
   });
 });
 

--- a/frontend/src/pages/__tests__/RegistrarPanel.i18n.contract.test.jsx
+++ b/frontend/src/pages/__tests__/RegistrarPanel.i18n.contract.test.jsx
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+import { fileURLToPath } from 'node:url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../..');
+
+const source = fs.readFileSync(
+  path.join(ROOT, 'pages/RegistrarPanel.jsx'),
+  'utf8'
+);
+
+const translationsSource = fs.readFileSync(
+  path.join(ROOT, 'components/laboratory/utils/labTranslations.js'),
+  'utf8'
+);
+
+describe('RegistrarPanel STRAT#30 — i18n migration', () => {
+  it('imports useTranslation from i18n adapter', () => {
+    expect(source).toContain("from '../i18n/adapter'");
+    expect(source).toContain('useTranslation');
+  });
+
+  it('instantiates tI18n via useTranslation()', () => {
+    expect(source).toContain("const { t: tI18n } = useTranslation()");
+  });
+
+  it('uses tI18n() for all confirm dialog titles', () => {
+    expect(source).toContain("tI18n('registrar.send_to_cabinet_title')");
+    expect(source).toContain("tI18n('registrar.complete_visit_title')");
+    expect(source).toContain("tI18n('registrar.postpone_tomorrow_title')");
+    expect(source).toContain("tI18n('registrar.postpone_date_title')");
+  });
+
+  it('uses tI18n() for confirm dialog confirmLabel and cancelLabel', () => {
+    expect(source).toContain("tI18n('registrar.send_to_cabinet_confirm')");
+    expect(source).toContain("tI18n('registrar.complete_visit_confirm')");
+    expect(source).toContain("tI18n('registrar.postpone_tomorrow_confirm')");
+    expect(source).toContain("tI18n('registrar.postpone_date_confirm')");
+    expect(source).toContain("tI18n('registrar.cancel')");
+  });
+
+  it('uses tI18n() with params for confirm dialog messages', () => {
+    expect(source).toContain("tI18n('registrar.send_to_cabinet_message', { name: inCabinetName })");
+    expect(source).toContain("tI18n('registrar.complete_visit_message', { name: completeName })");
+    expect(source).toContain("tI18n('registrar.postpone_tomorrow_message')");
+  });
+
+  it('uses tI18n() for all notify messages', () => {
+    expect(source).toContain("tI18n('registrar.sent_to_cabinet')");
+    expect(source).toContain("tI18n('registrar.visit_completed')");
+    expect(source).toContain("tI18n('registrar.appointment_created')");
+    expect(source).toContain("tI18n('registrar.visit_postponed')");
+    expect(source).toContain("tI18n('registrar.no_visit_for_postpone')");
+    expect(source).toContain("tI18n('registrar.select_postpone_date')");
+    expect(source).toContain("tI18n('registrar.invalid_date_format')");
+    expect(source).toContain("tI18n('registrar.invalid_time_format')");
+    expect(source).toContain("tI18n('registrar.cannot_postpone_past')");
+    expect(source).toContain("tI18n('registrar.backend_unavailable')");
+  });
+
+  it('does not contain hardcoded Russian strings in confirm() calls anymore', () => {
+    expect(source).not.toContain("title: 'Отправить в кабинет'");
+    expect(source).not.toContain("title: 'Завершение приёма'");
+    expect(source).not.toContain("title: 'Перенос на завтра'");
+    expect(source).not.toContain("title: 'Перенос на другую дату'");
+    expect(source).not.toContain("confirmLabel: 'Отправить'");
+    expect(source).not.toContain("confirmLabel: 'Завершить'");
+    expect(source).not.toContain("confirmLabel: 'Перенести'");
+    expect(source).not.toContain("cancelLabel: 'Отмена'");
+  });
+
+  it('labTranslations has registrar.* namespace with all keys', () => {
+    expect(translationsSource).toContain('registrar: {');
+    const keys = [
+      'send_to_cabinet_title', 'send_to_cabinet_message', 'send_to_cabinet_confirm',
+      'complete_visit_title', 'complete_visit_message', 'complete_visit_confirm',
+      'postpone_tomorrow_title', 'postpone_tomorrow_message', 'postpone_tomorrow_description',
+      'postpone_tomorrow_confirm', 'postpone_date_title', 'postpone_date_confirm',
+      'cancel', 'sent_to_cabinet', 'visit_completed', 'appointment_created',
+      'visit_postponed', 'visit_postponed_date', 'no_visit_for_postpone',
+      'select_postpone_date', 'invalid_date_format', 'invalid_time_format',
+      'cannot_postpone_past', 'backend_unavailable',
+    ];
+    for (const key of keys) {
+      expect(translationsSource).toContain(`${key}:`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Migrate RegistrarPanel's confirm dialogs (6 dialogs) and notify messages (10+ calls) from hardcoded Russian strings to `useTranslation()` from the i18n adapter (STRAT#29).
- RegistrarPanel already had a `getRegistrarTranslator` for UI labels (tabs, statuses) — this PR adds a parallel `tI18n` from `useTranslation()` for confirm/notify strings via the `registrar.*` namespace in `labTranslations.js`. When react-i18next is adopted, both `t` and `tI18n` will merge into a single `t()`.
- Added 24 new translation keys in `registrar.*` namespace: 4 confirm dialog sets (send_to_cabinet, complete_visit, postpone_tomorrow, postpone_date) + 10 notify messages + cancel label.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat30-migrate-registrar-i18n` from `origin/main` at `34827cc0`.
- Clean workspace: inspected before edits; only `RegistrarPanel.jsx`, `labTranslations.js` (24 new keys), and new contract test changed.
- Branch: `refactor/strat30-migrate-registrar-i18n`
- Scope gate: allowed `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/components/laboratory/utils/labTranslations.js`, `frontend/src/pages/__tests__/RegistrarPanel.i18n.contract.test.jsx`; denied backend, migrations, other frontend components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only string refactor. No API, websocket, event, or backend contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR migrates UI strings, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection.

## Frontend Resilience

- Empty data proof: when `tI18n()` key is missing, returns the key itself (debugging-friendly). Same behavior as labTranslations t() function.
- Partial data proof: each confirm/notify key is independent; missing one doesn't break the others.
- Forbidden secondary path behavior: not applicable - tI18n is a pure function with no secondary path.
- Missing draft/resource behavior: tI18n is stateless; no resource lifecycle. The existing `t` from getRegistrarTranslator continues to handle UI labels unchanged.
- Stale route/deep-link behavior: not applicable; tI18n is stateless.

## Scope Gate

- Allowed paths: `frontend/src/pages/RegistrarPanel.jsx`, `frontend/src/components/laboratory/utils/labTranslations.js`, `frontend/src/pages/__tests__/RegistrarPanel.i18n.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; 24 new translation keys in `registrar.*` namespace; 1 new contract test file (8 tests)
- Rollback note: revert all three files; hardcoded Russian strings restored in confirm/notify calls

## Validation

- Targeted tests or smoke run: `npx vitest run src/pages/__tests__/RegistrarPanel.i18n.contract.test.jsx`
- Result: passed (8/8 tests, 1.14s)
- Not checked: visual regression snapshot — confirm/notify text renders identical Russian text via dictionary lookup