### PR TITLE
refactor(payment): STRAT#39 — migrate payment/cashier components to t() (3 files)

### DIFF
--- a/frontend/src/components/cashier/RefundRequestsTable.jsx
+++ b/frontend/src/components/cashier/RefundRequestsTable.jsx
@@ -1,3 +1,4 @@
+import { t } from '../../i18n/adapter';
 /**
  * RefundRequestsTable - Table for managing refund requests
  *
@@ -137,7 +138,7 @@ const RefundRequestsTable = ({ onRefresh }) => {
       }
     } catch (err) {
       logger.error('[RefundRequestsTable] Process error:', err);
-      notify.error('Ошибка: ' + (err.message || 'Неизвестная ошибка'));
+      notify.error(t('payment.refund_error') + (err.message || t('payment.unknown_error')));
     } finally {
       setProcessingId(null);
     }
@@ -264,7 +265,7 @@ const RefundRequestsTable = ({ onRefresh }) => {
     },
     {
       key: 'patient_name',
-      title: 'Пациент',
+      title: t('payment.col_patient'),
       render: (_value, request) => (
         <span className="refund-inline-cluster">
           <User size={16} color="var(--mac-text-secondary)" aria-hidden="true" />
@@ -274,17 +275,17 @@ const RefundRequestsTable = ({ onRefresh }) => {
     },
     {
       key: 'amount',
-      title: 'Сумма',
+      title: t('payment.col_amount'),
       render: (amount) => <span className="refund-cell-amount">{formatAmount(amount)}</span>
     },
     {
       key: 'refund_type',
-      title: 'Тип',
+      title: t('payment.col_type'),
       render: (type) => getRefundTypeBadge(type)
     },
     {
       key: 'reason',
-      title: 'Причина',
+      title: t('payment.col_reason'),
       render: (reason) => (
         <span className="refund-cell-reason" title={reason}>
           {reason || '—'}
@@ -293,17 +294,17 @@ const RefundRequestsTable = ({ onRefresh }) => {
     },
     {
       key: 'status',
-      title: 'Статус',
+      title: t('payment.col_status'),
       render: (status) => getStatusBadge(status)
     },
     {
       key: 'created_at',
-      title: 'Дата',
+      title: t('payment.col_date'),
       render: (createdAt) => <span className="refund-cell-muted">{formatDate(createdAt)}</span>
     },
     {
       key: 'actions',
-      title: 'Действия',
+      title: t('payment.col_actions'),
       render: (_value, request) => renderActions(request)
     }
   ];

--- a/frontend/src/components/laboratory/utils/labTranslations.js
+++ b/frontend/src/components/laboratory/utils/labTranslations.js
@@ -674,6 +674,24 @@ const TRANSLATIONS = {
     treatment_plan_save_failed: 'Не удалось сохранить план лечения. Проверьте соединение и попробуйте снова.',
     visit_protocol_save_failed: 'Не удалось сохранить протокол визита. Проверьте соединение и попробуйте снова.',
   },
+  // ─── Payment (STRAT#39) ──────────────────────────────────────────────────
+  payment: {
+    timeout: 'Время ожидания истекло',
+    payment_success: 'Платёж успешно завершён!',
+    all_receipts_printed: 'Все талоны напечатаны!',
+    invalid_amount: 'Введите корректную сумму',
+    insufficient_amount: 'Полученная сумма меньше суммы к оплате',
+    refund_error: 'Ошибка: ',
+    unknown_error: 'Неизвестная ошибка',
+    // RefundRequestsTable headers
+    col_patient: 'Пациент',
+    col_amount: 'Сумма',
+    col_type: 'Тип',
+    col_reason: 'Причина',
+    col_status: 'Статус',
+    col_date: 'Дата',
+    col_actions: 'Действия',
+  },
 };
 
 /**

--- a/frontend/src/components/payment/CashPaymentModal.jsx
+++ b/frontend/src/components/payment/CashPaymentModal.jsx
@@ -1,3 +1,4 @@
+import { t } from '../../i18n/adapter';
 import { useState, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { CheckCircle, XCircle, Info } from 'lucide-react';
@@ -79,11 +80,11 @@ const CashPaymentModal = ({ appointment, onProcessPayment, onClose }) => {
     const handleSubmit = (e) => {
         e.preventDefault();
         if (!paymentData.amount || Number(paymentData.amount) <= 0) {
-            notify.warning('Введите корректную сумму');
+            notify.warning(t('payment.invalid_amount'));
             return;
         }
         if (insufficientCash) {
-            notify.warning('Полученная сумма меньше суммы к оплате');
+            notify.warning(t('payment.insufficient_amount'));
             return;
         }
         // Pass change due up to parent for receipt printing (HIGH #9 fix).

--- a/frontend/src/components/payment/PaymentProviderDialog.jsx
+++ b/frontend/src/components/payment/PaymentProviderDialog.jsx
@@ -1,3 +1,4 @@
+import { t } from '../../i18n/adapter';
 import { useState, useEffect, useRef } from 'react';
 import {
   CreditCard,
@@ -165,7 +166,7 @@ const PaymentProviderDialog = ({
         clearPolling();
         setPaymentState('failed');
         setError('Время ожидания оплаты истекло. Проверьте статус платежа вручную.');
-        notify.error('Время ожидания истекло');
+        notify.error(t('payment.timeout'));
       }
     }, pollingIntervalMs);
   };
@@ -184,7 +185,7 @@ const PaymentProviderDialog = ({
         const tickets = Array.isArray(data.print_tickets) ? data.print_tickets : [];
         setPrintTickets(tickets);
 
-        notify.success('Платёж успешно завершён!');
+        notify.success(t('payment.payment_success'));
 
         // Показываем принтер талонов если есть талоны для печати
         setShowTicketPrinter(tickets.length > 0);
@@ -551,7 +552,7 @@ const PaymentProviderDialog = ({
           onClose={() => setShowTicketPrinter(false)}
           onAllPrinted={() => {
             setShowTicketPrinter(false);
-            notify.success('Все талоны напечатаны!');
+            notify.success(t('payment.all_receipts_printed'));
           }} />
 
       </ModernDialog>

--- a/frontend/src/components/payment/__tests__/Payment.i18n.contract.test.jsx
+++ b/frontend/src/components/payment/__tests__/Payment.i18n.contract.test.jsx
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '../../..');
+const translationsSource = fs.readFileSync(path.join(ROOT, 'components/laboratory/utils/labTranslations.js'), 'utf8');
+
+describe('Payment components STRAT#39 — i18n migration', () => {
+  it('PaymentProviderDialog has no hardcoded Russian notify', () => {
+    const source = fs.readFileSync(path.join(ROOT, 'components/payment/PaymentProviderDialog.jsx'), 'utf8');
+    expect(source).not.toMatch(/notify\.\w+\('[А-Яа-я]/);
+  });
+  it('CashPaymentModal has no hardcoded Russian notify', () => {
+    const source = fs.readFileSync(path.join(ROOT, 'components/payment/CashPaymentModal.jsx'), 'utf8');
+    expect(source).not.toMatch(/notify\.\w+\('[А-Яа-я]/);
+  });
+  it('RefundRequestsTable has no hardcoded Russian strings', () => {
+    const source = fs.readFileSync(path.join(ROOT, 'components/cashier/RefundRequestsTable.jsx'), 'utf8');
+    expect(source).not.toMatch(/notify\.\w+\('[А-Яа-я]/);
+    expect(source).not.toMatch(/title: '[А-Яа-я]/);
+  });
+  it('labTranslations has payment.* namespace', () => {
+    expect(translationsSource).toContain('payment: {');
+    expect(translationsSource).toContain('timeout:');
+    expect(translationsSource).toContain('col_patient:');
+  });
+});


### PR DESCRIPTION
## Summary

- Migrate 3 payment/cashier component files (PaymentProviderDialog, CashPaymentModal, RefundRequestsTable) from hardcoded Russian strings to t() from the i18n adapter.
- Added 14 translation keys in payment.* namespace.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/strat39-migrate-payment-i18n` from `origin/main`.
- Clean workspace: 3 component files, `labTranslations.js` (14 new keys), and new contract test changed.
- Branch: `refactor/strat39-migrate-payment-i18n`
- Scope gate: allowed `frontend/src/components/payment/*.jsx`, `frontend/src/components/cashier/RefundRequestsTable.jsx`, `frontend/src/components/laboratory/utils/labTranslations.js`, `frontend/src/components/payment/__tests__/Payment.i18n.contract.test.jsx`; denied backend, migrations, other frontend components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only string refactor. No API, websocket, event, or backend contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR migrates UI strings, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection.

## Frontend Resilience

- Empty data proof: when t() key is missing, returns the key itself (debugging-friendly).
- Partial data proof: each key is independent.
- Forbidden secondary path behavior: not applicable - t is a pure function with no secondary path.
- Missing draft/resource behavior: t is stateless; no resource lifecycle.
- Stale route/deep-link behavior: not applicable; t is stateless.

## Scope Gate

- Allowed paths: `frontend/src/components/payment/*.jsx`, `frontend/src/components/cashier/RefundRequestsTable.jsx`, `frontend/src/components/laboratory/utils/labTranslations.js`, `frontend/src/components/payment/__tests__/Payment.i18n.contract.test.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: no migration; 14 new translation keys in `payment.*` namespace; 1 new contract test file (4 tests)
- Rollback note: revert all files; hardcoded Russian strings restored

## Validation

- Targeted tests or smoke run: `npx vitest run src/components/payment/__tests__/Payment.i18n.contract.test.jsx`
- Result: passed (4/4 tests, 1.24s)
- Not checked: visual regression snapshot