### PR TITLE
🎨 Palette: Add aria-invalid to form controls

### DIFF
--- a/frontend/src/components/ui/macos/Input.jsx
+++ b/frontend/src/components/ui/macos/Input.jsx
@@ -146,6 +146,7 @@ const Input = React.forwardRef(({
         disabled={disabled}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        aria-invalid={!!error}
         {...props}
       />
       {showClearButton && (

--- a/frontend/src/components/ui/macos/Select.jsx
+++ b/frontend/src/components/ui/macos/Select.jsx
@@ -168,6 +168,7 @@ const Select = React.forwardRef(({
           style={trigger}
           aria-haspopup="listbox"
           aria-expanded={isOpen}
+          aria-invalid={!!error}
           disabled={disabled}
           {...props}
         >

--- a/frontend/src/components/ui/macos/Textarea.jsx
+++ b/frontend/src/components/ui/macos/Textarea.jsx
@@ -121,6 +121,7 @@ const Textarea = React.forwardRef(({
       onBlur={handleBlur}
       onInput={adjustHeight}
       rows={minRows}
+      aria-invalid={!!error}
       {...props}
     />
   );


### PR DESCRIPTION
### 💡 What
Added `aria-invalid={!!error}` to the underlying native elements (`input`, `textarea`, and trigger `button`) in the macOS-themed form control components (`Input.jsx`, `Textarea.jsx`, `Select.jsx`).

### 🎯 Why
To properly communicate the validation state of form fields to assistive technologies like screen readers, improving the overall accessibility and user experience of the interface. This ensures that users relying on screen readers are immediately aware when a form field has a validation error.

### 📸 Before/After
N/A - This is a purely semantic/accessibility change that does not affect the visual presentation of the components.

### ♿ Accessibility
-   Improves screen reader support by correctly associating validation errors with their respective form controls using the `aria-invalid` attribute.
-   Addresses memory learnings regarding form accessibility.

---
*PR created automatically by Jules for task [9808641373849565211](https://jules.google.com/task/9808641373849565211) started by @drsapaev*