### PR TITLE
🎨 Palette: Add accessible labels to fullscreen modal close button

### DIFF
--- a/frontend/src/components/ui/macos/Modal.jsx
+++ b/frontend/src/components/ui/macos/Modal.jsx
@@ -248,6 +248,8 @@ const Modal = ({
           variant="ghost"
           size="small"
           onClick={onClose}
+          aria-label="Закрыть"
+          title="Закрыть"
           style={{
             position: 'absolute',
             top: '12px',

--- a/my_pr_body.md
+++ b/my_pr_body.md
@@ -1,0 +1,51 @@
+## Summary
+
+- Add aria-label and title attributes to the fullscreen modal close button
+- Improve accessibility for screen readers
+
+## Cyclic Execution Evidence
+
+- Fresh main sync: yes
+- Clean workspace: yes
+- Branch: palette-modal-close-a11y
+- Scope gate: frontend/src/components/ui/macos/Modal.jsx
+- Red-check handling: None required
+
+## Contract Impact
+
+not applicable - only accessibility attributes were modified.
+
+## RBAC / Permissions
+
+not applicable - no authorization boundaries were modified.
+
+## Notification / Realtime
+
+not applicable - no notification or realtime logic modified.
+
+## Frontend Resilience
+
+not applicable - only accessibility attributes were modified without changes to the frontend logic or data flow.
+
+## Scope Gate
+
+- Allowed paths: frontend/src/components/ui/macos/Modal.jsx
+- Denied paths: None
+- Migration/docs/test impact: None
+- Rollback note: Revert frontend/src/components/ui/macos/Modal.jsx
+
+## DevBrain Memory Impact
+
+- [x] no durable memory update needed
+- [ ] PROJECT_MEMORY updated
+- [ ] DEVBRAIN_STATUS updated
+- [ ] AI Factory dossier/log/patch updated
+- [ ] agent_gate routing rule updated
+- [ ] indexes/artifacts refreshed locally
+- [ ] regression matrix run
+
+## Validation
+
+- Targeted tests or smoke run: ran pnpm lint and pnpm test --run
+- Result: passing
+- Not checked: None


### PR DESCRIPTION
💡 **What:** Added `aria-label="Закрыть"` and `title="Закрыть"` to the fullscreen modal close button in `frontend/src/components/ui/macos/Modal.jsx`.

🎯 **Why:** The close button in fullscreen modals was previously rendered only with the text `✕` and lacked descriptive labels, making it inaccessible to screen reader users (it reads "✕" or "multiply") and missing a helpful tooltip on hover for mouse users.

📸 **Before/After:**
- **Before:** `<Button variant="ghost" size="small" onClick={onClose}>✕</Button>`
- **After:** `<Button variant="ghost" size="small" onClick={onClose} aria-label="Закрыть" title="Закрыть">✕</Button>`

♿ **Accessibility:**
- Ensures screen readers announce the button's action correctly.
- Provides a native browser tooltip on hover.

---
*PR created automatically by Jules for task [13807973363637175963](https://jules.google.com/task/13807973363637175963) started by @drsapaev*