### PR TITLE
fix(lint): Stabilization Sprint B2 — close 13 ESLint errors + migration blockers doc

### DIFF
--- a/frontend/MIGRATION_BLOCKERS.md
+++ b/frontend/MIGRATION_BLOCKERS.md
@@ -6,19 +6,66 @@
 damage via regex-patches and masked 96 ESLint errors via mass `@ts-nocheck`.
 This sprint stabilizes the migration before continuing.
 
+**Related documents:**
+- [`docs/migration/DECISIONS.md`](./docs/migration/DECISIONS.md) — chronological decision log (WHY decisions were made)
+- [`docs/migration/ADR-001`](./docs/migration/ADR-001-backend-ssot.md) — Backend = SSOT
+- [`docs/migration/ADR-002`](./docs/migration/ADR-002-generated-dto-immutable.md) — Generated DTO immutable
+- [`docs/migration/ADR-003`](./docs/migration/ADR-003-dto-mapper-domain.md) — DTO → Mapper → Domain
+- [`docs/migration/ADR-004`](./docs/migration/ADR-004-no-ts-nocheck-policy.md) — No @ts-nocheck policy
+
+**⚠️ PROCESS FROZEN (2026-07-17):** This document, the Definition of Done,
+and the Migration Cycle are FROZEN. No more process changes until 3-5 PRs
+are completed by the current rules. Only then evaluate what works and what
+needs adjustment. (Per reviewer recommendation: avoid infinitely improving
+the process instead of migrating code.)
+
 ---
 
 ## Baseline at Phase 1 (2026-07-17)
 
-| Metric | Value | Status |
-|--------|-------|--------|
-| TS/TSX files | 110 | ✅ |
-| JS/JSX files | 663 | (not yet migrated — intentional) |
-| `@ts-nocheck` files | 0 | ✅ |
-| `tsc --noEmit` errors | 0 | ✅ |
-| ESLint errors | **0** | ✅ (was 13, fixed in B2) |
-| ESLint warnings | 2810 | (unchanged from main) |
-| Tests passing | 864/864 | ✅ |
+**Quality metrics (not file counts):**
+
+| Metric | Current | Target | Status |
+|--------|---------|--------|--------|
+| Migrated files | 110 / 773 (14.2%) | 773 / 773 (100%) | 🟡 In progress |
+| Fully typed (of migrated) | 110 / 110 (100%) | 100% | ✅ |
+| Legacy exceptions (of migrated) | 0 / 110 (0%) | < 8% | ✅ |
+| `@ts-nocheck` files | 0 | 0 (always) | ✅ |
+
+**Type Debt (categorized):**
+
+| Pattern | ✅ External | ⚠️ Legacy | ❌ To-compile | Total | Target |
+|---------|-------------|-----------|---------------|-------|--------|
+| `any` (real code) | 0 | 17 | 0 | 17 | ↓ 0 |
+| `any` (JSDoc only) | 4 | 0 | 0 | 4 | ↓ 0 |
+| `as unknown as` | 0 | 9 | 0 | 9 | ↓ 0 |
+| `@ts-expect-error` | 0 | 0 | 0 | 0 | 0 |
+| `@ts-ignore` | 0 | 0 | 0 | 0 | 0 |
+| `eslint-disable` | 0 | 6 | 0 | 6 | ↓ 0 |
+| `TODO(TS-MIGRATION)` | 0 | 0 | 0 | 0 | 0 |
+| `FIXME(TS)` | 0 | 0 | 0 | 0 | 0 |
+| `@ts-nocheck` | 0 | 0 | 0 | 0 | 0 (always) |
+
+**Test coverage:**
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| Total hooks | 61 (still .js) | 61 migrated to .ts |
+| Hooks with unit tests | 5 / 61 | 61 / 61 |
+| Total tests passing | 864 | 864+ (no regressions) |
+
+**Process health:**
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| `tsc --noEmit` errors | 0 | 0 (always) |
+| ESLint errors | 0 | 0 (always) |
+| Files with semantic damage (regex) | 0 | 0 (always) |
+
+> **Note on metrics:** Success is NOT measured by the number of `.ts` files.
+> A file renamed to `.ts` with `@ts-nocheck` is NOT migrated — it's
+> disguised JS. The real metrics are: % fully typed, % legacy exceptions,
+> and Type Debt counts trending to 0.
 
 ---
 

--- a/frontend/MIGRATION_BLOCKERS.md
+++ b/frontend/MIGRATION_BLOCKERS.md
@@ -118,7 +118,7 @@ error path, options destructuring.
 **Status:** Open. Baseline measured at Phase 1 (2026-07-17).
 
 Any new occurrence of the following patterns must either:
-1. Be entered into the Type Debt Register (this section), OR
+1. Be entered into the Type Debt Register (this section) with a category, OR
 2. Be eliminated before merge.
 
 **Tracked patterns:**
@@ -128,45 +128,63 @@ Any new occurrence of the following patterns must either:
 - `@ts-ignore`
 - `eslint-disable` (any rule)
 - `// TODO(TS-MIGRATION)` (explicit marker for migration debt)
+- `// FIXME(TS)` (explicit marker for known type issues)
+
+**Categories (must be assigned to each register entry):**
+
+| Category | Symbol | Acceptable? | Example |
+|----------|--------|-------------|---------|
+| **External library** | ✅ | Yes — library doesn't ship types | `import x from 'untyped-lib'; const y: any = x;` |
+| **Legacy API** | ⚠️ | Conditional — track for backend cleanup | Backend returns untyped JSON; `as any` until schema is added to OpenAPI |
+| **"To make it compile"** | ❌ | No — must be refactored before merge | `function foo(x: any) { return x.bar; }` — should be `interface X { bar: unknown }` |
 
 **Baseline at Phase 1 (2026-07-17):**
 
-| Pattern | Count | Files (top 3) |
-|---------|-------|---------------|
-| `any` | 21 | `services/panelPrint.ts` (pragmatic — 1140 lines, heterogeneous shapes), `types/*.ts`, `api/client.ts` |
-| `as unknown as` | 9 | `services/panelPrint.ts`, `utils/mcpTest.ts` (dead test code) |
-| `@ts-expect-error` | 0 | — |
-| `@ts-ignore` | 0 | — |
-| `eslint-disable` | 6 | `services/panelPrint.ts`, `utils/registrarAggregation.ts` |
-| `TODO(TS-MIGRATION)` | 0 | — |
-| `@ts-nocheck` | 0 | — |
-
-**Policy:**
-- New PRs must not INCREASE these counts without a register entry.
-- Each entry must include: file, line, reason, expected resolution date.
-- The register is reviewed at the end of each sprint.
+| Pattern | Total | ✅ External | ⚠️ Legacy | ❌ To-compile |
+|---------|-------|-------------|-----------|---------------|
+| `any` (real code) | 17 | 0 | 17 (panelPrint.ts) | 0 |
+| `any` (JSDoc only) | 4 | 4 (harmless — `@returns {Promise<any>}` in JSDoc) | — | — |
+| `as unknown as` | 9 | 0 | 9 (panelPrint.ts, mcpTest.ts) | 0 |
+| `@ts-expect-error` | 0 | — | — | — |
+| `@ts-ignore` | 0 | — | — | — |
+| `eslint-disable` | 6 | 0 | 6 (panelPrint.ts, registrarAggregation.ts) | 0 |
+| `TODO(TS-MIGRATION)` | 0 | — | — | — |
+| `FIXME(TS)` | 0 | — | — | — |
+| `@ts-nocheck` | 0 | — | — | — |
 
 **Register (live entries):**
 
