### PR TITLE
fix(registrar): revert /registrar landing page to worklist table (was welcome)

### DIFF
--- a/frontend/src/pages/registrar/registrarNavigation.js
+++ b/frontend/src/pages/registrar/registrarNavigation.js
@@ -38,12 +38,14 @@ export const REGISTRAR_VIEW_PATHS = {
 export const REGISTRAR_PATH_TO_VIEW = {
   '/registrar/welcome': 'welcome',
   '/registrar/queue': 'queue',
-  // PR-51: /registrar now maps to 'welcome' (was null=worklist).
-  // The welcome dashboard is the registrar's landing page — showing the
-  // worklist table on first login was confusing (no overview, no quick actions).
-  // Worklist is still accessible via the header "Все записи" button or
-  // by navigating to /registrar/worklist.
-  '/registrar': 'welcome',
+  // /registrar maps to null = worklist table (the default landing page).
+  // PR-51 (#2134) temporarily changed this to 'welcome', making the worklist
+  // table inaccessible — the header had no button to navigate back to it,
+  // and no /registrar/worklist route existed. Reverted to null so the
+  // registrar sees the appointments table on login, as before.
+  // Welcome dashboard is still accessible via the "Главная" button in the
+  // header (navigates to /registrar/welcome).
+  '/registrar': null,
 };
 
 /**


### PR DESCRIPTION
## Summary

- Reverts the `/registrar` path mapping from `'welcome'` back to `null` (worklist table) in `registrarNavigation.js`.
- PR-51 (#2134) changed this mapping, making the appointments table with tabs inaccessible — the commit message claimed a 'Все записи' header button and a `/registrar/worklist` route existed, but neither was actually implemented.
- The welcome dashboard remains accessible via the 'Главная' button in the header (navigates to `/registrar/welcome`).

## Root Cause

PR-51 (#2134, commit fb18d45c) changed `REGISTRAR_PATH_TO_VIEW['/registrar']` from `null` to `'welcome'`. This made `getViewFromPath('/registrar')` return `'welcome'` instead of `null`, causing `RegistrarPanel.jsx` to render `<WelcomeView>` instead of the worklist table. The worklist table only renders when `currentView === null`, which became unreachable through normal navigation.

## Cyclic Execution Evidence

- Fresh main sync: yes
- Clean workspace: yes
- Branch: fix/registrar-worklist-landing-page, single commit
- Scope gate: 1 file changed (registrarNavigation.js). No backend, no migrations.
- Red-check handling: 626/626 tests pass, 0 lint errors.

## Contract Impact

- not applicable - frontend routing only, no API/backend contract changed.

## RBAC / Permissions

- not applicable - no role logic touched.

## Notification / Realtime

- not applicable

## Frontend Resilience

- The registrar now sees the appointments table on login (restoring pre-PR-51 behavior). The welcome dashboard is accessible via the 'Главная' header button.

## Scope Gate

- Allowed paths: frontend/src/pages/registrar/registrarNavigation.js.
- Rollback note: revert this commit.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- npm test -- --run (626/626 passed), npm run lint (0 errors).