### PR TITLE
Phase F3-2: Resolve PatientCard + TeethChart Props conflicts — 20→18 any casts

### DIFF
--- a/frontend/src/components/dental/TeethChart.tsx
+++ b/frontend/src/components/dental/TeethChart.tsx
@@ -41,18 +41,44 @@ import {
 import { useTranslation } from '../../i18n/useTranslation';
 import React from "react";
 
-const TeethChart = ({ onToothClick, initialData = {}, readOnly = false }: any) => {
+// === Domain types ===
+// TeethChart tracks per-tooth state keyed by FDI tooth number.
+// Backend persists this as specialty_data.tooth_status; the chart reads
+// it as a plain object.
+
+export interface ToothData {
+  status?: string;
+  updatedAt?: string;
+  note?: string;
+  [key: string]: unknown;
+}
+
+export type TeethChartMap = Record<string, ToothData>;
+
+export interface TeethChartProps {
+  /** Called whenever a tooth is clicked. Receives the tooth number and its current data. */
+  onToothClick?: (toothNumber: number, toothData: ToothData) => void;
+  /** Initial per-tooth state (typically loaded from EMR specialty_data.tooth_status). */
+  initialData?: TeethChartMap;
+  /** When true, the chart only emits clicks without mutating internal state. */
+  readOnly?: boolean;
+  /** Optional patient ID (passed through for downstream consumers). */
+  patientId?: string | number | null;
+  [key: string]: unknown;
+}
+
+const TeethChart = ({ onToothClick, initialData = {}, readOnly = false }: TeethChartProps) => {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
-  const [teethData, setTeethData] = useState(initialData);
-  const [selectedTooth, setSelectedTooth] = useState(null);
+  const [teethData, setTeethData] = useState<TeethChartMap>(initialData);
+  const [selectedTooth, setSelectedTooth] = useState<number | null>(null);
   const [selectedStatus, setSelectedStatus] = useState<string>(TOOTH_STATUS.CARIES);
   const [viewMode, setViewMode] = useState('adult'); // adult, child
   const [zoom, setZoom] = useState(1);
 
   // Обработка клика по зубу
-  const handleToothClick = (toothNumber) => {
+  const handleToothClick = (toothNumber: number) => {
     if (readOnly) {
-      onToothClick && onToothClick(toothNumber, teethData[toothNumber]);
+      onToothClick && onToothClick(toothNumber, teethData[toothNumber] || {});
       return;
     }
 
@@ -62,7 +88,7 @@ const TeethChart = ({ onToothClick, initialData = {}, readOnly = false }: any) =
     const newData = {
       ...teethData,
       [toothNumber]: {
-        ...teethData[toothNumber],
+        ...(teethData[toothNumber] || {}),
         status: selectedStatus,
         updatedAt: new Date().toISOString()
       }
@@ -79,8 +105,8 @@ const TeethChart = ({ onToothClick, initialData = {}, readOnly = false }: any) =
   };
 
   // Отрисовка одного зуба
-  const renderTooth = (toothNumber) => {
-    const toothData = teethData[toothNumber] || { status: TOOTH_STATUS.HEALTHY };
+  const renderTooth = (toothNumber: number) => {
+    const toothData: ToothData = teethData[toothNumber] || { status: TOOTH_STATUS.HEALTHY };
     const isSelected = selectedTooth === toothNumber;
     const status = toothData.status || TOOTH_STATUS.HEALTHY;
 
@@ -345,8 +371,8 @@ const TeethChart = ({ onToothClick, initialData = {}, readOnly = false }: any) =
             </Typography>
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
               {Object.entries(
-              Object.values(teethData).reduce((acc, tooth) => {
-                const status = (tooth as Record<string, unknown>).status || TOOTH_STATUS.HEALTHY;
+              Object.values(teethData).reduce<Record<string, number>>((acc, tooth) => {
+                const status = tooth?.status || TOOTH_STATUS.HEALTHY;
                 acc[String(status)] = (acc[String(status)] || 0) + 1;
                 return acc;
               }, {})

--- a/frontend/src/components/medical/PatientCard.tsx
+++ b/frontend/src/components/medical/PatientCard.tsx
@@ -5,6 +5,49 @@ import Icon from '../Icon';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useTranslation } from '../../i18n/useTranslation';
 
+// === Domain types ===
+// PatientCard displays a single patient as a tile. The shape covers both
+// MediLabDemo's structured Patient objects and DentistPanelUnified's
+// selectedPatient (which is a superset with visit_id, examinationData,
+// etc. — those extra fields ride along via the index signature).
+
+export interface PatientCardPatient {
+  id?: string | number;
+  name?: string;
+  avatar?: string | null;
+  patientId?: string | number;
+  age?: string | number;
+  gender?: string;
+  lastVisit?: string;
+  department?: string;
+  status?: string;
+  is_deleted?: boolean;
+  [key: string]: unknown;
+}
+
+export interface PatientCardProps {
+  /** Patient data to render. */
+  patient: PatientCardPatient;
+  /** Open patient details view. */
+  onView?: (patient: PatientCardPatient) => void;
+  /** Open edit form. */
+  onEdit?: (patient: PatientCardPatient) => void;
+  /** Hard-delete (used as fallback when onArchive is not provided). */
+  onDelete?: (patient: PatientCardPatient) => void;
+  /** Soft-delete (archive) handler — preferred over onDelete. */
+  onArchive?: (patient: PatientCardPatient) => void;
+  /** Restore an archived patient. */
+  onRestore?: (patient: PatientCardPatient) => void;
+  /** Save handler (used by DentistPanelUnified modal flow). */
+  onSave?: (updatedPatient: PatientCardPatient) => void;
+  /** Close handler (used by DentistPanelUnified modal flow). */
+  onClose?: () => void;
+  /** Extra CSS class. */
+  className?: string;
+  /** Pass-through props to underlying MedicalCard. */
+  [key: string]: unknown;
+}
+
 /**
  * Карточка пациента в стиле MediLab
  */
@@ -17,7 +60,7 @@ const PatientCard = ({
   onRestore,  // Restore handler
   className = '',
   ...props
-}: any) => {
+}: PatientCardProps) => {
   const { isDark } = useTheme();
 
   const {
@@ -33,7 +76,7 @@ const PatientCard = ({
     is_deleted = false  // Soft-delete flag
   } = patient;
 
-  const getStatusColor = (status) => {
+  const getStatusColor = (status: string | undefined) => {
     if (is_deleted) return 'var(--mac-text-tertiary)';  // Gray for archived
     switch (status) {
       case 'active': return 'var(--mac-success)';
@@ -44,7 +87,7 @@ const PatientCard = ({
     }
   };
 
-  const getGenderIcon = (gender) => {
+  const getGenderIcon = (gender: string | undefined) => {
     return gender === 'M' ? '👨' : gender === 'F' ? '👩' : '👤';
   };
 

--- a/frontend/src/pages/DentistPanelUnified.tsx
+++ b/frontend/src/pages/DentistPanelUnified.tsx
@@ -2021,7 +2021,7 @@ const DentistPanelUnified = () => {
             </div>
             <TeethChart
             patientId={selectedPatientId}
-            initialData={dentalChartData}
+            initialData={(dentalChartData ?? {}) as Record<string, { status?: string; updatedAt?: string; [key: string]: unknown }>}
             onToothClick={(toothNumber, toothData) => {
               logger.info('Клик по зубу:', toothNumber, toothData);
               setSelectedTooth({ number: toothNumber, data: toothData });

--- a/scripts/type-debt-baseline.json
+++ b/scripts/type-debt-baseline.json
@@ -1,5 +1,5 @@
 {
-  "anyCasts": 20,
+  "anyCasts": 18,
   "tsIgnore": 0,
   "tsNoCheck": 0,
   "indexSignatureAny": 0

--- a/scripts/type-debt-check.mjs
+++ b/scripts/type-debt-check.mjs
@@ -26,7 +26,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const FRONTEND_DIR = resolve(__dirname, '..', 'frontend', 'src');
 
 const BASELINE = {
-  anyCasts: 20,
+  anyCasts: 18,
   tsIgnore: 0,
   tsNoCheck: 0,
   indexSignatureAny: 0,


### PR DESCRIPTION
## Summary

- Follow-up to PR #2449 (Phase F). Resolves the 2 components with conflicts identified in the F3-0 caller inventory.
- Used canonical structured type as winner in both cases; DentistPanelUnified callers pass through index signatures or one-time call-site casts.
- Debt: 20 → 18 `any` casts (-2). All callers compile without new casts.

## Cyclic Execution Evidence

- Fresh main sync: branch `phase-f3-2-conflict-resolution` created from current `origin/main` after PR #2449 merge (commit e467a4dc)
- Clean workspace: inspected before each edit; only 3 source files + 2 baseline files changed
- Branch: `phase-f3-2-conflict-resolution`
- Scope gate: allowed PatientCard Props + TeethChart Props + DentistPanelUnified call-site cast; denied Sprint F3-3 (Generic domain), backend changes, test changes
- Red-check handling: every change verified with `npx tsc --noEmit` and `npx eslint src/` locally before push; failed checks fixed in same commit

## Contract Impact

- Canonical surface: 2 component Props interfaces (`PatientCardProps`, `TeethChartProps`) + 3 domain types (`PatientCardPatient`, `ToothData`, `TeethChartMap`)
- Request shape: not applicable - no API request shapes modified (type-only refactor)
- Response shape: not applicable - no API response shapes modified; new domain interfaces describe existing shapes
- Status codes: not applicable - no HTTP status code handling changed (type-only refactor)
- Frontend consumer: PatientCard (2 callers: MediLabDemo, DentistPanelUnified) + TeethChart (3 callers: DentistPanelUnified, DentalVisitScreen, DentistrySection); all compile without new casts
- Compatibility path or alias: all Props interfaces include `[key: string]: unknown` index signature, so existing callers passing extra fields continue to compile
- Contract proof: F3-0 caller inventory (`docs/f3-0-caller-inventory.md`) identified both conflicts; local `tsc --noEmit` (0 errors) + local `eslint` (0 errors) confirm resolution

## RBAC / Permissions

- Roles allowed: not applicable - this PR is type-only, no auth logic touched
- Roles denied: not applicable - no role checks modified by this type-only refactor
- Positive auth proof: not applicable - no auth code paths changed; type-only refactor
- Negative auth proof: not applicable - no auth code paths changed; type-only refactor

## Notification / Realtime

- Event type or websocket channel: not applicable - no WebSocket event types or channels changed
- Payload version / ack behavior: not applicable - no message payload versions or ack semantics changed
- Read/unread or delivery semantics: not applicable - no read/unread or delivery logic changed
- Reconnect/resync proof: not applicable - no reconnect or resync logic changed

## Frontend Resilience

- Empty data proof: TeethChart `initialData = {}` default still works (empty `TeethChartMap`); PatientCard still crashes if `patient` is null/undefined (unchanged behavior — caller must guard with `{selectedPatient && <PatientCard ...>}`)
- Partial data proof: all PatientCardPatient fields are optional; ToothData fields are optional; missing fields fall back to defaults (`status = 'active'`, `is_deleted = false`, `name = 'Unknown Patient'`)
- Forbidden secondary path behavior: not applicable - no secondary path used; components render the same JSX they did before
- Missing draft/resource behavior: not applicable - no draft or resource creation logic in scope; PatientCard and TeethChart are read-only display components
- Stale route/deep-link behavior: not applicable - no route or deep-link state read by either component

## Scope Gate

- Allowed paths: PatientCard Props interface, TeethChart Props interface, DentistPanelUnified call-site cast, type-debt baseline
- Denied paths: Sprint F3-3 (Generic domain), Sprint F4 (Form.tsx), backend changes, test changes, MediLabDemo / DentalVisitScreen / DentistrySection changes (those callers already passed compatible types)
- Migration/docs/test impact: no migration; no new docs; no test changes (type-only refactor)
- Rollback note: revert commit `8df4323c` on `phase-f3-2-conflict-resolution`; baseline will return to 20 `any` casts (CI debt gate will then enforce 20)

## Validation

- Targeted tests or smoke run: `npx tsc --noEmit` (0 errors), `npx eslint src/` (0 errors, 4025 pre-existing warnings), `node scripts/type-debt-check.mjs` (baseline=18, delta=0)
- Result: passed locally
- Not checked: full browser panel smoke (DentistPanelUnified dental chart + MediLabDemo patient grid) — recommended for manual verification before merge

---

### PatientCard conflict resolution

Conflict from F3-0 inventory: `patient` prop receives `any` (DentistPanelUnified) vs structured `{id, name, patientId, age, gender, lastVisit, department, status, avatar}` (MediLabDemo).

Resolution: structured Patient type is canonical (matches `propTypes`). DentistPanelUnified's `selectedPatient` is a SUPERSET (visit_id, examinationData, etc.) — those extra fields ride along via the index signature.

### TeethChart conflict resolution

Conflict from F3-0 inventory: `initialData` receives `Record<string, unknown>` (DentistPanelUnified), `{}` (DentalVisitScreen), `Record<string, any>` (DentistrySection).

Resolution: canonical type is `Record<string, ToothData>` (`TeethChartMap`). `ToothData` has at minimum `status` + `updatedAt` (set by the component itself on click). DentistPanelUnified caller casts at call site because its `dentalChartData` state was already typed as `Record<string, unknown> | null` — one-time cast in caller, not in the component contract.

### Domain types added

- `PatientCardPatient` (matches propTypes + index sig for DentistPanelUnified superset)
- `PatientCardProps` with patient, onView?, onEdit?, onDelete?, onArchive?, onRestore?, onSave?, onClose?, className?
- `ToothData` (status, updatedAt, note + index sig)
- `TeethChartMap` = `Record<string, ToothData>`
- `TeethChartProps` with onToothClick?, initialData?, readOnly?, patientId?

### CI debt gate

Baseline updated: `20 → 18` `any` casts. Future PRs cannot increase the baseline.

### Remaining 18 casts (planned for follow-up PRs)

- 10 component props `: any) =>` — Sprint F3-3 (Generic domain: Table 19 callers/7 conflicts, EMRSmartFieldV2 5 callers/6 conflicts, ModernQueueManager, PrescriptionEditor, PhoneVerification, DentalPatientsTab, DoctorServiceSelector, renderStatCard, QueueTable, ComplaintsField)
- 4 in `components/common/Form.tsx` — Sprint F4 (FormContextValue)
- 2 in `types/react-i18next-override.d.ts` — TECH-DEBT(i18n-001) documented
- 1 in `components/integration/IntegrationDemo.tsx` — TECH-DEBT(integration-demo-001) documented
- 1 in `utils/navigationReact.ts` JSDoc — documentation only