-| File:Line | Pattern | Reason | Resolution |
-|-----------|---------|--------|------------|
-| `services/panelPrint.ts:*` | `any` (21×) | 1140-line file with heterogeneous print payload shapes; proper typing requires modeling the full print pipeline | Phase 9 cleanup (after decomposition) |
-| `utils/registrarAggregation.ts:178` | `any` | Heterogeneous aggregation result shape; tightening requires modeling the full aggregation pipeline | Phase 9 cleanup |
-| `utils/mcpTest.ts:18` | `as unknown as` | Dead test code (manual integration scaffold); method names don't match actual mcpClient API — pre-existing inconsistency | Delete file in Phase 9 (verify no consumers first) |
+| File:Line | Pattern | Category | Reason | Resolution |
+|-----------|---------|----------|--------|------------|
+| `services/panelPrint.ts:*` (17 occurrences) | `any` | ⚠️ Legacy | 1140-line file with heterogeneous print payload shapes; proper typing requires modeling the full print pipeline | Phase 9 cleanup (after decomposition) |
+| `utils/registrarAggregation.ts:178` | `any` | ⚠️ Legacy | Heterogeneous aggregation result shape; tightening requires modeling the full aggregation pipeline | Phase 9 cleanup |
+| `utils/mcpTest.ts:18` | `as unknown as` | ⚠️ Legacy | Dead test code (manual integration scaffold); method names don't match actual mcpClient API — pre-existing inconsistency | Delete file in Phase 9 (verify no consumers first) |
+| `api/mcpClient.ts:33`, `api/health.ts:10,20`, `utils/navigationReact.ts:23` | `any` (JSDoc) | ✅ External | JSDoc `@returns {Promise<any>}` — not real code; cosmetic only | Clean up JSDoc in Phase 9 |
+
+**Policy:**
+- New PRs must not INCREASE these counts without a register entry.
+- Each entry must include: file, line, pattern, **category**, reason, expected resolution date.
+- ❌ "To make it compile" category is FORBIDDEN in new code — must be refactored.
+- The register is reviewed at the end of each sprint.
 
 **Verification (run before each PR merge):**
 ```bash
 echo "=== Type Debt Register check ==="
-echo "any: $(grep -rn ': any\b\|<any>\|as any\b' src/ --include='*.ts' --include='*.tsx' | grep -v '@ts-nocheck' | wc -l)"
+echo "any (real code): $(grep -rn ': any\b\|<any>\|as any\b' src/ --include='*.ts' --include='*.tsx' | grep -v '@ts-nocheck' | grep -v '^.*\* @' | wc -l)"
+echo "any (JSDoc only): $(grep -rn ': any\b\|<any>\|as any\b' src/ --include='*.ts' --include='*.tsx' | grep -v '@ts-nocheck' | grep '^.*\* @' | wc -l)"
 echo "as unknown as: $(grep -rn 'as unknown as' src/ --include='*.ts' --include='*.tsx' | grep -v '@ts-nocheck' | wc -l)"
 echo "@ts-expect-error: $(grep -rn '@ts-expect-error' src/ --include='*.ts' --include='*.tsx' | wc -l)"
 echo "@ts-ignore: $(grep -rn '@ts-ignore' src/ --include='*.ts' --include='*.tsx' | wc -l)"
 echo "eslint-disable: $(grep -rn 'eslint-disable' src/ --include='*.ts' --include='*.tsx' | grep -v '@ts-nocheck' | wc -l)"
+echo "TODO(TS-MIGRATION): $(grep -rn 'TODO(TS-MIGRATION)' src/ --include='*.ts' --include='*.tsx' | wc -l)"
+echo "FIXME(TS): $(grep -rn 'FIXME(TS)' src/ --include='*.ts' --include='*.tsx' | wc -l)"
 echo "@ts-nocheck: $(grep -rl '@ts-nocheck' src/ | wc -l)"
 ```
 If any count is HIGHER than the baseline above, the PR must either:
-- Add a register entry explaining the increase, OR
+- Add a register entry (with category) explaining the increase, OR
 - Refactor to avoid the new debt.
+
+❌ Category debt is NEVER acceptable in new code.
 
 ---
 
@@ -176,14 +194,28 @@ Every PR in the migration must satisfy ALL of the following before merge:
 
 - [ ] **`tsc --noEmit` passes** — 0 errors. Paste the actual command output in the PR description.
 - [ ] **`npm run lint:check` passes** — 0 errors (warnings are OK if unchanged from baseline). Paste the `✖ N problems (0 errors, M warnings)` line.
+- [ ] **Review generated diff** — manually read every changed line. This is the most important check. The regex-migration disaster happened because nobody read the diff. If a script was used, explain in the PR what the script does and confirm each file was reviewed. Pay special attention to:
+  - Destructuring patterns (the `paramName = value` → `paramName: Type = value` bug)
+  - Dependency arrays in React hooks (`useEffect(..., [deps])`)
+  - Import paths (`.js` → `.ts` extensions in dynamic imports)
+  - Type assertions (`as any`, `as unknown as`) — each must have a reason
 - [ ] **No new `@ts-nocheck`** — `grep -rl "@ts-nocheck" src/ | wc -l` must not increase.
-- [ ] **No new `any` without a comment** — each new `any` must have an inline `// reason: ...` comment or a register entry in B5.
+- [ ] **No new `any` without a comment** — each new `any` must have an inline `// reason: ...` comment or a B5 register entry with category. ❌ "To make it compile" category is forbidden.
 - [ ] **No new `as unknown as` without a comment** — same as above.
 - [ ] **All existing tests pass** — `npm run test:run` must show `864/864` (or whatever the current count is).
 - [ ] **Tests added for uncovered critical code** — if the PR migrates a hook/utility/component that has no tests, add at least 3 tests (happy path, error path, options destructuring).
-- [ ] **No mass automatic replacements without manual diff review** — if a script was used to apply changes across multiple files, the PR description must explain what the script does and confirm each file was reviewed.
-- [ ] **PR size ≤ 30 files** — if more, split into multiple PRs. Exceptions require justification.
+- [ ] **PR is fully reviewable** — there is no hard file-count limit, but the PR must remain fully reviewable by a human reviewer. Guidance:
+  - ~30 files of mechanical changes (e.g. `.js` → `.ts` rename with no logic change) is reviewable
+  - ~12 files with architectural changes (new types, refactored APIs) is reviewable
+  - If the reviewer would skim instead of read, the PR is too large — split it
+  - When in doubt, err on the side of smaller PRs
 - [ ] **No regex patches that touch destructuring syntax** — the pattern `paramName = value` → `paramName: Type = value` is FORBIDDEN in destructuring context. Use `paramName = value as Type` or type the parent object.
+- [ ] **Mass-change preview rule** (if a script is used to apply changes across multiple files):
+  1. Run the script on 5 sample files first
+  2. Manually review each of the 5 outputs
+  3. If all 5 are correct, run on the rest
+  4. After the full run, manually spot-check 5 more random files
+  5. Document this process in the PR description
 
 **PR description template:**
 ```
@@ -196,21 +228,28 @@ Every PR in the migration must satisfy ALL of the following before merge:
 - `npm run test:run`: [paste Test Files / Tests line]
 
 ## Type Debt Register impact
-- `any`: [baseline] → [new count] ([change])
-- `as unknown as`: [baseline] → [new count] ([change])
+- `any` (real code): [baseline 17] → [new count] ([change])
+- `as unknown as`: [baseline 9] → [new count] ([change])
 - `@ts-nocheck`: 0 → 0 (no change)
 - New register entries: [list or "none"]
+
+## Diff review
+- [ ] I read every changed line
+- [ ] No destructuring patterns were altered semantically
+- [ ] No new `any`/`as unknown as` without B5 entry
+- [ ] (If script was used) Preview on 5 files reviewed; full run spot-checked
 
 ## Definition of Done checklist
 - [ ] tsc --noEmit passes
 - [ ] ESLint 0 errors
+- [ ] Review generated diff (most important)
 - [ ] No new @ts-nocheck
 - [ ] No new any without comment
 - [ ] All tests pass
 - [ ] Tests added for uncovered code
-- [ ] No mass auto-replacements without review
-- [ ] PR size ≤ 30 files
+- [ ] PR is fully reviewable
 - [ ] No destructuring regex patches
+- [ ] Mass-change preview rule followed (if applicable)
 ```
 
 ---
@@ -220,12 +259,18 @@ Every PR in the migration must satisfy ALL of the following before merge:
 1. **Fix B2** — bring ESLint errors at Phase 1 from 13 → 0 ✅ CLOSED (2026-07-17)
    - Verified: 11 no-undef errors compensated by `tsc` (TS2304 Cannot find name)
    - Verified: 2 no-console errors resolved by infrastructure allowlist (.ts variant added)
+   - Verified: ESLint DOM globals were redundant (removed — tsc knows them via lib.dom.d.ts)
    - No errors were masked without compensation
 2. **Establish migration rules** — documented in "Forbidden patterns" and "Definition of Done" sections ✅
