### PR TITLE
refactor(dental): STRAT#34 — migrate notify messages to useTranslation()

### DIFF
--- a/frontend/src/components/laboratory/utils/labTranslations.js
+++ b/frontend/src/components/laboratory/utils/labTranslations.js
@@ -510,6 +510,21 @@ const TRANSLATIONS = {
     price_change_unavailable: 'Изменение цены недоступно — используйте каталог услуг',
     session_extending: 'Продлеваем сессию...',
   },
+  // ─── Dentist (STRAT#34) ──────────────────────────────────────────────────
+  dental: {
+    session_expired: 'Сессия истекла. Пожалуйста, войдите снова.',
+    no_queue_id_for_visit: 'Cannot start visit without a queue entry id',
+    no_active_visit: 'У пациента нет активного визита. Откройте вкладку «Пациенты» для поиска.',
+    no_patient_for_complete: 'Не выбран пациент для завершения приёма',
+    no_queue_id_for_complete: 'Невозможно завершить приём без ID записи в очереди',
+    visit_completed: 'Приём завершён успешно',
+    protocol_needs_visit_id: 'Для протокола визита нужен канонический visit_id. Откройте пациента из вкладки «Записи».',
+    protocol_not_found: 'Не удалось открыть протокол визита: данные не найдены.',
+    treatment_plan_needs_visit_id: 'План лечения требует канонический visit_id. Откройте пациента из вкладки «Записи».',
+    templates_future: 'Шаблоны будут реализованы в следующей версии',
+    icd_added_from_ai: 'Код МКБ-10 добавлен из AI предложения',
+    session_extending: 'Продлеваем сессию...',
+  },
 };
 
 /**

--- a/frontend/src/pages/DentistPanelUnified.jsx
+++ b/frontend/src/pages/DentistPanelUnified.jsx
@@ -43,6 +43,8 @@ import { getApiBaseUrl } from '../api/runtime';
 import { resolveCanonicalVisitId } from '../utils/canonicalVisit';
 import { printPanelTicket } from '../services/panelPrint';
 import notify from '../services/notify';
+// STRAT#34: useTranslation adapter for confirm/notify i18n.
+import { useTranslation } from '../i18n/adapter';
 import { useConfirm } from '../components/common/ConfirmDialog';
 import { useSessionTimeoutWarning } from '../hooks/useSessionTimeoutWarning';
 import { useDentalHotkeys } from '../hooks/useDentalHotkeys';
@@ -405,6 +407,8 @@ const DentistPanelUnified = () => {
 
   // C-1 (UX audit): confirm hook for visit completion
   const [confirm, confirmDialog] = useConfirm();
+  // STRAT#34: useTranslation adapter for confirm/notify i18n.
+  const { t: tI18n } = useTranslation();
   // C-2 (UX audit): session timeout warning
   const [sessionWarning, setSessionWarning] = useState(null);
 
@@ -412,7 +416,7 @@ const DentistPanelUnified = () => {
     onWarning: () => setSessionWarning({ active: true }),
     onExpired: () => {
       setSessionWarning(null);
-      notify.error('Сессия истекла. Пожалуйста, войдите снова.');
+      notify.error(tI18n('dental.session_expired'));
       if (typeof window !== 'undefined') {
         window.location.href = '/login';
       }
@@ -681,7 +685,7 @@ const DentistPanelUnified = () => {
           const queueEntryId = resolveDoctorQueueEntryId(row);
           if (queueEntryId === null) {
             logger.warn('[Dentist] Cannot start visit without OnlineQueueEntry id', row);
-            notify.error('Cannot start visit without a queue entry id');
+            notify.error(tI18n('dental.no_queue_id_for_visit'));
             break;
           }
           const token = tokenManager.getAccessToken();
@@ -976,7 +980,7 @@ const DentistPanelUnified = () => {
       return;
     }
 
-    notify.info('У пациента нет активного визита. Откройте вкладку «Пациенты» для поиска.');
+    notify.info(tI18n('dental.no_active_visit'));
     handleTabChange('patients');
   };
 
@@ -1060,14 +1064,14 @@ const DentistPanelUnified = () => {
 
   const handleCompleteVisit = async () => {
     if (!selectedPatient) {
-      notify.error('Не выбран пациент для завершения приёма');
+      notify.error(tI18n('dental.no_patient_for_complete'));
       return;
     }
 
     const queueEntryId = resolveDoctorQueueEntryId(selectedPatient);
     if (queueEntryId === null) {
       logger.error('[Dentistry] handleCompleteVisit: нет queueEntryId', { selectedPatient });
-      notify.error('Невозможно завершить приём без ID записи в очереди');
+      notify.error(tI18n('dental.no_queue_id_for_complete'));
       return;
     }
 
@@ -1139,7 +1143,7 @@ const DentistPanelUnified = () => {
       logger.info('[Dentistry] handleCompleteVisit: payload', visitPayload);
       await queueService.completeVisit(queueEntryId, visitPayload);
       logger.info('[Dentistry] handleCompleteVisit: completeVisit OK');
-      notify.success('Приём завершён успешно');
+      notify.success(tI18n('dental.visit_completed'));
 
       // Сброс состояния
       setSelectedPatient(null);
@@ -1219,7 +1223,7 @@ const DentistPanelUnified = () => {
   const handleVisitProtocol = async (patient) => {
     const visitId = patient?.visit_id || await ensureCanonicalVisitId(patient);
     if (!visitId) {
-      notify.error('Для протокола визита нужен канонический visit_id. Откройте пациента из вкладки "Записи".');
+      notify.error(tI18n('dental.protocol_needs_visit_id'));
       return;
     }
 
@@ -1382,7 +1386,7 @@ const DentistPanelUnified = () => {
     const backendProtocol = await loadDentistVisitProtocolByVisitId(protocolRecord?.visit_id, protocolRecord);
 
     if (!backendProtocol && !protocolRecord?.visitData) {
-      notify.error('Не удалось открыть протокол визита: данные не найдены.');
+      notify.error(tI18n('dental.protocol_not_found'));
       return;
     }
 
@@ -1413,7 +1417,7 @@ const DentistPanelUnified = () => {
   const handleTreatmentPlanner = async (patient) => {
     const visitId = patient?.visit_id || await ensureCanonicalVisitId(patient);
     if (!visitId) {
-      notify.error('План лечения требует канонический visit_id. Откройте пациента из вкладки "Записи".');
+      notify.error(tI18n('dental.treatment_plan_needs_visit_id'));
       return;
     }
 
@@ -1767,7 +1771,7 @@ const DentistPanelUnified = () => {
     <DentalTemplatesTab
       onManageTemplates={handleProtocolTemplates}
       templates={[]}
-      onApplyTemplate={() => notify.info('Шаблоны будут реализованы в следующей версии')}
+      onApplyTemplate={() => notify.info(tI18n('dental.templates_future'))}
     />;
   const renderReports = () =>
     <DentalReportsTab
@@ -1831,7 +1835,7 @@ const DentistPanelUnified = () => {
         onSuggestionSelect={(type, suggestion) => {
           logger.info('[Dentistry] AI suggestion:', { type, suggestion });
           if (type === 'icd10') {
-            notify.success('Код МКБ-10 добавлен из AI предложения');
+            notify.success(tI18n('dental.icd_added_from_ai'));
           }
         }} />
 
@@ -2309,7 +2313,7 @@ const DentistPanelUnified = () => {
         <SessionWarningModal
           visible={!!sessionWarning}
           onDismiss={() => setSessionWarning(null)}
-          onExtend={() => notify.info('Продлеваем сессию...')}
+          onExtend={() => notify.info(tI18n('dental.session_extending'))}
         />
       )}
     </div>);

--- a/frontend/src/pages/__tests__/DentistPanel.i18n.contract.test.jsx
+++ b/frontend/src/pages/__tests__/DentistPanel.i18n.contract.test.jsx
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../..');
+const source = fs.readFileSync(path.join(ROOT, 'pages/DentistPanelUnified.jsx'), 'utf8');
+const translationsSource = fs.readFileSync(path.join(ROOT, 'components/laboratory/utils/labTranslations.js'), 'utf8');
+
+describe('DentistPanel STRAT#34 — i18n migration', () => {
+  it('imports useTranslation from i18n adapter', () => {
+    expect(source).toContain("from '../i18n/adapter'");
+    expect(source).toContain('useTranslation');
+  });
+  it('uses tI18n() for notify messages', () => {
+    expect(source).toContain("tI18n('dental.session_expired')");
+    expect(source).toContain("tI18n('dental.visit_completed')");
+    expect(source).toContain("tI18n('dental.icd_added_from_ai')");
+  });
+  it('does not contain hardcoded Russian notify strings', () => {
+    expect(source).not.toContain("notify.error('Сессия истекла");
+    expect(source).not.toContain("notify.success('Приём завершён успешно')");
+  });
+  it('labTranslations has dental.* namespace', () => {
+    expect(translationsSource).toContain('dental: {');
+    expect(translationsSource).toContain('visit_completed:');
+  });
+});


### PR DESCRIPTION
## Summary

- Migrate DentistPanelUnified's notify messages (12 calls) from hardcoded Russian strings to useTranslation() from the i18n adapter (STRAT#29).
- Added 12 new translation keys in dental.* namespace. No confirm dialogs in this panel.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat34-migrate-dentist-i18n` from `origin/main` at `8ef5b7cd`.
- Clean workspace: inspected before edits; only `DentistPanelUnified.jsx`, `labTranslations.js` (12 new keys), and new contract test changed.
- Branch: `refactor/strat34-migrate-dentist-i18n`
- Scope gate: allowed `frontend/src/pages/DentistPanelUnified.jsx`, `frontend/src/components/laboratory/utils/labTranslations.js`, `frontend/src/pages/__tests__/DentistPanel.i18n.contract.test.jsx`; denied backend, migrations, other frontend components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only string refactor. No API, websocket, event, or backend contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR migrates UI strings, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection.

## Frontend Resilience

- Empty data proof: when tI18n() key is missing, returns the key itself (debugging-friendly). Same behavior as labTranslations t() function.
- Partial data proof: each notify key is independent; missing one doesn't break the others.
- Forbidden secondary path behavior: not applicable - tI18n is a pure function with no secondary path.
- Missing draft/resource behavior: tI18n is stateless; no resource lifecycle.
- Stale route/deep-link behavior: not applicable; tI18n is stateless.

## Scope Gate

- Allowed paths: `frontend/src/pages/DentistPanelUnified.jsx`, `frontend/src/components/laboratory/utils/labTranslations.js`, `frontend/src/pages/__tests__/DentistPanel.i18n.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; 12 new translation keys in `dental.*` namespace; 1 new contract test file (4 tests)
- Rollback note: revert all three files; hardcoded Russian strings restored in notify calls

## Validation

- Targeted tests or smoke run: `npx vitest run src/pages/__tests__/DentistPanel.i18n.contract.test.jsx`
- Result: passed (4/4 tests, 763ms)
- Not checked: visual regression snapshot — notify text renders identical Russian text via dictionary lookup