### PR TITLE
Phase F3-3: Recover Props for 10 Generic-domain components — 18→8 any casts

### DIFF
--- a/frontend/src/components/auth/PhoneVerification.tsx
+++ b/frontend/src/components/auth/PhoneVerification.tsx
@@ -17,6 +17,34 @@ import logger from '../../utils/logger';
 import PropTypes from 'prop-types';
 import { useSafeInput } from '../../hooks/useSafeInput';  // PR-39 / P0-5: sanitizer wired to form
 import { useTranslation } from '../../i18n/useTranslation';
+
+// === Domain types ===
+export type PhoneVerificationPurpose = 'verification' | 'login' | 'reset' | string;
+
+export interface PhoneVerificationResult {
+  phone: string;
+  verified_at?: string;
+  [key: string]: unknown;
+}
+
+export interface PhoneVerificationProps {
+  /** Initial phone number (E.164 or local format). */
+  phone?: string;
+  /** Why the code is being sent — controls i18n + backend endpoint selection. */
+  purpose?: PhoneVerificationPurpose;
+  /** Called once the phone is successfully verified. */
+  onVerified?: (result: PhoneVerificationResult) => void;
+  /** Cancel handler — closes the verification flow. */
+  onCancel?: () => void;
+  /** Optional custom message shown to the user. */
+  customMessage?: string;
+  /** When true, the user can edit the phone number inline. */
+  showPhoneInput?: boolean;
+  /** Optional override for the card title (defaults to translated string). */
+  title?: string;
+  [key: string]: unknown;
+}
+
 const PhoneVerification = ({
   phone,
   purpose = 'verification',
@@ -25,7 +53,7 @@ const PhoneVerification = ({
   customMessage,
   showPhoneInput = false,
   title  // PR-44 / P0-19: default now comes from useTranslation
-}: any) => {
+}: PhoneVerificationProps) => {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   // PR-44 / P0-19: title defaults to translated string instead of hardcoded RU
   const displayTitle = title || t('verificationTitle');

--- a/frontend/src/components/common/Table.tsx
+++ b/frontend/src/components/common/Table.tsx
@@ -5,7 +5,76 @@ import { useState, useMemo, useCallback } from 'react';
 import { useTheme } from '../../contexts/ThemeContext';
 import { Input } from '../ui/macos';
 import { useTranslation } from '../../i18n/useTranslation';
-import React, { type CSSProperties } from "react";
+import React, { type CSSProperties, type ReactNode } from "react";
+
+// === Domain types ===
+// Table is a generic sortable/filterable/paginated table. Column shape
+// covers all variants observed in 19 callers (key, title/header/label,
+// render, sortable, width, align, filterable). Row shape is dynamic
+// (backend-driven), so it rides along via index signature.
+
+export interface TableColumn {
+  /** Unique column key — used as the row[cell.key] accessor. */
+  key: string;
+  /** Header label (string or ReactNode). */
+  title?: ReactNode;
+  /** Alias for `title` (used by some callers). */
+  header?: string;
+  /** Alias for `title` (used by some callers). */
+  label?: string;
+  /** Custom cell renderer: receives (cellValue, row). */
+  render?: (value: unknown, row: Record<string, unknown>) => ReactNode;
+  /** Whether this column is sortable (defaults to table-level `sortable`). */
+  sortable?: boolean;
+  /** Whether this column is filterable (defaults to table-level `filterable`). */
+  filterable?: boolean;
+  /** Column width (CSS value). */
+  width?: string;
+  /** Cell text alignment. */
+  align?: 'left' | 'right' | 'center' | string;
+  [key: string]: unknown;
+}
+
+export interface TableProps {
+  /** Row data (each row is a dynamic object keyed by column.key). */
+  data?: Record<string, unknown>[];
+  /** Column definitions. */
+  columns?: TableColumn[];
+  /** Whether sorting is enabled (per-column overrides via column.sortable). */
+  sortable?: boolean;
+  /** Whether filtering is enabled (per-column overrides via column.filterable). */
+  filterable?: boolean;
+  /** Whether pagination is enabled. */
+  pagination?: boolean;
+  /** Number of rows per page. */
+  pageSize?: number;
+  /** Sort change handler. */
+  onSort?: (field: string, direction: 'asc' | 'desc') => void;
+  /** Filter change handler. */
+  onFilter?: (field: string, value: string) => void;
+  /** Page change handler. */
+  onPageChange?: (page: number) => void;
+  /** Loading flag — renders skeleton rows when true. */
+  loading?: boolean;
+  /** Empty-state message. */
+  emptyMessage?: string;
+  /** Optional empty-state element (overrides emptyMessage). */
+  emptyState?: ReactNode;
+  /** Optional CSS class. */
+  className?: string;
+  /** Optional variant. */
+  variant?: string;
+  /** Optional size. */
+  size?: string;
+  /** Optional striped rows flag. */
+  striped?: boolean;
+  /** Optional hoverable rows flag. */
+  hoverable?: boolean;
+  /** Optional inline style. */
+  style?: CSSProperties;
+  /** Pass-through props to underlying <table>. */
+  [key: string]: unknown;
+}
 
 /**
  * Компонент таблицы
@@ -23,7 +92,7 @@ export function Table({
   loading = false,
   emptyMessage = 'Нет данных',
   ...props
-}: any) {
+}: TableProps) {
   const theme = useTheme();
   const { getColor, getSpacing, getFontSize } = theme;
   
@@ -79,7 +148,7 @@ export function Table({
       setSortDirection('asc');
     }
     
-    onSort?.(field, sortDirection);
+    onSort?.(field, sortDirection as 'asc' | 'desc');
   }, [sortField, sortDirection, sortable, onSort]);
 
   // Обработка фильтрации
@@ -223,8 +292,8 @@ export function Table({
                   {column.filterable !== false && (
                     <Input
                       type="text"
-                      aria-label={`Filter ${column.title}`}
-                      placeholder={`Фильтр по ${column.title.toLowerCase()}`}
+                      aria-label={`Filter ${String(column.title ?? column.header ?? column.label ?? '')}`}
+                      placeholder={`Фильтр по ${String(column.title ?? column.header ?? column.label ?? '').toLowerCase()}`}
                       value={filters[column.key] || ''}
                       onChange={(e) => handleFilter(column.key, e.target.value)}
                       style={filterInputStyle as CSSProperties}
@@ -246,7 +315,7 @@ export function Table({
           ) : (
             paginatedData.map((row, index) => (
               <tr
-                key={row.id || index}
+                key={String(row.id ?? index)}
                 style={rowStyle as CSSProperties}
                 onMouseEnter={(e) => {
                   e.currentTarget.style.backgroundColor = getColor('background', 'tertiary');
@@ -257,7 +326,7 @@ export function Table({
               >
                 {columns.map((column) => (
                   <td key={column.key} style={cellStyle as CSSProperties}>
-                    {column.render ? column.render(row[column.key], row) : row[column.key]}
+                    {column.render ? column.render(row[column.key], row) : String(row[column.key] ?? '')}
                   </td>
                 ))}
               </tr>

--- a/frontend/src/components/dental/DentalPatientsTab.tsx
+++ b/frontend/src/components/dental/DentalPatientsTab.tsx
@@ -10,13 +10,40 @@ import { Scissors, FileText, Eye } from 'lucide-react';
 import { Stethoscope as Tooth } from 'lucide-react';
 import { useTranslation } from '../../i18n/useTranslation';
 
+// === Domain types ===
+export interface DentalPatientsTabPatient {
+  id?: string | number;
+  name?: string;
+  patient_name?: string;
+  full_name?: string;
+  patient_id?: string | number;
+  phone?: string;
+  last_visit?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface DentalPatientsTabProps {
+  /** Patients to render as cards. */
+  patients?: DentalPatientsTabPatient[];
+  /** Open the patient details view. */
+  onSelectPatient?: (patient: DentalPatientsTabPatient) => void;
+  /** Open the dental chart for a patient. */
+  onDentalChart?: (patient: DentalPatientsTabPatient) => void;
+  /** Open the treatment planner for a patient. */
+  onTreatment?: (patient: DentalPatientsTabPatient) => void;
+  /** Open the prosthetic flow for a patient. */
+  onProsthetic?: (patient: DentalPatientsTabPatient) => void;
+  [key: string]: unknown;
+}
+
 export function DentalPatientsTab({
   patients = [],
   onSelectPatient,
   onDentalChart,
   onTreatment,
   onProsthetic,
-}: any) {
+}: DentalPatientsTabProps) {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   if (patients.length === 0) {
     return (

--- a/frontend/src/components/doctor/DoctorServiceSelector.tsx
+++ b/frontend/src/components/doctor/DoctorServiceSelector.tsx
@@ -26,6 +26,36 @@ import tokenManager from '../../utils/tokenManager';
 import PropTypes from 'prop-types';
 import { useTranslation } from '../../i18n/useTranslation';
 import React from "react";
+
+// === Domain types ===
+export interface DoctorServiceItem {
+  id?: string | number;
+  service_id?: string | number;
+  service?: string;
+  name?: string;
+  quantity?: number;
+  price?: number;
+  total?: number;
+  duration?: number;
+  duration_minutes?: number;
+  currency?: string;
+  [key: string]: unknown;
+}
+
+export interface DoctorServiceSelectorProps {
+  /** Medical specialty filter (e.g. 'cardiology', 'dermatology'). */
+  specialty?: string;
+  /** Currently selected services (controlled). */
+  selectedServices?: DoctorServiceItem[];
+  /** Called whenever the selection changes. */
+  onServicesChange?: (services: DoctorServiceItem[]) => void;
+  /** Whether the user can edit service prices inline. */
+  canEditPrices?: boolean;
+  /** Extra CSS class. */
+  className?: string;
+  [key: string]: unknown;
+}
+
 /**
  * Селектор услуг для панели врача
  * Использует справочник из админ панели согласно passport.md стр. 1254
@@ -36,7 +66,7 @@ const DoctorServiceSelector = ({
   onServicesChange,
   canEditPrices = true,
   className = ''
-}: any) => {
+}: DoctorServiceSelectorProps) => {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   // Проверяем демо-режим в самом начале
   const isDemoMode = window.location.pathname.includes('/medilab-demo');
@@ -167,11 +197,11 @@ const DoctorServiceSelector = ({
   };
 
   const getTotalCost = () => {
-    return selectedServices.reduce((total, service) => total + (service.total || service.price * service.quantity), 0);
+    return selectedServices.reduce((total, service) => total + (Number(service.total ?? 0) || (Number(service.price ?? 0) * Number(service.quantity ?? 1))), 0);
   };
 
   const getTotalDuration = () => {
-    return selectedServices.reduce((total, service) => total + service.duration_minutes * service.quantity, 0);
+    return selectedServices.reduce((total, service) => total + (Number(service.duration_minutes ?? 0) * Number(service.quantity ?? 1)), 0);
   };
   const handleActivationKeyDown = (event, onActivate) => {
     if (event.key === 'Enter' || event.key === ' ') {
@@ -268,7 +298,7 @@ const DoctorServiceSelector = ({
           <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--mac-spacing-2)' }}>
             {selectedServices.map((service) =>
           <div
-            key={service.id}
+            key={String(service.id ?? service.service_id ?? '')}
             style={{
               display: 'flex',
               alignItems: 'center',
@@ -285,12 +315,12 @@ const DoctorServiceSelector = ({
                     <div style={{
                   fontWeight: 'var(--mac-font-weight-medium)',
                   color: 'var(--mac-text-primary)'
-                }}>{service.name}</div>
+                }}>{String(service.name ?? '')}</div>
                     <div style={{
                   fontSize: 'var(--mac-font-size-sm)',
                   color: 'var(--mac-text-tertiary)'
                 }}>
-                      {service.duration_minutes} мин
+                      {String(service.duration_minutes ?? '')} мин
                     </div>
                   </div>
                 </div>
@@ -369,13 +399,13 @@ const DoctorServiceSelector = ({
               <span style={{
                 fontWeight: 'var(--mac-font-weight-medium)',
                 color: 'var(--mac-text-primary)'
-              }}>{service.price.toLocaleString()}</span>
+              }}>{Number(service.price ?? 0).toLocaleString()}</span>
               }
 
                   <span style={{
                 fontSize: 'var(--mac-font-size-sm)',
                 color: 'var(--mac-text-tertiary)'
-              }}>{service.currency}</span>
+              }}>{String(service.currency ?? '')}</span>
 
                   {/* Убрать услугу */}
                   <Button

--- a/frontend/src/components/emr-v2/sections/ComplaintsField.tsx
+++ b/frontend/src/components/emr-v2/sections/ComplaintsField.tsx
@@ -21,8 +21,42 @@ import './ComplaintsField.css';
 import logger from '../../../utils/logger';
 import { useTranslation } from '../../../i18n/useTranslation';
 
+// === Domain types ===
+export interface ComplaintsFieldSuggestion {
+  id?: string | number;
+  content?: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+export interface ComplaintsFieldProps {
+  /** Current complaints text (controlled). */
+  value?: string;
+  /** Called whenever the user edits the field. */
+  onChange?: (value: string) => void;
+  /** Whether the field is editable (read-only when false). */
+  isEditable?: boolean;
+  /** Whether AI suggestions are enabled. */
+  aiEnabled?: boolean;
+  /** Request AI suggestions for the given draft text; returns 2-3 variants. */
+  onRequestAI?: (text: string) => Promise<ComplaintsFieldSuggestion[]> | ComplaintsFieldSuggestion[] | undefined;
+  /** Inline validation error message. */
+  error?: string;
+  /** Auto-focus the field on mount. */
+  autoFocus?: boolean;
+  /** Called when the field is first touched (focus). Caller may receive field name. */
+  onFieldTouch?: (fieldName?: string) => void;
+  /** Called when the field loses focus. */
+  onBlur?: () => void;
+  /** Optional label override. */
+  label?: string;
+  /** Optional placeholder override. */
+  placeholder?: string;
+  [key: string]: unknown;
+}
+
 // Debounce hook
-const useDebounce = (value, delay) => {
+const useDebounce = (value: string, delay: number) => {
   const { t } = useTranslation();
     const [debouncedValue, setDebouncedValue] = useState(value);
 
@@ -46,7 +80,7 @@ const ComplaintsField = ({
     onBlur,
     label = 'Жалобы',
     placeholder = 'Введите жалобы пациента...'
-}: any) => {
+}: ComplaintsFieldProps) => {
     const complaintsFieldId = useId();
     const textareaRef = useRef(null);
 

--- a/frontend/src/components/emr-v2/sections/EMRSmartFieldV2.tsx
+++ b/frontend/src/components/emr-v2/sections/EMRSmartFieldV2.tsx
@@ -26,9 +26,61 @@ import './EMRSmartFieldV2.css';
 import { Input } from '../../ui/macos';
 import { useTranslation } from '../../../i18n/useTranslation';
 
+// === Domain types ===
+export interface EMRSmartFieldV2Suggestion {
+  id?: string | number;
+  content?: string;
+  text?: string;
+  source?: string;
+  confidence?: number;
+  [key: string]: unknown;
+}
+
+export interface EMRSmartFieldV2Props {
+  /** Current text value (controlled). */
+  value?: string;
+  /** Called whenever the user edits the field. Optional second arg for metadata. */
+  onChange?: (value: string, options?: Record<string, unknown>) => void;
+  /** Placeholder text. */
+  placeholder?: string;
+  /** When true, render a textarea instead of a single-line input. */
+  multiline?: boolean;
+  /** Rows for the textarea (ignored when multiline=false). */
+  rows?: number;
+  /** Read-only flag. */
+  disabled?: boolean;
+  /** Field id (used for scroll navigation and aria). */
+  id?: string;
+  /** Field name — passed to AI request handler to disambiguate which field. */
+  fieldName?: string;
+  /** AI suggestions to show in the popover. */
+  suggestions?: EMRSmartFieldV2Suggestion[] | unknown[];
+  /** Loading flag for AI requests. */
+  aiLoading?: boolean;
+  /** Apply a suggestion to the field. */
+  onApplySuggestion?: (suggestion: unknown) => void;
+  /** Dismiss a suggestion. */
+  onDismissSuggestion?: (suggestion: unknown) => void;
+  /** Request AI suggestions for the field. Receives field name or text. */
+  onRequestAI?: (textOrFieldName: string) => void;
+  /** Whether to show the AI assist button. */
+  showAIButton?: boolean;
+  /** Opt-in experimental inline ghost-text mode. */
+  experimentalGhostMode?: boolean;
+  /** Telemetry callback. */
+  onTelemetry?: (payload: Record<string, unknown>) => void;
+  /** Optional label (observed in DiagnosisSection caller). */
+  label?: string;
+  /** Optional required flag (observed in DiagnosisSection caller). */
+  required?: boolean;
+  /** Optional AI-disabled tooltip (observed in ExaminationSection caller). */
+  aiDisabledTooltip?: string;
+  [key: string]: unknown;
+}
+
 /**
  * EMRSmartFieldV2 Component
- * 
+ *
  * @param {Object} props
  * @param {string} props.value - Current value
  * @param {Function} props.onChange - Change handler (value, metadata?)
@@ -64,7 +116,7 @@ export function EMRSmartFieldV2({
     showAIButton = true,
     experimentalGhostMode = false,
     onTelemetry,
-}: any) {
+}: EMRSmartFieldV2Props) {
     const [isFocused, setIsFocused] = useState(false);
     const [showPopover, setShowPopover] = useState(false);
     const [ghostText, setGhostText] = useState('');
@@ -152,8 +204,9 @@ export function EMRSmartFieldV2({
             }
 
             // Ghost Text Logic
-            if (experimentalGhostMode && suggestions[0]?.content && value) {
-                const topSuggestion = suggestions[0].content;
+            const firstSuggestion = suggestions[0] as EMRSmartFieldV2Suggestion | undefined;
+            if (experimentalGhostMode && firstSuggestion?.content && value) {
+                const topSuggestion = String(firstSuggestion.content);
                 if (topSuggestion.startsWith(value) && topSuggestion.length > value.length) {
                     setGhostText(topSuggestion.substring(value.length));
                 } else {

--- a/frontend/src/components/emr-v2/sections/PrescriptionEditor.tsx
+++ b/frontend/src/components/emr-v2/sections/PrescriptionEditor.tsx
@@ -16,6 +16,32 @@ import './PrescriptionEditor.css';
 import { Input } from '../../ui/macos';
 import { useTranslation } from '../../../i18n/useTranslation';
 
+// === Domain types ===
+export interface PrescriptionItem {
+  id?: string | number;
+  name?: string;
+  drug?: string;
+  dose?: string;
+  dosage?: string;
+  frequency?: string;
+  freq?: string;
+  duration?: string;
+  note?: string;
+  [key: string]: unknown;
+}
+
+export interface PrescriptionEditorProps {
+  /** Current list of prescriptions (controlled). */
+  prescriptions?: PrescriptionItem[];
+  /** Called whenever the list changes (add/edit/delete). */
+  onChange?: (prescriptions: PrescriptionItem[]) => void;
+  /** Whether the editor is editable (read-only when false). */
+  isEditable?: boolean;
+  /** Called when the field is first touched. */
+  onFieldTouch?: (fieldName?: string) => void;
+  [key: string]: unknown;
+}
+
 // Mock DB препаратов
 const getMockDrugs = (t) => [
 { name: t('misc.pe_drug_amoxicillin'), defaultDose: t('misc.pe_drug_amoxicillin_dose'), defaultFreq: t('misc.pe_drug_amoxicillin_freq') },
@@ -32,7 +58,7 @@ const PrescriptionEditor = ({
   onChange,
   isEditable = true,
   onFieldTouch
-}: any) => {
+}: PrescriptionEditorProps) => {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   const [isAdding, setIsAdding] = useState(false);
   const [newItem, setNewItem] = useState({

--- a/frontend/src/components/emr-v2/sections/TreatmentSection.tsx
+++ b/frontend/src/components/emr-v2/sections/TreatmentSection.tsx
@@ -226,7 +226,7 @@ export function TreatmentSection({
                     Лекарственные назначения
                 </h4>
                 <PrescriptionEditor
-          prescriptions={medications || []}
+          prescriptions={(medications || []) as import('./PrescriptionEditor').PrescriptionItem[]}
           onChange={onMedicationsChange}
           isEditable={!disabled} />
         

--- a/frontend/src/components/emr-v2/sections/specialty/DermatologySection.tsx
+++ b/frontend/src/components/emr-v2/sections/specialty/DermatologySection.tsx
@@ -262,7 +262,7 @@ export function DermatologySection({
             <div className="dermatology-field-group">
                 <label className="dermatology-label">{i18nT('misc.ds_lokalizatsiya_porazheniy')}</label>
                 <EMRSmartFieldV2
-          value={localization?.description || ''}
+          value={String(localization?.description ?? '')}
           onChange={(value) => onChange?.('localization', {
             ...localization,
             description: value

--- a/frontend/src/components/notifications/EmailSMSManager.tsx
+++ b/frontend/src/components/notifications/EmailSMSManager.tsx
@@ -339,7 +339,13 @@ const EmailSMSManager = () => {
     );
   };
 
-  const renderStatCard = ({ title, value, detail, icon: Icon, tone = 'blue' }: any) => {
+  const renderStatCard = ({ title, value, detail, icon: Icon, tone = 'blue' }: {
+    title: string;
+    value: unknown;
+    detail?: string;
+    icon: import('lucide-react').LucideIcon;
+    tone?: 'blue' | 'green' | 'red' | 'orange' | string;
+  }) => {
     const toneColor = {
       blue: 'var(--mac-accent-blue)',
       green: 'var(--mac-success)',
@@ -353,7 +359,7 @@ const EmailSMSManager = () => {
           <div>
             <p style={{ margin: 0, color: 'var(--mac-text-secondary)', fontSize: 'var(--mac-font-size-sm)', fontWeight: 'var(--mac-font-weight-semibold)' }}>{title}</p>
             <strong style={{ display: 'block', marginTop: 'var(--mac-spacing-2)', fontSize: '26px', color: 'var(--mac-text-primary)' }}>
-              {value}
+              {String(value ?? '')}
             </strong>
             {detail && (
               <span style={{ display: 'block', marginTop: 'var(--mac-spacing-1)', color: toneColor, fontSize: 'var(--mac-font-size-xs)' }}>

--- a/frontend/src/components/queue/ModernQueueManager.tsx
+++ b/frontend/src/components/queue/ModernQueueManager.tsx
@@ -25,6 +25,45 @@ import QueueTable from './QueueTable';
 import logger from '../../utils/logger';
 import './ModernQueueManager.css';
 
+// === Domain types ===
+// ModernQueueManager is a registrar/queue-management surface.
+// The parent owns the date + doctor selection; ModernQueueManager
+// receives them as controlled props and emits change events.
+// Doctors shape is dynamic (backend-driven), so it rides via index sig.
+
+export interface ModernQueueManagerDoctor {
+  id: string | number;
+  full_name?: string;
+  name?: string;
+  specialty?: string;
+  specialty_display?: string;
+  department?: string;
+  cabinet?: string | number;
+  [key: string]: unknown;
+}
+
+export interface ModernQueueManagerProps {
+  /** Currently selected date (YYYY-MM-DD). */
+  selectedDate?: string;
+  /** Currently selected doctor id. */
+  selectedDoctor?: string | number;
+  /** Called when the queue snapshot needs to be reloaded. */
+  onQueueUpdate?: () => void | Promise<void>;
+  /** Active UI language. */
+  language?: string;
+  /** Doctor lookup array (passed from parent). */
+  doctors?: ModernQueueManagerDoctor[];
+  /** Called when the user changes the doctor selection. */
+  onDoctorChange?: (doctorId: string) => void;
+  /** Called when the user changes the date. */
+  onDateChange?: (date: string) => void;
+  /** Optional UI theme override. */
+  theme?: string;
+  /** Optional search query (observed in QueueView caller). */
+  searchQuery?: string;
+  [key: string]: unknown;
+}
+
 const ModernQueueManager = ({
   selectedDate = getLocalDateString(),
   selectedDoctor = '',
@@ -33,7 +72,7 @@ const ModernQueueManager = ({
   doctors = [],
   onDoctorChange,
   onDateChange
-}: any) => {
+}: ModernQueueManagerProps) => {
   const {
     loading,
     queueData,
@@ -129,7 +168,7 @@ const ModernQueueManager = ({
   // При получении queue_update события — перезагружаем snapshot очереди.
   // Polling выше остаётся как fallback (60s).
   const { isConnected: wsConnected, connectionState: wsState } = useQueueWebSocket({
-    specialistId: effectiveDoctor,
+    specialistId: String(effectiveDoctor ?? ''),
     date: effectiveDate,
     enabled: Boolean(effectiveDoctor && effectiveDate),
     onUpdate: loadQueue,
@@ -611,7 +650,7 @@ const ModernQueueManager = ({
 
           <QueueTable
             queueData={queueData}
-            effectiveDoctor={effectiveDoctor}
+            effectiveDoctor={String(effectiveDoctor ?? '')}
             onGenerateQR={generateQR}
             loading={loading}
             t={queueTableT} />

--- a/frontend/src/components/queue/QueueTable.tsx
+++ b/frontend/src/components/queue/QueueTable.tsx
@@ -8,6 +8,64 @@ import { formatRegistrarTime } from '../../utils/dateUtils';
 import './QueueTable.css';
 import { useTranslation } from '../../i18n/useTranslation';
 
+// === Domain types ===
+// QueueTable is a pure display component driven by ModernQueueManager.
+// It receives a pre-translated strings object (queueTableT) plus the
+// queue snapshot and the effective doctor selection.
+
+export interface QueueTableEntry {
+  id?: string | number;
+  patient_name?: string;
+  name?: string;
+  patient_phone?: string;
+  phone?: string;
+  queue_number?: number | string;
+  number?: number | string;
+  queue_time?: string;
+  created_at?: string;
+  timestamp?: string;
+  status?: string;
+  source?: string;
+  source_kind?: string;
+  [key: string]: unknown;
+}
+
+export interface QueueTableData {
+  entries?: QueueTableEntry[];
+  is_open?: boolean;
+  [key: string]: unknown;
+}
+
+export interface QueueTableDoctor {
+  id?: string | number;
+  full_name?: string;
+  name?: string;
+  specialty?: string;
+  [key: string]: unknown;
+}
+
+export interface QueueTableT {
+  selectDoctor?: string;
+  patient?: string;
+  phone?: string;
+  time?: string;
+  status?: string;
+  actions?: string;
+  called?: string;
+  queueEmpty?: string;
+  queueNotFound?: string;
+  [key: string]: unknown;
+}
+
+export interface QueueTableProps {
+  queueData?: QueueTableData | null;
+  effectiveDoctor?: QueueTableDoctor | string | null;
+  loading?: boolean;
+  /** Pre-translated strings object (built by ModernQueueManager). */
+  t?: QueueTableT;
+  [key: string]: unknown;
+}
+
 /**
  * QueueTable Component
  * Displays the current queue entries in a table format
@@ -17,7 +75,7 @@ const QueueTable = ({
     effectiveDoctor = null,
     loading = false,
     t = {}
-}: any) => {
+}: QueueTableProps) => {
     // If no queue data or no doctor selected
     if (!effectiveDoctor) {
         return (

--- a/scripts/type-debt-baseline.json
+++ b/scripts/type-debt-baseline.json
@@ -1,5 +1,5 @@
 {
-  "anyCasts": 12,
+  "anyCasts": 8,
   "tsIgnore": 0,
   "tsNoCheck": 0,
   "indexSignatureAny": 0

--- a/scripts/type-debt-baseline.json
+++ b/scripts/type-debt-baseline.json
@@ -1,5 +1,5 @@
 {
-  "anyCasts": 18,
+  "anyCasts": 12,
   "tsIgnore": 0,
   "tsNoCheck": 0,
   "indexSignatureAny": 0

--- a/scripts/type-debt-check.mjs
+++ b/scripts/type-debt-check.mjs
@@ -26,7 +26,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const FRONTEND_DIR = resolve(__dirname, '..', 'frontend', 'src');
 
 const BASELINE = {
-  anyCasts: 18,
+  anyCasts: 12,
   tsIgnore: 0,
   tsNoCheck: 0,
   indexSignatureAny: 0,

--- a/scripts/type-debt-check.mjs
+++ b/scripts/type-debt-check.mjs
@@ -26,7 +26,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const FRONTEND_DIR = resolve(__dirname, '..', 'frontend', 'src');
 
 const BASELINE = {
-  anyCasts: 12,
+  anyCasts: 8,
   tsIgnore: 0,
   tsNoCheck: 0,
   indexSignatureAny: 0,


### PR DESCRIPTION
## Summary

- Follow-up to PR #2450. Recovers Props contracts for all 10 remaining Generic-domain components identified in the F3-0 caller inventory.
- 2 commits: F3-3a (6 zero-conflict components) + F3-3b/c/d/e (4 components with conflicts).
- Debt: 18 → 8 `any` casts (-10). All callers compile without new casts.

## Cyclic Execution Evidence

- Fresh main sync: branch `phase-f3-3-generic-domain` created from current `origin/main` after PR #2450 merge (commit b735802d)
- Clean workspace: inspected before each commit; only scoped Props-interface files + caller call-site casts changed
- Branch: `phase-f3-3-generic-domain`
- Scope gate: allowed 10 Generic-domain component Props interfaces + 2 caller call-site casts (TreatmentSection, DermatologySection); denied Sprint F4 (Form.tsx), backend changes, test changes
- Red-check handling: every change verified with `npx tsc --noEmit` and `npx eslint src/` locally before push; failed checks fixed in same commit

## Contract Impact

- Canonical surface: 10 component Props interfaces + 11 domain types (`PhoneVerificationProps`, `DentalPatientsTabProps`, `DoctorServiceSelectorProps`, `QueueTableProps` (5 sub-types), `ComplaintsFieldProps`, `ModernQueueManagerProps`, `PrescriptionEditorProps`, `EMRSmartFieldV2Props`, `TableProps` + `TableColumn`)
- Request shape: not applicable - no API request shapes modified (type-only refactor)
- Response shape: not applicable - no API response shapes modified; new domain interfaces describe existing shapes
- Status codes: not applicable - no HTTP status code handling changed (type-only refactor)
- Frontend consumer: 10 components migrated; all callers compile without new casts. Notable: Table has 19 callers (largest surface) — TableColumn interface permissive enough to accept all 11 observed column-shape variants
- Compatibility path or alias: all Props interfaces include `[key: string]: unknown` index signature, so existing callers passing extra fields continue to compile
- Contract proof: F3-0 caller inventory (`docs/f3-0-caller-inventory.md`) identified all conflicts; local `tsc --noEmit` (0 errors) + local `eslint` (0 errors) confirm resolution

## RBAC / Permissions

- Roles allowed: not applicable - this PR is type-only, no auth logic touched
- Roles denied: not applicable - no role checks modified by this type-only refactor
- Positive auth proof: not applicable - no auth code paths changed; type-only refactor
- Negative auth proof: not applicable - no auth code paths changed; type-only refactor

## Notification / Realtime

- Event type or websocket channel: not applicable - no WebSocket event types or channels changed; ModernQueueManager typing only tightens existing types
- Payload version / ack behavior: not applicable - no message payload versions or ack semantics changed
- Read/unread or delivery semantics: not applicable - no read/unread or delivery logic changed
- Reconnect/resync proof: not applicable - no reconnect or resync logic changed; useQueueWebSocket signature unchanged

## Frontend Resilience

- Empty data proof: all defaults preserved (`data = []`, `patients = []`, `prescriptions = []`, `suggestions = []`, `selectedServices = []`); empty arrays render stable empty states
- Partial data proof: all domain interfaces use optional fields (`?`) and index signatures, so missing optional fields fall back to defaults without crashing. Table row[column.key] uses `String(... ?? '')` to safely render unknown values.
- Forbidden secondary path behavior: not applicable - no secondary path used; components render the same JSX they did before
- Missing draft/resource behavior: not applicable - no draft or resource creation logic in scope; all 10 components are display/edit components without lifecycle side effects
- Stale route/deep-link behavior: not applicable - no route or deep-link state read by any of the 10 migrated components

## Scope Gate

- Allowed paths: 10 component Props interfaces, 2 caller call-site casts (TreatmentSection, DermatologySection), type-debt baseline
- Denied paths: Sprint F4 (Form.tsx), backend changes, test changes, QueueView/QueueIntegration caller changes (those callers already passed compatible types)
- Migration/docs/test impact: no migration; no new docs; no test changes (type-only refactor)
- Rollback note: revert commits `d0dce6a9` + `9788a98a` on `phase-f3-3-generic-domain`; baseline will return to 18 `any` casts (CI debt gate will then enforce 18)

## Validation

- Targeted tests or smoke run: `npx tsc --noEmit` (0 errors), `npx eslint src/` (0 errors, 4025 pre-existing warnings), `node scripts/type-debt-check.mjs` (baseline=8, delta=0)
- Result: passed locally
- Not checked: full browser panel smoke — recommended for manual verification before merge

---

### Commits (2)

| # | Commit | Sprint | Debt change |
|---|--------|--------|-------------|
| 1 | `d0dce6a9` | F3-3a | 18→12 — 6 zero-conflict components |
| 2 | `9788a98a` | F3-3b/c/d/e | 12→8 — 4 conflict components |

### Components migrated (10)

| Component | Conflict | Resolution |
|-----------|----------|------------|
| PhoneVerification | 0 | PhoneVerificationProps (onVerified takes object) |
| DentalPatientsTab | 0 | DentalPatientsTabProps + Patient |
| DoctorServiceSelector | 0 | DoctorServiceSelectorProps + DoctorServiceItem |
| renderStatCard (EmailSMSManager helper) | 0 | Inline typed props |
| QueueTable | 0 | 5 interfaces (Entry/Data/Doctor/T/Props) |
| ComplaintsField | 0 | ComplaintsFieldProps + Suggestion |
| ModernQueueManager | 2 | ModernQueueManagerProps + Doctor (id required) |
| PrescriptionEditor | 2 | PrescriptionEditorProps + Item; caller cast |
| EMRSmartFieldV2 | 6 | EMRSmartFieldV2Props + Suggestion; canonical onChange/onRequestAI |
| Table | 7 (11 column variants) | TableColumn + TableProps; data: Record<string, unknown>[] |

### CI debt gate

Baseline updated: `18 → 8` `any` casts. Future PRs cannot increase the baseline.

### Remaining 8 casts (planned for follow-up PRs)

- 4 in `components/common/Form.tsx` — Sprint F4 (FormContextValue)
- 2 in `types/react-i18next-override.d.ts` — TECH-DEBT(i18n-001) documented
- 1 in `components/integration/IntegrationDemo.tsx` — TECH-DEBT(integration-demo-001) documented
- 1 in `utils/navigationReact.ts` JSDoc — documentation only