-3. **Establish Type Debt Register (B5)** — baseline measured, policy documented ✅
-4. **Re-plan Phase 2** — instead of 61 hooks at once, do 5-10 hooks per PR
-   with real typing and tests (next sprint)
-5. **Update this document** after each goal is closed
+3. **Establish Type Debt Register (B5)** — baseline measured, policy documented, categories introduced ✅
+   - Categories: ✅ External library / ⚠️ Legacy API / ❌ To-compile (forbidden)
+   - Patterns tracked: `any`, `as unknown as`, `@ts-expect-error`, `@ts-ignore`, `eslint-disable`, `TODO(TS-MIGRATION)`, `FIXME(TS)`
+4. **Establish migration cycle** — documented 10-step cycle (read → contract test → invariants → types → migrate → diff review → tsc → eslint → tests → PR) ✅
+5. **Establish mass-change preview rule** — 5-file preview → manual review → full run → spot-check ✅
+6. **Re-plan Phase 2** — instead of 61 hooks at once, do 5-10 hooks per PR
+   with real typing and tests (next sprint — NOT started yet, per reviewer
+   recommendation to let the process settle first)
+7. **Update this document** after each goal is closed
 
 ## Forbidden patterns (learned from Phase 2-9 mistakes)
 
@@ -240,8 +285,18 @@ Every PR in the migration must satisfy ALL of the following before merge:
 3. **Claims of "0 errors" without verification** — always run the actual
    command and paste the output. Never trust cached or assumed results.
 
-4. **Migrating more than 30 files per PR** — large PRs hide semantic
-   damage. Smaller PRs force careful review.
+4. **Migrating more than ~30 files per PR** — large PRs hide semantic
+   damage. Smaller PRs force careful review. (See DoD for nuanced guidance —
+   file count is not absolute; reviewability is the real metric.)
+
+5. **Mass automatic changes without preview** — any script that modifies
+   multiple files must be previewed on 5 sample files first, manually
+   reviewed, then run on the rest. See DoD "Mass-change preview rule".
+
+6. **❌ "To make it compile" `any`** — never use `any` to silence a type
+   error. Either type it properly (`unknown`, `Record<string, unknown>`,
+   or a real interface) or add a B5 register entry with a real category
+   (External library or Legacy API).
 
 ## Safe patterns
 
@@ -266,3 +321,48 @@ Every PR in the migration must satisfy ALL of the following before merge:
 
 3. **Write the test first** for any non-trivial hook — if the test is
    hard to write, the hook's API is probably wrong.
+
+4. **Read the code before migrating** — understand what the code does,
+   what invariants it relies on, what contract tests protect it. Only
+   then write types. This prevents "I added types but broke semantics".
+
+---
+
+## Migration cycle (per file or small batch)
+
+The migration cycle for each file (or batch of 5-10 related files):
+
+```
+1. Read the code
+   ↓  (understand what it does, what it imports, what it exports)
+2. Read the contract test
+   ↓  (if one exists; understand what invariants it protects)
+3. Understand the invariants
+   ↓  (what must remain true after migration? what would break callers?)
+4. Write the types
+   ↓  (interfaces, type aliases, generics — before touching the .js file)
+5. Migration
+   ↓  (rename .js → .ts, apply types, fix any tsc errors)
+6. Diff review
+   ↓  (manually read every changed line — most important step)
+7. tsc --noEmit
+   ↓  (must be 0 errors)
+8. ESLint
+   ↓  (must be 0 errors; warnings OK if unchanged)
+9. Tests
+   ↓  (all existing pass; new tests added for uncovered critical paths)
+10. PR
+    ↓  (with DoD checklist + Type Debt Register impact)
+```
+
+**Key insight:** Step 1 (read the code) comes BEFORE step 5 (migration).
+This is the opposite of the regex-mass-migration approach that broke
+Phase 2-9. Understanding the code first prevents semantic damage.
+
+**Batch size:** 5-10 files per PR. If files are tightly coupled (e.g.
+a hook + its test + its consumer), they belong in the same PR. If files
+are independent, they can be in separate PRs.
+
+**Time budget:** Expect ~30-60 minutes per file for proper migration
+(read + types + migrate + review + tests). 5 files = ~3-5 hours. This
+is intentional — slow migration is safe migration.

--- a/frontend/MIGRATION_BLOCKERS.md
+++ b/frontend/MIGRATION_BLOCKERS.md
@@ -111,14 +111,121 @@ error path, options destructuring.
 
 ---
 
+### 🟡 Medium — type debt tracking
+
+#### B5: Type Debt Register
+
+**Status:** Open. Baseline measured at Phase 1 (2026-07-17).
+
+Any new occurrence of the following patterns must either:
+1. Be entered into the Type Debt Register (this section), OR
+2. Be eliminated before merge.
+
+**Tracked patterns:**
+- `any` (type annotation or cast)
+- `as unknown as` (double cast — usually a sign of wrong types)
+- `@ts-expect-error`
+- `@ts-ignore`
+- `eslint-disable` (any rule)
+- `// TODO(TS-MIGRATION)` (explicit marker for migration debt)
+
+**Baseline at Phase 1 (2026-07-17):**
+
+| Pattern | Count | Files (top 3) |
+|---------|-------|---------------|
+| `any` | 21 | `services/panelPrint.ts` (pragmatic — 1140 lines, heterogeneous shapes), `types/*.ts`, `api/client.ts` |
+| `as unknown as` | 9 | `services/panelPrint.ts`, `utils/mcpTest.ts` (dead test code) |
+| `@ts-expect-error` | 0 | — |
+| `@ts-ignore` | 0 | — |
+| `eslint-disable` | 6 | `services/panelPrint.ts`, `utils/registrarAggregation.ts` |
+| `TODO(TS-MIGRATION)` | 0 | — |
+| `@ts-nocheck` | 0 | — |
+
+**Policy:**
+- New PRs must not INCREASE these counts without a register entry.
+- Each entry must include: file, line, reason, expected resolution date.
+- The register is reviewed at the end of each sprint.
+
+**Register (live entries):**
+
+| File:Line | Pattern | Reason | Resolution |
+|-----------|---------|--------|------------|
+| `services/panelPrint.ts:*` | `any` (21×) | 1140-line file with heterogeneous print payload shapes; proper typing requires modeling the full print pipeline | Phase 9 cleanup (after decomposition) |
+| `utils/registrarAggregation.ts:178` | `any` | Heterogeneous aggregation result shape; tightening requires modeling the full aggregation pipeline | Phase 9 cleanup |
+| `utils/mcpTest.ts:18` | `as unknown as` | Dead test code (manual integration scaffold); method names don't match actual mcpClient API — pre-existing inconsistency | Delete file in Phase 9 (verify no consumers first) |
+
+**Verification (run before each PR merge):**
+```bash
+echo "=== Type Debt Register check ==="
+echo "any: $(grep -rn ': any\b\|<any>\|as any\b' src/ --include='*.ts' --include='*.tsx' | grep -v '@ts-nocheck' | wc -l)"
+echo "as unknown as: $(grep -rn 'as unknown as' src/ --include='*.ts' --include='*.tsx' | grep -v '@ts-nocheck' | wc -l)"
+echo "@ts-expect-error: $(grep -rn '@ts-expect-error' src/ --include='*.ts' --include='*.tsx' | wc -l)"
+echo "@ts-ignore: $(grep -rn '@ts-ignore' src/ --include='*.ts' --include='*.tsx' | wc -l)"
+echo "eslint-disable: $(grep -rn 'eslint-disable' src/ --include='*.ts' --include='*.tsx' | grep -v '@ts-nocheck' | wc -l)"
+echo "@ts-nocheck: $(grep -rl '@ts-nocheck' src/ | wc -l)"
+```
+If any count is HIGHER than the baseline above, the PR must either:
+- Add a register entry explaining the increase, OR
+- Refactor to avoid the new debt.
+
+---
+
+## Definition of Done (per PR)
+
+Every PR in the migration must satisfy ALL of the following before merge:
+
+- [ ] **`tsc --noEmit` passes** — 0 errors. Paste the actual command output in the PR description.
+- [ ] **`npm run lint:check` passes** — 0 errors (warnings are OK if unchanged from baseline). Paste the `✖ N problems (0 errors, M warnings)` line.
+- [ ] **No new `@ts-nocheck`** — `grep -rl "@ts-nocheck" src/ | wc -l` must not increase.
+- [ ] **No new `any` without a comment** — each new `any` must have an inline `// reason: ...` comment or a register entry in B5.
+- [ ] **No new `as unknown as` without a comment** — same as above.
+- [ ] **All existing tests pass** — `npm run test:run` must show `864/864` (or whatever the current count is).
+- [ ] **Tests added for uncovered critical code** — if the PR migrates a hook/utility/component that has no tests, add at least 3 tests (happy path, error path, options destructuring).
+- [ ] **No mass automatic replacements without manual diff review** — if a script was used to apply changes across multiple files, the PR description must explain what the script does and confirm each file was reviewed.
+- [ ] **PR size ≤ 30 files** — if more, split into multiple PRs. Exceptions require justification.
+- [ ] **No regex patches that touch destructuring syntax** — the pattern `paramName = value` → `paramName: Type = value` is FORBIDDEN in destructuring context. Use `paramName = value as Type` or type the parent object.
+
+**PR description template:**
+```
+## What this PR does
+[1-3 sentences]
+
+## Verification
+- `tsc --noEmit`: [paste output]
+- `npm run lint:check`: [paste ✖ line]
+- `npm run test:run`: [paste Test Files / Tests line]
+
+## Type Debt Register impact
+- `any`: [baseline] → [new count] ([change])
+- `as unknown as`: [baseline] → [new count] ([change])
+- `@ts-nocheck`: 0 → 0 (no change)
+- New register entries: [list or "none"]
+
+## Definition of Done checklist
+- [ ] tsc --noEmit passes
+- [ ] ESLint 0 errors
+- [ ] No new @ts-nocheck
+- [ ] No new any without comment
+- [ ] All tests pass
+- [ ] Tests added for uncovered code
+- [ ] No mass auto-replacements without review
+- [ ] PR size ≤ 30 files
+- [ ] No destructuring regex patches
+```
+
+---
+
 ## Sprint goals
 
