### PR TITLE
fix: MOD#2 — fix 6 pre-existing test failures (Landing + QueueJoin) — 864/864 green

### DIFF
--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -29,7 +29,7 @@ import { LANDING_COPY, buildGlassStyle } from './landingContent';
 import { BRAND } from '../config/brand';
 import './Landing.css';
 import PropTypes from 'prop-types';
-import { useTranslation } from '../i18n/adapter';
+import { useTranslation } from '../hooks/useTranslation';
 
 const FEATURE_VISUALS = [
   { icon: FileText, accent: 'var(--mac-accent-blue)' },

--- a/frontend/src/pages/QueueJoin.jsx
+++ b/frontend/src/pages/QueueJoin.jsx
@@ -60,6 +60,7 @@ const QUEUE_JOIN_MESSAGES = {
 };
 
 const QueueJoin = () => {
+  const { t } = useTranslation();
   const { token: paramToken } = useParams();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary

- Fix 6 pre-existing test failures: 3 in Landing.test.jsx, 3 in QueueJoin.accessibility.test.jsx.
- Landing.jsx: was importing useTranslation from i18n/adapter (react-i18next) which doesn't return `availableLanguages`/`setLanguage`. Changed to import from legacy `hooks/useTranslation` which provides the full translation context.
- QueueJoin.jsx: imported useTranslation but never called the hook — `t` was undefined at runtime. Added `const { t } = useTranslation()` call.

## Cyclic Execution Evidence

- Fresh main sync: branch `fix/mod2-landing-queuejoin-test-failures` from `origin/main`.
- Clean workspace: only `Landing.jsx` and `QueueJoin.jsx` changed.
- Branch: `fix/mod2-landing-queuejoin-test-failures`
- Scope gate: allowed `frontend/src/pages/Landing.jsx`, `frontend/src/pages/QueueJoin.jsx`; denied backend, migrations, other frontend components.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - frontend-only bug fix. No API, websocket, event, or backend contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR fixes test failures, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection.

## Frontend Resilience

- Empty data proof: useTranslation() from legacy hook returns default context when no provider is present — same as before.
- Partial data proof: Landing.jsx degrades gracefully when language data is missing (falls back to LANDING_COPY.ru).
- Forbidden secondary path behavior: not applicable - this PR fixes import path and adds a missing hook call, no alternative code path exists.
- Missing draft/resource behavior: not applicable - no resource lifecycle involved.
- Stale route/deep-link behavior: not applicable - no routing dependency in the fix.

## Scope Gate

- Allowed paths: `frontend/src/pages/Landing.jsx`, `frontend/src/pages/QueueJoin.jsx`
- Denied paths: backend runtime, other frontend components, migrations, generated output
- Migration/docs/test impact: 0 migration; 0 new tests; 6 pre-existing tests now pass
- Rollback note: revert both files to restore pre-existing failures

## Validation

- Targeted tests or smoke run: `npx vitest run` (full suite)
- Result: passed (864/864 tests across 148 files, 36s) — ZERO failures!
- Not checked: visual regression snapshot