### PR TITLE
fix(dev): restore backend/run_server.py for VS Code Run and Debug

### DIFF
--- a/backend/run_server.py
+++ b/backend/run_server.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+VS Code launch entrypoint for the FastAPI backend.
+
+Launched by `.vscode/launch.json` → "Backend: FastAPI (run_server.py)".
+Simple wrapper around uvicorn so the IDE debugger can attach.
+
+For non-IDE workflows prefer:
+    uvicorn app.main:app --reload --port 18000
+"""
+import os
+
+import uvicorn
+
+from app.main import app
+
+if __name__ == "__main__":
+    host = os.environ.get("BACKEND_HOST", "0.0.0.0")  # nosec B104 — intentional bind to all interfaces for dev server
+    port = int(os.environ.get("BACKEND_PORT", "18000"))
+    reload = os.environ.get("BACKEND_RELOAD", "1") == "1"
+
+    print("Запускаем FastAPI сервер...")
+    print(f"[FIX:START] Host={host} Port={port} Reload={reload}")
+    uvicorn.run(app, host=host, port=port, reload=reload, log_level="info")


### PR DESCRIPTION
Single-file fix: restores backend/run_server.py entrypoint for VS Code launch configuration.

This file was previously removed but is needed for the VS Code Run and Debug workflow (launch.json references it).

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main HEAD
- Clean workspace: only 1 file changed
- Branch: fix/staging-blockers-rebase
- Scope gate: single backend file, no API/DB/routing changes
- Red-check handling: N/A (trivial file restore)

## Contract Impact

- Canonical surface: N/A — no API changes
- Request shape: N/A
- Response shape: N/A
- Status codes: N/A
- Frontend consumer: N/A
- Compatibility path or alias: N/A
- Contract proof: N/A — restores previously existing file

## RBAC / Permissions

- Roles allowed: N/A
- Roles denied: N/A
- Positive auth proof: N/A
- Negative auth proof: N/A

## Notification / Realtime

- Event type or websocket channel: N/A
- Payload version / ack behavior: N/A
- Read/unread or delivery semantics: N/A
- Reconnect/resync proof: N/A

## Frontend Resilience

- Empty data proof: N/A because no frontend changes
- Partial data proof: N/A because no data rendering changes
- Forbidden secondary path behavior: N/A because no navigation changes
- Missing draft/resource behavior: N/A because no draft management changes
- Stale route/deep-link behavior: N/A because no routing changes

## Scope Gate

- Allowed paths: backend/run_server.py (single file restore)
- Denied paths: all other files
- Migration/docs/test impact: none
- Rollback note: delete the file

## Validation

- Targeted tests or smoke run: file is a simple uvicorn launcher, verified import works
- Result: N/A
- Not checked: full backend test suite (no logic changes)