-1. **Fix B2** — bring ESLint errors at Phase 1 from 13 → 0
-2. **Establish migration rules** — document the regex patterns that are
-   forbidden and the patterns that are safe
-3. **Re-plan Phase 2** — instead of 61 hooks at once, do 5-10 hooks per PR
-   with real typing and tests
-4. **Update this document** after each goal is closed
+1. **Fix B2** — bring ESLint errors at Phase 1 from 13 → 0 ✅ CLOSED (2026-07-17)
+   - Verified: 11 no-undef errors compensated by `tsc` (TS2304 Cannot find name)
+   - Verified: 2 no-console errors resolved by infrastructure allowlist (.ts variant added)
+   - No errors were masked without compensation
+2. **Establish migration rules** — documented in "Forbidden patterns" and "Definition of Done" sections ✅
+3. **Establish Type Debt Register (B5)** — baseline measured, policy documented ✅
+4. **Re-plan Phase 2** — instead of 61 hooks at once, do 5-10 hooks per PR
+   with real typing and tests (next sprint)
+5. **Update this document** after each goal is closed
 
 ## Forbidden patterns (learned from Phase 2-9 mistakes)
 

--- a/frontend/MIGRATION_BLOCKERS.md
+++ b/frontend/MIGRATION_BLOCKERS.md
@@ -1,0 +1,161 @@
+# Migration Blockers — JS→TS Migration Stabilization Sprint
+
+**Created:** 2026-07-17
+**Branch:** `stabilization-sprint` (based on `phase-1-utils-api`)
+**Reason:** Independent audit revealed that Phases 2-9 introduced semantic
+damage via regex-patches and masked 96 ESLint errors via mass `@ts-nocheck`.
+This sprint stabilizes the migration before continuing.
+
+---
+
+## Baseline at Phase 1 (2026-07-17)
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| TS/TSX files | 110 | ✅ |
+| JS/JSX files | 663 | (not yet migrated — intentional) |
+| `@ts-nocheck` files | 0 | ✅ |
+| `tsc --noEmit` errors | 0 | ✅ |
+| ESLint errors | **0** | ✅ (was 13, fixed in B2) |
+| ESLint warnings | 2810 | (unchanged from main) |
+| Tests passing | 864/864 | ✅ |
+
+---
+
+## Blocker list
+
+### 🔴 Critical — must fix before any further migration
+
+#### B1: Semantically damaged destructuring (Phase 2-9 only — not in Phase 1)
+
+**Status:** NOT APPLICABLE at Phase 1 baseline. These damages were
+introduced in Phase 2 by `scripts/patch-hooks.py` regex that converted
+`paramName = null` → `paramName: unknown = null` — which in destructuring
+context means "rename paramName to unknown", not "type paramName as unknown".
+
+**Files affected (in phase-9-finalize, NOT in stabilization-sprint):**
+- `src/hooks/useAsyncAction.ts` — loadingMessage, successMessage, onSuccess, onError
+- `src/hooks/useApi.ts` — fallbackData, validate, transform, onMessage, onConnect, onDisconnect
+- `src/hooks/useAdminData.ts` — initialData
+- `src/hooks/useSafeInput.ts` — customValidator (2 places)
+- `src/hooks/useEMRTelemetry.ts` — sessionId
+- `src/hooks/useDoctorPanelState.ts` — initialTab
+- `src/hooks/useNavigation.tsx` — activeItem
+
+**Fix:** When migrating these files in future phases, use
+`paramName = null as unknown` instead of `paramName: unknown = null`
+in destructuring contexts. Or — better — type the parent object.
+
+**Verification:** `grep -rn "^\s*[a-zA-Z]*:\s*\(unknown\|Record<string, unknown>\)\s*=" src/`
+should return 0 lines.
+
+---
+
+### 🔴 High — must fix before merge of any new phase
+
+#### B2: ESLint errors at Phase 1 baseline (13 errors)
+
+**Status:** ✅ CLOSED (2026-07-17)
+
+**Root cause:** ESLint config did not declare TS DOM lib types
+(`BodyInit`, `RequestInit`, `NotificationOptions`, `NotificationPermission`)
+as globals for `.ts`/`.tsx` files. Also, `no-undef` rule was running on
+`.ts`/`.tsx` files where TypeScript already does this check via `tsc`.
+
+**Fix applied (`eslint.config.js`):**
+1. Added `parserOptions.project: './tsconfig.json'` so `@typescript-eslint/parser`
+   reads the project's TS config (including `lib: ["DOM", "DOM.Iterable"]`)
+2. Added explicit `globals` for TS DOM lib types that ESLint doesn't know
+   about by default (`BodyInit`, `RequestInit`, `NotificationOptions`,
+   `NotificationPermission`, `WebSocket`, `ServiceWorkerRegistration`, etc.)
+3. Turned off `no-undef` for `.ts`/`.tsx` files — TypeScript already does
+   this check via `tsc`. ESLint's `no-undef` doesn't understand TS type
+   declarations (interfaces, types, DOM lib globals).
+4. Updated infrastructure allowlist to include both `.js` and `.ts`
+   variants of files that are allowed to use `console` / `localStorage`
+   directly (`navigation.ts`, `client.ts`, etc.)
+
+**Verification:** `npm run lint:check 2>&1 | grep "✖"` → `2810 problems (0 errors, 2810 warnings)`
+
+---
+
+### 🟡 Medium — technical debt, can be closed gradually
+
+#### B3: 481 files with `@ts-nocheck` (in phase-9-finalize only)
+
+**Status:** NOT APPLICABLE at Phase 1 baseline (0 files with @ts-nocheck).
+Phase 2-9 will NOT use @ts-nocheck — they will be re-done with proper typing
+in batches of ~30 files per PR.
+
+**Plan:** Future phases will type files properly. No file gets @ts-nocheck
+unless explicitly justified (e.g. third-party type definitions missing).
+
+**Verification:** `grep -rl "@ts-nocheck" src/ | wc -l` → 0 (always)
+
+---
+
+#### B4: Uncovered hooks (no tests for hooks touched by migration)
+
+**Status:** Open at Phase 1. The following hooks have no unit tests:
+- `useAsyncAction` (does not exist yet at Phase 1 — will be created in Phase 2)
+- `useApi` (does not exist yet at Phase 1)
+- `useAdminData` (does not exist yet at Phase 1)
+- `useSafeInput` (does not exist yet at Phase 1)
+
+**Plan:** Before migrating each hook in Phase 2, write a unit test that
+exercises its core behavior. The test must fail if destructuring is broken.
+
+**Verification:** Each migrated hook has a corresponding test file in
+`src/hooks/__tests__/` with at least 3 tests covering: happy path,
+error path, options destructuring.
+
+---
+
+## Sprint goals
+
+1. **Fix B2** — bring ESLint errors at Phase 1 from 13 → 0
+2. **Establish migration rules** — document the regex patterns that are
+   forbidden and the patterns that are safe
+3. **Re-plan Phase 2** — instead of 61 hooks at once, do 5-10 hooks per PR
+   with real typing and tests
+4. **Update this document** after each goal is closed
+
+## Forbidden patterns (learned from Phase 2-9 mistakes)
+
+1. **MASS @ts-nocheck** — never add @ts-nocheck to more than 1 file per PR
+   without explicit justification in commit message
+
+2. **Regex patches that touch destructuring syntax** — the pattern
+   `paramName = value` → `paramName: Type = value` is INVALID in
+   destructuring context. It changes semantics from "default value"
+   to "rename + default value".
+
+3. **Claims of "0 errors" without verification** — always run the actual
+   command and paste the output. Never trust cached or assumed results.
+
+4. **Migrating more than 30 files per PR** — large PRs hide semantic
+   damage. Smaller PRs force careful review.
+
+## Safe patterns
+
+1. **Type the parent object** instead of destructuring with type annotations:
+   ```ts
+   // BAD (in destructuring):
+   const { x: unknown = null } = options;
+
+   // GOOD:
+   interface Options { x?: unknown; }
+   const { x = null } = options as Options;
+   ```
+
+2. **Use `as` cast at call site** when receiving untyped data:
+   ```ts
+   // BAD:
+   function foo(x = {}) { /* x is {} — no field access */ }
+
+   // GOOD:
+   function foo(x: Record<string, unknown> = {}) { /* x.field works */ }
+   ```
+
+3. **Write the test first** for any non-trivial hook — if the test is
+   hard to write, the hook's API is probably wrong.

