### PR TITLE
chore: MOD#3 — remove unused notistack dependency (4th notification system, 0 imports)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,6 @@
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.8",
         "lucide-react": "0.577.0",
-        "notistack": "^3.0.2",
         "prop-types": "15.8.1",
         "qrcode.react": "4.2.0",
         "react": "18.3.1",
@@ -5074,15 +5073,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6862,15 +6852,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/goober": {
-      "version": "2.1.19",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
-      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -9487,28 +9468,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/notistack": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz",
-      "integrity": "sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^1.1.0",
-        "goober": "^2.0.33"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/notistack"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/nwsapi": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,6 @@
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.8",
     "lucide-react": "0.577.0",
-    "notistack": "^3.0.2",
     "prop-types": "15.8.1",
     "qrcode.react": "4.2.0",
     "react": "18.3.1",


### PR DESCRIPTION
## Summary

- Remove `notistack` — unused dependency (0 imports in codebase). Project has 3 notification systems: `react-toastify` (primary, 44 files), `services/notify` (wrapper around react-toastify, 49 files), and custom `Toast.jsx` (2 files: ChatWindow + ComponentTest). notistack was a 4th system with 0 usages.

## Cyclic Execution Evidence

- Fresh main sync: branch `refactor/mod3-unify-icons-notifications-react19` from `origin/main`.
- Clean workspace: only `package.json` and `package-lock.json` changed.
- Branch: `refactor/mod3-unify-icons-notifications-react19`
- Scope gate: allowed `frontend/package.json`, `frontend/package-lock.json`; denied backend, migrations, source code.
- Red-check handling: if targeted tests fail, fix in this same PR before merge.

## Contract Impact

not applicable - dependency removal only. No API, websocket, event, or backend contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- Event type or websocket channel: not applicable - this PR removes an unused npm package, no websocket events involved.
- Payload version / ack behavior: not applicable - no realtime payload.
- Read/unread or delivery semantics: not applicable - no read/unread tracking.
- Reconnect/resync proof: not applicable - no realtime connection.

## Frontend Resilience

- Empty data proof: not applicable - removing unused package has no runtime effect.
- Partial data proof: not applicable - no data involved.
- Forbidden secondary path behavior: not applicable - package removal does not create alternative code paths, notistack had zero imports.
- Missing draft/resource behavior: not applicable - no resource lifecycle.
- Stale route/deep-link behavior: not applicable - no routing dependency.

## Scope Gate

- Allowed paths: `frontend/package.json`, `frontend/package-lock.json`
- Denied paths: backend runtime, source code, migrations, generated output
- Migration/docs/test impact: 1 package removed; 0 code changes; 0 new tests
- Rollback note: `npm install notistack` to restore

## Validation

- Targeted tests or smoke run: `npx vite build` (passes), `npx vitest run` (864/864 pass)
- Result: build successful, all tests pass
- Not checked: bundle size reduction (expected ~30KB from notistack removal)