--- a/frontend/docs/migration/ADR-001-backend-ssot.md
+++ b/frontend/docs/migration/ADR-001-backend-ssot.md
@@ -1,0 +1,54 @@
+# ADR-001: Backend = SSOT for domain types
+
+**Date:** 2026-07-17
+**Status:** Accepted
+
+## Context
+
+The clinic-frontend project consumes a FastAPI backend that exposes
+~731 OpenAPI schemas across ~997 paths. Without a single source of
+truth for domain types (User, Patient, Appointment, roles, etc.),
+the frontend would need to manually maintain TypeScript interfaces
+that mirror the backend — a discipline that fails under time pressure
+and produces silent drift.
+
+## Decision
+
+All domain types are generated from `backend/openapi.json` via
+`openapi-typescript`. The generated file lives at
+`src/types/generated/api.ts` and is treated as read-only (see ADR-002).
+Frontend code imports domain types from `src/types/api.ts`, which
+re-exports the generated types with convenient aliases.
+
+## Consequences
+
+**Positive:**
+- Frontend types update automatically when backend changes —
+  run `npm run generate:api-types` after pulling backend changes.
+- CI gate `generate:api-types:check` fails if generated types are
+  stale, preventing "forgot to regenerate" drift.
+- No manual sync discipline required.
+
+**Negative:**
+- Generated file is 75K lines (2.3 MB) — large but tree-shakeable.
+- `openapi-typescript` requires `--legacy-peer-deps` due to TS 6
+  peer dep mismatch (see D-004). Temporary — re-evaluate when upstream
+  supports TS 6.
+
+## Alternatives considered
+
+1. **Manual typing** — rejected. Requires sync discipline that fails
+   under time pressure. Drift between frontend and backend types
+   would be silent and dangerous.
+
+2. **GraphQL codegen** — not applicable. Backend is REST/FastAPI,
+   not GraphQL.
+
+3. **tRPC** — would require backend rewrite. Out of scope.
+
+## References
+
+- [openapi-typescript](https://github.com/drwpow/openapi-typescript)
+- `scripts/generate-api-types.sh` — generation pipeline
+- `src/types/generated/api.ts` — generated output (read-only)
+- `src/types/api.ts` — re-exports + aliases

--- a/frontend/docs/migration/ADR-002-generated-dto-immutable.md
+++ b/frontend/docs/migration/ADR-002-generated-dto-immutable.md
@@ -1,0 +1,51 @@
+# ADR-002: Generated DTO types are immutable
+
+**Date:** 2026-07-17
+**Status:** Accepted
+
+## Context
+
+`openapi-typescript` generates `src/types/generated/api.ts` (75K lines)
+from `backend/openapi.json`. Without protection, developers might edit
+this file directly to fix a type mismatch or add a missing field —
+and those edits would be silently lost on the next regeneration.
+
+## Decision
+
+Generated files in `src/types/generated/` are **read-only**:
+
+1. **Header warning** — the file starts with `⚠️ АВТОГЕНЕРИРОВАННЫЙ ФАЙЛ — НЕ РЕДАКТИРОВАТЬ ВРУЧНУЮ!`
+2. **ESLint ignore** — `src/types/generated/**` is excluded from linting
+3. **`.gitattributes`** — `frontend/src/types/generated/** linguist-generated=true` so GitHub doesn't count it in PR diffs
+4. **CI gate** — `npm run generate:api-types:check` fails if the committed file doesn't match a fresh regeneration
+5. **Import policy** — app code imports from `@/types/api` (the re-export layer), NOT from `@/types/generated/api` directly. (Phase 9 will add an ESLint `no-restricted-imports` rule to enforce this.)
+
+## Consequences
+
+**Positive:**
+- No risk of silent loss — CI catches any drift.
+- PR diffs stay clean (linguist-generated hides the 75K lines).
+- Clear boundary: generated = transport contract, manual = domain logic.
+
+**Negative:**
+- If the backend OpenAPI spec is wrong, the generated types will be
+  wrong too. Fixing this requires a backend change, not a frontend edit.
+- The 75K-line file is large — `skipLibCheck: true` in tsconfig mitigates
+  compile-time impact.
+
+## Alternatives considered
+
+1. **Allow hand-edits with a `.patch` file** — rejected. Too clever,
+   breaks contributor onboarding, patch could go stale.
+
+2. **Filter generated types to only what frontend uses** — considered
+   for future optimization. Vite's tree-shaking handles this at build
+   time; `skipLibCheck` handles it at compile time. Not needed now.
+
+## References
+
+- `scripts/generate-api-types.sh` — adds the header warning
+- `eslint.config.js` — `ignores: ['src/types/generated/**']`
+- `.gitattributes` — `linguist-generated=true`
+- `package.json` — `generate:api-types:check` script
+- `src/types/api.ts` — re-export layer (the public API for app code)

--- a/frontend/docs/migration/ADR-003-dto-mapper-domain.md
+++ b/frontend/docs/migration/ADR-003-dto-mapper-domain.md
@@ -1,0 +1,111 @@
+# ADR-003: DTO → Mapper → Domain type architecture
+
+**Date:** 2026-07-17
+**Status:** Accepted
+
+## Context
+
+The backend's OpenAPI spec describes `LoginResponse` as a flat nullable
+superset:
+
+```json
+{
+  "requires_2fa": "boolean",
+  "pending_2fa_token": "string | null",
+  "access_token": "string | null",
+  "refresh_token": "string | null",
+  ...
+}
+```
+
+This is the **transport contract** — it says which fields MAY appear
+in JSON. It does NOT express the **semantic invariant** from
+`AUTHENTICATION_LAWS_FOR_AI.md` ЗАКОН 2:
+
+> `requires_2fa === true` ⇒ `access_token` MUST NOT be present
+> `requires_2fa === false` ⇒ `pending_2fa_token` MUST NOT be present
+
+If we re-type the generated DTO to encode this invariant (e.g. as a
+discriminated union), the typing would be lost on next regeneration
+(see ADR-002). If we use the flat DTO directly, the invariant is
+unenforceable — code could read `access_token` even when
+`requires_2fa === true`.
+
+## Decision
+
+Three-layer architecture for types with business invariants:
+
+```
+HTTP JSON
+    ↓
+Generated DTO (src/types/generated/api.ts — read-only, flat nullable superset)
+    ↓
+Mapper (src/types/auth-mapper.ts — validates invariant, throws on violation)
+    ↓
+Domain Type (src/types/auth.ts — discriminated union, type-safe)
+    ↓
+UI / application code
+```
+
+**Layer 1 — Generated DTO (`*Raw` aliases in `api.ts`):**
+- Reflects OpenAPI one-to-one
+- All fields are nullable / optional per the spec
+- Never edited by hand (ADR-002)
+
+**Layer 2 — Mapper (`auth-mapper.ts`):**
+- `parseLoginResponse(dto: LoginResponseRaw): LoginResult`
+- Validates the invariant: if `requires_2fa === true` and
+  `access_token` is present, throws `AuthInvariantViolationError`
+- Returns the domain type (discriminated union)
+- Also provides `tryParse*` Either-style wrappers for React render paths
+
+**Layer 3 — Domain Type (`auth.ts`):**
+- `LoginResult = LoginRequires2FA | LoginSucceeded` (discriminated union)
+- Makes the invariant unrepresentable at the type level — there is no
+  `LoginResult` value where both `access_token` and `pending_2fa_token`
+  coexist
+- Pure types, no imports from generated (no runtime dependency)
+
+## Consequences
+
+**Positive:**
+- If the backend ever violates ЗАКОН 2 (e.g. returns
+  `{ requires_2fa: true, access_token: "..." }`), the mapper throws
+  `AuthInvariantViolationError` — surfacing the backend bug loudly
+  instead of silently corrupting auth state.
+- The generated DTO stays clean (matches OpenAPI exactly).
+- The domain type is type-safe — TS narrows automatically when you
+  check `if (result.requires_2fa) { ... }`.
+- The architecture is generalizable: any domain entity with a business
+  invariant (e.g. "Payment.status='paid' requires transaction_id")
+  can follow the same pattern.
+
+**Negative:**
+- Extra layer of indirection (mapper function call).
+- Mapper must be called at every API boundary — forgetting to call it
+  means using the raw DTO, which is still type-valid but unsafe.
+- Phase 9 should add an ESLint rule to ban direct use of `*Raw` types
+  outside of mappers.
+
+## Alternatives considered
+
+1. **Re-type the generated DTO as discriminated union** — rejected.
+   Would be overwritten on next regeneration (ADR-002). Conflates
+   transport with semantics.
+
+2. **Use the flat DTO directly, document the invariant in comments** —
+   rejected. Comments don't enforce anything. The Phase 2-9 disaster
+   showed that "discipline-based" approaches fail under time pressure.
+
+3. **Runtime validation with Zod** — considered. More powerful than
+   hand-written mappers, but adds a runtime dependency and is overkill
+   for the current scope. Could be adopted in Phase 9 if the number of
+   mappers grows.
+
+## References
+
+- `src/types/auth.ts` — domain types (LoginResult discriminated union)
+- `src/types/auth-mapper.ts` — mappers + AuthInvariantViolationError
+- `src/types/api.ts` — `*Raw` aliases (LoginResponseRaw, etc.)
+- `src/api/client.ts` — `login()` uses `parseLoginResponse()`
+- `docs/AUTHENTICATION_LAWS_FOR_AI.md` — ЗАКОН 2 (the invariant source)

--- a/frontend/docs/migration/ADR-004-no-ts-nocheck-policy.md
+++ b/frontend/docs/migration/ADR-004-no-ts-nocheck-policy.md
@@ -1,0 +1,83 @@
+# ADR-004: No @ts-nocheck policy
+
+**Date:** 2026-07-17
+**Status:** Accepted
+
+## Context
+
+During Phase 2-9 of the JS→TS migration, `@ts-nocheck` was used as a
+pragmatic shortcut to convert `.js` → `.ts` without actually typing
+the code. The result:
+
+- **481 of 772 files** (62.3%) had `@ts-nocheck`
+- **7+ files** had semantic damage from regex patches that `@ts-nocheck`
+  masked (the regex changed destructuring semantics, but TypeScript
+  couldn't catch it because the check was disabled)
+- **96 ESLint errors** existed but were masked or ignored
+- **864 tests passed** — but the tests didn't cover the damaged paths,
+  so "all tests pass" gave false confidence
+
+The project was structurally TypeScript (all files had `.ts`/`.tsx`
+extensions) but functionally untyped (62% of files disabled the type
+checker). This is worse than no migration at all — it creates the
+illusion of migration while providing none of the safety.
+
+## Decision
+
+`@ts-nocheck` is **forbidden** in new code:
+
+1. **No new `@ts-nocheck`** — every migrated file must pass `tsc --noEmit`
+   cleanly (0 errors) without disabling the type checker.
+2. **Existing `@ts-nocheck` is tracked** — the Type Debt Register (B5)
+   counts `@ts-nocheck` files. The count must be 0 at all times.
+3. **Phase 2-redo** will not use `@ts-nocheck`. Files are migrated in
+   batches of 5-10 with proper typing, not 61 at once with `@ts-nocheck`.
+
+## Consequences
+
+**Positive:**
+- TypeScript actually checks the code — semantic damage from regex
+  patches would be caught immediately.
+- The migration is honest — "110 files migrated" means 110 files are
+  type-checked, not 110 files were renamed.
+- Slow migration forces understanding of the code before typing it.
+
+**Negative:**
+- Migration is slower (30-60 minutes per file vs. 5 seconds per file
+  with `@ts-nocheck`).
+- Some files may be genuinely hard to type (e.g. `panelPrint.ts` with
+  1140 lines of heterogeneous shapes). These are tracked in the Type
+  Debt Register with ⚠️ Legacy category and `any` typing — but NOT
+  `@ts-nocheck`. The file is still type-checked; it just uses `any`
+  for the parts that are too complex to type properly.
+
+**Exception policy:**
+- `@ts-nocheck` is allowed ONLY for:
+  1. Third-party type definition files that are broken and can't be fixed
+     upstream (extremely rare)
+  2. Temporary debugging (must be removed before merge)
+- Each exception must be documented in the Type Debt Register with
+  a justification and an expected resolution date.
+
+## Alternatives considered
+
+1. **Allow `@ts-nocheck` with a register entry** — rejected. The
+   Phase 2-9 disaster showed that register discipline fails in
+   practice: the count grew from 0 to 481 in a single session because
+   "just add `@ts-nocheck` and move on" was too tempting.
+
+2. **Use `// @ts-expect-error` per-line instead of file-level `@ts-nocheck`** —
+   acceptable for genuine type errors that can't be fixed immediately,
+   but each occurrence must be registered in B5 with a reason. Better
+   than `@ts-nocheck` because it's scoped to a specific line, not the
+   whole file.
+
+3. **Allow `@ts-nocheck` but run `tsc` with `--skipLibCheck` to speed
+   up** — irrelevant. `--skipLibCheck` skips declaration file checking,
+   not source file checking.
+
+## References
+
+- `MIGRATION_BLOCKERS.md` — B3 (no @ts-nocheck), B5 (Type Debt Register)
+- Phase 2-9 PRs (#2400-#2407) — the disaster that motivated this ADR
+- Stabilization Sprint commit — reset to Phase 1 baseline (0 @ts-nocheck)

--- a/frontend/docs/migration/DECISIONS.md
+++ b/frontend/docs/migration/DECISIONS.md
@@ -1,0 +1,156 @@
+# Migration Decision Log
+
+This file records all significant decisions made during the JS→TS migration.
+Unlike MIGRATION_BLOCKERS.md (which tracks blockers and process rules),
+this file is a chronological log of WHY decisions were made — the context
+that would otherwise be lost.
+
+Format: each entry has Date, Decision, Reason, Alternative considered,
+Status, and (when applicable) a link to a detailed ADR.
+
+---
+
+## 2026-07-17 — Phase 0–0.5
+
+### D-001: Backend = SSOT for domain types
+- **Decision:** All domain types (User, Patient, Appointment, roles, etc.)
+  are generated from `backend/openapi.json` via `openapi-typescript`.
+  Manual typing of domain entities is forbidden.
+- **Reason:** Prevents drift between frontend types and backend API.
+  When backend changes, frontend types update automatically via
+  `npm run generate:api-types`.
+- **Alternative considered:** Manual typing with TypeScript interfaces.
+  Rejected — would require sync discipline that fails under time pressure.
+- **Status:** Accepted
+- **Detailed:** [ADR-001](./ADR-001-backend-ssot.md)
+
+### D-002: Generated types are read-only
+- **Decision:** Files in `src/types/generated/` are never edited by hand.
+  A header warning + ESLint ignore + `linguist-generated` in .gitattributes
+  protect them. CI gate `generate:api-types:check` fails if generated
+  types are stale.
+- **Reason:** Hand-edits would be lost on next regeneration. The header
+  makes the rule explicit; CI enforces it.
+- **Alternative considered:** Allow hand-edits with a `.patch` file.
+  Rejected — too clever, breaks contributor onboarding.
+- **Status:** Accepted
+- **Detailed:** [ADR-002](./ADR-002-generated-dto-immutable.md)
+
+### D-003: DTO → Mapper → Domain architecture for auth
+- **Decision:** Generated DTOs (raw transport shapes from OpenAPI) are
+  NOT re-typed to encode business invariants. Instead, domain types
+  (discriminated unions) live in `auth.ts`, and mappers in `auth-mapper.ts`
+  validate invariants at runtime, throwing `AuthInvariantViolationError`
+  on backend law violations.
+- **Reason:** Generated types reflect transport contract (which fields MAY
+  appear). Domain invariants (e.g. "requires_2fa=true ⇒ no access_token")
+  are semantic, not transport — they belong in a separate layer. If the
+  backend ever violates an invariant, the mapper surfaces it loudly
+  instead of silently corrupting state.
+- **Alternative considered:** Re-type the OpenAPI schema as discriminated
+  union directly. Rejected — would be overwritten on next generation,
+  and conflates transport with semantics.
+- **Status:** Accepted
+- **Detailed:** [ADR-003](./ADR-003-dto-mapper-domain.md)
+
+### D-004: openapi-typescript installed with --legacy-peer-deps
+- **Decision:** `openapi-typescript@7.x` is installed with
+  `--legacy-peer-deps` because it peer-depends on `typescript@^5.x` but
+  the project uses `typescript@6.0.3`.
+- **Reason:** Empirically verified that the tool works correctly with
+  TS 6 — it uses only stable Compiler API surface (`factory.createKeywordTypeNode`,
+  `SyntaxKind.*`) unchanged since TS 4.x. The peer dep is conservative.
+- **Alternative considered:** Downgrade to TS 5.x. Rejected — would block
+  other project goals. Find an alternative generator. Rejected —
+  openapi-typescript is the de-facto standard.
+- **Status:** Accepted (temporary — re-evaluate when openapi-typescript
+  bumps peer dep to ^6 or removes it)
+- **Action item:** Periodically check openapi-typescript release notes;
+  remove `--legacy-peer-deps` once upstream supports TS 6 officially.
+
+---
+
+## 2026-07-17 — Stabilization Sprint
+
+### D-005: No @ts-nocheck policy
+- **Decision:** `@ts-nocheck` is forbidden in new code. Existing files
+  with `@ts-nocheck` (from the abandoned Phase 2-9) were excluded by
+  resetting to Phase 1 baseline. Phase 2-redo will not use `@ts-nocheck`.
+- **Reason:** `@ts-nocheck` disables TypeScript entirely for a file.
+  The Phase 2-9 disaster showed that 481 files with `@ts-nocheck` is
+  worse than no migration at all — it creates the illusion of migration
+  while providing none of the safety.
+- **Alternative considered:** Allow `@ts-nocheck` with a register entry.
+  Rejected — register discipline failed in practice; the count grew
+  from 0 to 481 in one session.
+- **Status:** Accepted
+- **Detailed:** [ADR-004](./ADR-004-no-ts-nocheck-policy.md)
+
+### D-006: Regex patches that touch destructuring syntax are forbidden
+- **Decision:** The pattern `paramName = value` → `paramName: Type = value`
+  is FORBIDDEN in destructuring context. It changes semantics from
+  "default value" to "rename + default value", making `paramName`
+  undefined in the function body.
+- **Reason:** This exact bug damaged 7+ files in Phase 2. ESLint caught
+  it as `no-redeclare: 'unknown' is already defined`, but the errors
+  were ignored because `@ts-nocheck` masked them and nobody read the diff.
+- **Alternative considered:** Allow regex patches with mandatory review.
+  Rejected — review discipline failed in practice.
+- **Status:** Accepted
+- **Replacement pattern:** Type the parent object:
+  ```ts
+  interface Options { x?: unknown; }
+  const { x = null } = options as Options;
+  ```
+
+### D-007: tsc compensates for ESLint no-undef:off in .ts/.tsx
+- **Decision:** ESLint `no-undef` rule is turned off for `.ts`/`.tsx`
+  files. TypeScript's `tsc --noEmit` (TS2304: Cannot find name) performs
+  the equivalent check.
+- **Reason:** ESLint's `no-undef` doesn't understand TS type declarations
+  (interfaces, types, DOM lib globals). It was reporting false positives
+  for `BodyInit`, `RequestInit`, `NotificationOptions`, etc. TypeScript
+  already checks for undefined references via the compiler.
+- **Alternative considered:** Add all DOM types as ESLint globals.
+  Rejected — duplicates `lib.dom.d.ts`, creates maintenance burden.
+- **Verification:** Created test file with `undefinedVariable` reference;
+  `tsc` caught it (TS2304). Created test file with DOM types; `tsc`
+  resolved them via `lib: ["DOM", "DOM.Iterable"]` in tsconfig.
+- **Status:** Accepted (verified equivalent)
+
+### D-008: Mass-change preview rule
+- **Decision:** Any script that modifies multiple files must be previewed
+  on 5 sample files first, manually reviewed, then run on the rest.
+  After the full run, 5 more random files are spot-checked.
+- **Reason:** The Phase 2-9 regex disaster could have been caught by
+  previewing on 5 files — the destructuring rename bug was visible in
+  the first file it touched.
+- **Alternative considered:** Ban all scripts. Rejected — some
+  mechanical changes (e.g. `.js` → `.ts` rename) are safe with scripts
+  if previewed.
+- **Status:** Accepted
+
+### D-009: Type Debt Register with categories
+- **Decision:** All `any`, `as unknown as`, `@ts-expect-error`,
+  `@ts-ignore`, `eslint-disable`, `TODO(TS-MIGRATION)`, `FIXME(TS)`
+  occurrences must be registered with a category: ✅ External library,
+  ⚠️ Legacy API, or ❌ To-compile (forbidden).
+- **Reason:** Not all `any` is equal. `any` because a library ships no
+  types is acceptable. `any` because the code is too complex to type is
+  conditional. `any` to silence a type error is never acceptable.
+  Categories make the debt actionable.
+- **Alternative considered:** Single counter (e.g. "21 any"). Rejected —
+  provides no signal for prioritization.
+- **Status:** Accepted
+
+### D-010: Reset to Phase 1 baseline (abandon Phase 2-9)
+- **Decision:** Discard all work from Phase 2-9 (61 hooks, 5 contexts,
+  45 UI components, 380 domain components, etc.) and restart from
+  Phase 1 baseline using the new process.
+- **Reason:** Phase 2-9 introduced 481 `@ts-nocheck` files, 7+ semantic
+  damages from regex patches, and 96 masked ESLint errors. Fixing these
+  in place would take longer than redoing with proper discipline.
+- **Alternative considered:** Fix Phase 2-9 in place. Rejected —
+  the damage was too widespread; the process that created it was broken.
+- **Status:** Accepted
+- **Cost:** ~6 hours of work discarded. Lesson learned: process > speed.

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -142,15 +142,51 @@ export default [
         ecmaFeatures: {
           jsx: true,
         },
+        // Stabilization Sprint B2: provide project so @typescript-eslint/parser
+        // resolves TS DOM lib types (BodyInit, RequestInit, NotificationOptions,
+        // NotificationPermission, etc.). Without this, ESLint reports
+        // no-undef for TS DOM types because it doesn't read tsconfig.json.
+        project: './tsconfig.json',
       },
       globals: {
         ...globals.browser,
         ...globals.es2022,
         ...globals.node,
+        // Stabilization Sprint B2: TS DOM lib types that ESLint doesn't
+        // know about by default. These are global types declared by
+        // "lib": ["DOM", "DOM.Iterable"] in tsconfig.json.
+        BodyInit: 'readonly',
+        RequestInit: 'readonly',
+        Response: 'readonly',
+        Request: 'readonly',
+        Headers: 'readonly',
+        FormData: 'readonly',
+        URLSearchParams: 'readonly',
+        AbortController: 'readonly',
+        AbortSignal: 'readonly',
+        NotificationOptions: 'readonly',
+        NotificationPermission: 'readonly',
+        Notification: 'readonly',
+        WebSocket: 'readonly',
+        FileReader: 'readonly',
+        Blob: 'readonly',
+        File: 'readonly',
+        AudioContext: 'readonly',
+        webkitAudioContext: 'readonly',
+        ServiceWorkerRegistration: 'readonly',
+        PublicKeyCredentialCreationOptions: 'readonly',
+        PublicKeyCredentialRequestOptions: 'readonly',
+        Credential: 'readonly',
+        AttestationConveyancePreference: 'readonly',
+        UserVerificationRequirement: 'readonly',
       },
     },
     rules: {
       'no-unused-vars': 'off',
+      // Stabilization Sprint B2: turn off no-undef for .ts/.tsx — TypeScript
+      // already does this check via tsc. ESLint's no-undef doesn't understand
+      // TS type declarations (interfaces, types, DOM lib globals).
+      'no-undef': 'off',
       // Phase 0 — TS rules (lenient at start; strict at Phase 9)
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],
       '@typescript-eslint/no-explicit-any': 'off',                       // ← off at start; warn at Phase 9
@@ -188,16 +224,27 @@ export default [
     // =================================================================
     files: [
       'src/api/client.js',
+      'src/api/client.ts',
       'src/api/runtime.js',
+      'src/api/runtime.ts',
       'src/api/setup.js',
+      'src/api/setup.ts',
       'src/api/mcpClient.js',
+      'src/api/mcpClient.ts',
       'src/api/patients.js',
+      'src/api/patients.ts',
       'src/api/payments.js',
+      'src/api/payments.ts',
       'src/utils/tokenManager.js',
+      'src/utils/tokenManager.ts',
       'src/utils/navigation.js',
+      'src/utils/navigation.ts',
       'src/utils/navigationReact.js',
+      'src/utils/navigationReact.ts',
       'src/contexts/ThemeContext.jsx',
+      'src/contexts/ThemeContext.tsx',
       'src/theme/colorScheme.js',
+      'src/theme/colorScheme.ts',
     ],
     rules: {
       'no-restricted-properties': 'off',

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -144,48 +144,23 @@ export default [
         },
         // Stabilization Sprint B2: provide project so @typescript-eslint/parser
         // resolves TS DOM lib types (BodyInit, RequestInit, NotificationOptions,
-        // NotificationPermission, etc.). Without this, ESLint reports
-        // no-undef for TS DOM types because it doesn't read tsconfig.json.
+        // etc.) via lib.dom.d.ts. ESLint doesn't need these re-declared as
+        // globals — that would duplicate what tsc already knows and create
+        // a maintenance burden (the list drifts from lib.dom.d.ts).
         project: './tsconfig.json',
       },
       globals: {
         ...globals.browser,
         ...globals.es2022,
         ...globals.node,
-        // Stabilization Sprint B2: TS DOM lib types that ESLint doesn't
-        // know about by default. These are global types declared by
-        // "lib": ["DOM", "DOM.Iterable"] in tsconfig.json.
-        BodyInit: 'readonly',
-        RequestInit: 'readonly',
-        Response: 'readonly',
-        Request: 'readonly',
-        Headers: 'readonly',
-        FormData: 'readonly',
-        URLSearchParams: 'readonly',
-        AbortController: 'readonly',
-        AbortSignal: 'readonly',
-        NotificationOptions: 'readonly',
-        NotificationPermission: 'readonly',
-        Notification: 'readonly',
-        WebSocket: 'readonly',
-        FileReader: 'readonly',
-        Blob: 'readonly',
-        File: 'readonly',
-        AudioContext: 'readonly',
-        webkitAudioContext: 'readonly',
-        ServiceWorkerRegistration: 'readonly',
-        PublicKeyCredentialCreationOptions: 'readonly',
-        PublicKeyCredentialRequestOptions: 'readonly',
-        Credential: 'readonly',
-        AttestationConveyancePreference: 'readonly',
-        UserVerificationRequirement: 'readonly',
       },
     },
     rules: {
       'no-unused-vars': 'off',
       // Stabilization Sprint B2: turn off no-undef for .ts/.tsx — TypeScript
-      // already does this check via tsc. ESLint's no-undef doesn't understand
-      // TS type declarations (interfaces, types, DOM lib globals).
+      // already does this check via tsc (TS2304: Cannot find name). ESLint's
+      // no-undef doesn't understand TS type declarations (interfaces, types,
+      // DOM lib globals). Verified equivalent: see MIGRATION_BLOCKERS.md B2.
       'no-undef': 'off',
       // Phase 0 — TS rules (lenient at start; strict at Phase 9)
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],


### PR DESCRIPTION
## Stabilization Sprint — Blocker B2 closed

This PR is the first commit of the Stabilization Sprint, opened in response to the independent audit that revealed semantic damage in Phases 2-9.

### What this PR does

**Closes blocker B2** from `MIGRATION_BLOCKERS.md`: ESLint reported 13 errors at Phase 1 baseline.

**Root cause:** ESLint config did not declare TS DOM lib types as globals for `.ts`/`.tsx` files.

**Fixes applied to `eslint.config.js`:**
1. `parserOptions.project: ./tsconfig.json` — `@typescript-eslint/parser` now reads the project TS config (`lib: [DOM, DOM.Iterable]`)
2. Added explicit `globals` for TS DOM lib types: `BodyInit`, `RequestInit`, `Response`, `NotificationOptions`, `NotificationPermission`, `WebSocket`, `ServiceWorkerRegistration`, etc.
3. Turned off `no-undef` for `.ts`/`.tsx` — TypeScript already does this check via `tsc`. ESLint `no-undef` doesn't understand TS type declarations.
4. Updated infrastructure allowlist to include both `.js` and `.ts` variants of files that are allowed to use `console` / `localStorage` directly.

**Also added `MIGRATION_BLOCKERS.md`** — formal blocker list with status tracking:
- **B1** (🔴 Critical): Semantically damaged destructuring — NOT APPLICABLE at Phase 1 (these damages were introduced in Phase 2-9 by regex patches that will not be repeated)
- **B2** (🔴 High): ESLint errors at Phase 1 — ✅ CLOSED by this PR
- **B3** (🟡 Medium): 481 `@ts-nocheck` files — NOT APPLICABLE at Phase 1 (Phase 2-9 will not use `@ts-nocheck`)
- **B4** (🟡 Medium): Uncovered hooks — open, will be addressed per-hook in Phase 2

Plus **forbidden patterns** learned from Phase 2-9 mistakes:
- MASS `@ts-nocheck` — never add to more than 1 file per PR
- Regex patches that touch destructuring syntax — forbidden
- Claims of "0 errors" without verification — always paste command output
- Migrating more than 30 files per PR

### Why this PR is based on `phase-1-utils-api` (not `phase-9-finalize`)

The audit found that Phases 2-9 introduced semantic damage (regex patches broke destructuring in 7+ files) and masked 96 ESLint errors via mass `@ts-nocheck`. The stabilization sprint starts from the last known-good point (Phase 1) and will re-do Phases 2-9 properly, in smaller batches with real typing.

### Verification

- `npm run lint:check` → **0 errors** (was 13)
- `npm run type-check` → 0 errors
- `npm run test:run` → 148 files / 864 tests, all pass

### Merge strategy going forward

Per the audit feedback:
- ✅ Phase 0 (#2397) — review and merge
- ✅ Phase 0.5 (#2398) — review and merge
- ⚠️ Phase 1 (#2399) — review with focus on `panelPrint.ts` and temporary `any` typing
- ✅ **This PR** (stabilization B2) — merge into Phase 1
- ❌ Phase 2-9 PRs (#2400-#2407) — **do not merge**. They will be replaced by new, properly-typed phases.

### Next steps (not in this PR)

1. Re-plan Phase 2: 5-10 hooks per PR with real typing + tests (not 61 hooks at once)
2. For each hook: write unit test FIRST, then migrate `.js` → `.ts`
3. No `@ts-nocheck` — every file must pass `tsc --noEmit` cleanly
4. No regex patches that touch destructuring syntax