### PR TITLE
G1-C: AppDataContext Contract Recovery — noImplicitAny 5316→5271 (-45)

### DIFF
--- a/frontend/src/contexts/AppDataContext.tsx
+++ b/frontend/src/contexts/AppDataContext.tsx
@@ -1,12 +1,25 @@
 import { createContext, useContext, useReducer, useCallback } from 'react';
+import type { ReactNode } from 'react';
 import PropTypes from 'prop-types';
+import type {
+  AppDataState,
+  AppDataAction,
+  AppDataContextValue,
+  AppUser,
+  AppPatient,
+  AppAppointment,
+  AppQueueData,
+  AppQueueEntry,
+  AppEMRData,
+  AppLabResult,
+} from '../types/domain/appData';
 /**
  * Контекст для управления глобальным состоянием приложения
  * Оптимизирует передачу данных между компонентами
  */
 
 // Начальное состояние
-const initialState = {
+const initialState: AppDataState = {
   // Пользователи и роли
   users: [],
   currentUser: null,
@@ -75,10 +88,10 @@ const ActionTypes = {
   SET_LOADING: 'SET_LOADING',
   SET_ERROR: 'SET_ERROR',
   CLEAR_ERROR: 'CLEAR_ERROR'
-};
+} as const;
 
 // Reducer для управления состоянием
-function appDataReducer(state, action) {
+function appDataReducer(state: AppDataState, action: AppDataAction): AppDataState {
   switch (action.type) {
     // Пользователи
     case ActionTypes.SET_USERS:
@@ -257,102 +270,102 @@ function appDataReducer(state, action) {
 }
 
 // Создаем контекст
-const AppDataContext = createContext<unknown>(null);
+const AppDataContext = createContext<AppDataContextValue | null>(null);
 
 // Провайдер контекста
-export const AppDataProvider = ({ children }) => {
+export const AppDataProvider = ({ children }: { children: ReactNode }) => {
   const [state, dispatch] = useReducer(appDataReducer, initialState);
 
   // Action creators
   const actions = {
     // Пользователи
-    setUsers: useCallback((users) => {
+    setUsers: useCallback((users: AppUser[]) => {
       dispatch({ type: ActionTypes.SET_USERS, payload: users });
     }, []),
     
-    setCurrentUser: useCallback((user) => {
+    setCurrentUser: useCallback((user: AppUser) => {
       dispatch({ type: ActionTypes.SET_CURRENT_USER, payload: user });
     }, []),
     
-    addUser: useCallback((user) => {
+    addUser: useCallback((user: AppUser) => {
       dispatch({ type: ActionTypes.ADD_USER, payload: user });
     }, []),
     
-    updateUser: useCallback((user) => {
+    updateUser: useCallback((user: AppUser) => {
       dispatch({ type: ActionTypes.UPDATE_USER, payload: user });
     }, []),
     
-    deleteUser: useCallback((userId) => {
+    deleteUser: useCallback((userId: string | number) => {
       dispatch({ type: ActionTypes.DELETE_USER, payload: userId });
     }, []),
 
     // Пациенты
-    setPatients: useCallback((patients) => {
+    setPatients: useCallback((patients: AppPatient[]) => {
       dispatch({ type: ActionTypes.SET_PATIENTS, payload: patients });
     }, []),
     
-    setSelectedPatient: useCallback((patient) => {
+    setSelectedPatient: useCallback((patient: AppPatient) => {
       dispatch({ type: ActionTypes.SET_SELECTED_PATIENT, payload: patient });
     }, []),
     
-    addPatient: useCallback((patient) => {
+    addPatient: useCallback((patient: AppPatient) => {
       dispatch({ type: ActionTypes.ADD_PATIENT, payload: patient });
     }, []),
     
-    updatePatient: useCallback((patient) => {
+    updatePatient: useCallback((patient: AppPatient) => {
       dispatch({ type: ActionTypes.UPDATE_PATIENT, payload: patient });
     }, []),
 
     // Записи
-    setAppointments: useCallback((appointments) => {
+    setAppointments: useCallback((appointments: AppAppointment[]) => {
       dispatch({ type: ActionTypes.SET_APPOINTMENTS, payload: appointments });
     }, []),
     
-    addAppointment: useCallback((appointment) => {
+    addAppointment: useCallback((appointment: AppAppointment) => {
       dispatch({ type: ActionTypes.ADD_APPOINTMENT, payload: appointment });
     }, []),
     
-    updateAppointment: useCallback((appointment) => {
+    updateAppointment: useCallback((appointment: AppAppointment) => {
       dispatch({ type: ActionTypes.UPDATE_APPOINTMENT, payload: appointment });
     }, []),
 
     // Очередь
-    setQueueData: useCallback((queueData) => {
+    setQueueData: useCallback((queueData: AppQueueData | null) => {
       dispatch({ type: ActionTypes.SET_QUEUE_DATA, payload: queueData });
     }, []),
     
-    updateQueueEntry: useCallback((entry) => {
+    updateQueueEntry: useCallback((entry: AppQueueEntry) => {
       dispatch({ type: ActionTypes.UPDATE_QUEUE_ENTRY, payload: entry });
     }, []),
 
     // EMR
-    setEMRData: useCallback((emrData) => {
+    setEMRData: useCallback((emrData: AppEMRData | null) => {
       dispatch({ type: ActionTypes.SET_EMR_DATA, payload: emrData });
     }, []),
     
-    updateEMRField: useCallback((field, value) => {
+    updateEMRField: useCallback((field: string, value: unknown) => {
       dispatch({ type: ActionTypes.UPDATE_EMR_FIELD, payload: { field, value } });
     }, []),
 
     // Лабораторные результаты
-    setLabResults: useCallback((results) => {
+    setLabResults: useCallback((results: AppLabResult[]) => {
       dispatch({ type: ActionTypes.SET_LAB_RESULTS, payload: results });
     }, []),
     
-    addLabResult: useCallback((result) => {
+    addLabResult: useCallback((result: AppLabResult) => {
       dispatch({ type: ActionTypes.ADD_LAB_RESULT, payload: result });
     }, []),
 
     // Утилиты
-    setLoading: useCallback((key, value) => {
+    setLoading: useCallback((key: string, value: boolean) => {
       dispatch({ type: ActionTypes.SET_LOADING, payload: { key, value } });
     }, []),
     
-    setError: useCallback((key, error) => {
+    setError: useCallback((key: string, error: string | null) => {
       dispatch({ type: ActionTypes.SET_ERROR, payload: { key, error } });
     }, []),
     
-    clearError: useCallback((key) => {
+    clearError: useCallback((key: string) => {
       dispatch({ type: ActionTypes.CLEAR_ERROR, payload: key });
     }, [])
   };
@@ -376,7 +389,7 @@ AppDataProvider.propTypes = {
 };
 
 // Хук для использования контекста
-export const useAppData = () => {
+export const useAppData = (): AppDataContextValue => {
   const context = useContext(AppDataContext);
   if (!context) {
     throw new Error('useAppData must be used within an AppDataProvider');
@@ -385,7 +398,7 @@ export const useAppData = () => {
 };
 
 // Селекторы для оптимизации производительности
-export const useAppDataSelector = (selector) => {
+export const useAppDataSelector = <T,>(selector: (context: AppDataContextValue) => T): T => {
   const context = useAppData();
   return selector(context);
 };

--- a/frontend/src/types/domain/appData.ts
+++ b/frontend/src/types/domain/appData.ts
@@ -1,0 +1,131 @@
+/**
+ * Domain types for the AppData context.
+ *
+ * These are intentionally permissive — each entity uses an index signature
+ * for backend-driven dynamic fields, with canonical fields typed explicitly.
+ * As the strict-mode migration progresses, these can be tightened.
+ */
+
+export interface AppUser {
+  id: string | number;
+  name?: string;
+  full_name?: string;
+  email?: string;
+  role?: string;
+  [key: string]: unknown;
+}
+
+export interface AppPatient {
+  id: string | number;
+  name?: string;
+  full_name?: string;
+  phone?: string;
+  [key: string]: unknown;
+}
+
+export interface AppAppointment {
+  id: string | number;
+  patient_id?: string | number;
+  doctor_id?: string | number;
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface AppQueueEntry {
+  id: string | number;
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface AppQueueData {
+  entries: AppQueueEntry[];
+  is_open?: boolean;
+  [key: string]: unknown;
+}
+
+export interface AppEMRData {
+  [key: string]: unknown;
+}
+
+export interface AppLabResult {
+  id?: string | number;
+  [key: string]: unknown;
+}
+
+export interface AppLoadingState {
+  users: boolean;
+  patients: boolean;
+  appointments: boolean;
+  emr: boolean;
+  [key: string]: boolean;
+}
+
+export interface AppErrorsState {
+  users: string | null;
+  patients: string | null;
+  appointments: string | null;
+  emr: string | null;
+  [key: string]: string | null;
+}
+
+export interface AppDataState {
+  users: AppUser[];
+  currentUser: AppUser | null;
+  patients: AppPatient[];
+  selectedPatient: AppPatient | null;
+  appointments: AppAppointment[];
+  queueData: AppQueueData | null;
+  emrData: AppEMRData | null;
+  labResults: AppLabResult[];
+  loading: AppLoadingState;
+  errors: AppErrorsState;
+}
+
+export type AppDataAction =
+  | { type: 'SET_USERS'; payload: AppUser[] }
+  | { type: 'SET_CURRENT_USER'; payload: AppUser | null }
+  | { type: 'ADD_USER'; payload: AppUser }
+  | { type: 'UPDATE_USER'; payload: AppUser }
+  | { type: 'DELETE_USER'; payload: string | number }
+  | { type: 'SET_PATIENTS'; payload: AppPatient[] }
+  | { type: 'SET_SELECTED_PATIENT'; payload: AppPatient | null }
+  | { type: 'ADD_PATIENT'; payload: AppPatient }
+  | { type: 'UPDATE_PATIENT'; payload: AppPatient }
+  | { type: 'SET_APPOINTMENTS'; payload: AppAppointment[] }
+  | { type: 'ADD_APPOINTMENT'; payload: AppAppointment }
+  | { type: 'UPDATE_APPOINTMENT'; payload: AppAppointment }
+  | { type: 'SET_QUEUE_DATA'; payload: AppQueueData | null }
+  | { type: 'UPDATE_QUEUE_ENTRY'; payload: AppQueueEntry }
+  | { type: 'SET_EMR_DATA'; payload: AppEMRData | null }
+  | { type: 'UPDATE_EMR_FIELD'; payload: { field: string; value: unknown } }
+  | { type: 'SET_LAB_RESULTS'; payload: AppLabResult[] }
+  | { type: 'ADD_LAB_RESULT'; payload: AppLabResult }
+  | { type: 'SET_LOADING'; payload: { key: string; value: boolean } }
+  | { type: 'SET_ERROR'; payload: { key: string; error: string | null } }
+  | { type: 'CLEAR_ERROR'; payload: string };
+
+export interface AppDataContextValue extends AppDataState {
+  actions: {
+    setUsers: (users: AppUser[]) => void;
+    setCurrentUser: (user: AppUser | null) => void;
+    addUser: (user: AppUser) => void;
+    updateUser: (user: AppUser) => void;
+    deleteUser: (userId: string | number) => void;
+    setPatients: (patients: AppPatient[]) => void;
+    setSelectedPatient: (patient: AppPatient | null) => void;
+    addPatient: (patient: AppPatient) => void;
+    updatePatient: (patient: AppPatient) => void;
+    setAppointments: (appointments: AppAppointment[]) => void;
+    addAppointment: (appointment: AppAppointment) => void;
+    updateAppointment: (appointment: AppAppointment) => void;
+    setQueueData: (queueData: AppQueueData | null) => void;
+    updateQueueEntry: (entry: AppQueueEntry) => void;
+    setEMRData: (emrData: AppEMRData | null) => void;
+    updateEMRField: (field: string, value: unknown) => void;
+    setLabResults: (results: AppLabResult[]) => void;
+    addLabResult: (result: AppLabResult) => void;
+    setLoading: (key: string, value: boolean) => void;
+    setError: (key: string, error: string | null) => void;
+    clearError: (key: string) => void;
+  };
+}

--- a/scripts/strict-baseline.json
+++ b/scripts/strict-baseline.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-07-23",
+  "generatedAt": "2026-07-24",
   "description": "Baseline error counts for strict-mode migration (Phase G). This file is used by scripts/strict-baseline-check.mjs to prevent regression — new code must not increase the error count above these baselines.",
   "flags": {
     "noImplicitAny": {
-      "totalErrors": 5316,
+      "totalErrors": 5271,
       "topErrorCodes": {
         "TS7006": 3207,
         "TS7031": 943,


### PR DESCRIPTION
## Summary

- Contract Recovery for AppDataContext — the highest cascade-priority context (56 errors → 0 in this file, -45 total noImplicitAny).
- Created `src/types/domain/appData.ts` with 12 domain types (AppUser, AppPatient, AppDataState, AppDataAction, AppDataContextValue, etc.).
- Key insight: `as const` on ActionTypes was the critical missing piece for discriminated union narrowing.

## Cyclic Execution Evidence

- Fresh main sync: branch `phase-g1c-contexts` created from current `origin/main` after PR #2461 merge (commit 60bd5f90)
- Clean workspace: 3 files changed (1 new domain types file, 1 context file, 1 baseline JSON)
- Branch: `phase-g1c-contexts`
- Scope gate: allowed AppDataContext typing + domain types creation; denied other contexts (next batch), tsconfig changes
- Red-check handling: first attempt failed with 45 TS2322 errors (union type not narrowed); fixed by adding `as const` to ActionTypes constant, which enables discriminated union narrowing in switch cases

## Contract Impact

- Canonical surface: `src/types/domain/appData.ts` (new — 12 exported domain types), `src/contexts/AppDataContext.tsx` (typed reducer, action creators, hooks)
- Request shape: not applicable - no API request shapes modified
- Response shape: not applicable - no API response shapes modified
- Status codes: not applicable - no HTTP status code handling changed
- Frontend consumer: AppDataContext now has typed State, Action, and ContextValue. All 21 action creators have specific domain types. useAppData() returns AppDataContextValue (was unknown). useAppDataSelector<T>() is now generic.
- Compatibility path or alias: not applicable - type annotations are additive, runtime behavior unchanged. `as const` on ActionTypes is compile-time only.
- Contract proof: local `npx tsc --noEmit` (0 errors) + `node scripts/type-debt-check.mjs` (baseline=0) + `node scripts/strict-baseline-check.mjs` (noImplicitAny=5271 delta=0)

## RBAC / Permissions

- Roles allowed: not applicable - type-only changes, no auth logic touched
- Roles denied: not applicable - no role checks modified by type-only refactor
- Positive auth proof: not applicable - no auth code paths changed; type-only refactor
- Negative auth proof: not applicable - no auth code paths changed; type-only refactor

## Notification / Realtime

- Event type or websocket channel: not applicable - no WebSocket event types or channels changed
- Payload version / ack behavior: not applicable - no message payload versions or ack semantics changed
- Read/unread or delivery semantics: not applicable - no read/unread or delivery logic changed
- Reconnect/resync proof: not applicable - no reconnect or resync logic changed

## Frontend Resilience

- Empty data proof: not applicable - no runtime behavior change (type annotations are compile-time only); initialState unchanged
- Partial data proof: not applicable - no frontend rendering changes; type annotations are compile-time only. Domain interfaces use optional fields + index signatures for backend extensibility.
- Forbidden secondary path behavior: not applicable - no secondary path used; type annotations are additive
- Missing draft/resource behavior: not applicable - no draft or resource creation logic in scope
- Stale route/deep-link behavior: not applicable - no route or deep-link state read by context

## Scope Gate

- Allowed paths: src/types/domain/appData.ts (new), src/contexts/AppDataContext.tsx (typed), scripts/strict-baseline.json (updated)
- Denied paths: tsconfig.json changes, other contexts (next batch), hooks (next batch), test changes, backend changes
- Migration/docs/test impact: new domain types file; strict-baseline.json updated (noImplicitAny 5316→5271); no migration; no test changes
- Rollback note: revert commit on phase-g1c-contexts; baseline returns to 5316

## Validation

- Targeted tests or smoke run: `npx tsc --noEmit` (0 errors), `node scripts/type-debt-check.mjs` (baseline=0), `node scripts/strict-baseline-check.mjs` (noImplicitAny=5271 delta=0)
- Result: passed locally
- Not checked: full browser smoke — verify AppDataContext consumers still work (users, patients, appointments, queue, EMR, lab results)

---

### What changed

**New file: `src/types/domain/appData.ts`** — 12 domain types:
- Entity types: AppUser, AppPatient, AppAppointment, AppQueueEntry, AppQueueData, AppEMRData, AppLabResult
- State types: AppLoadingState, AppErrorsState, AppDataState
- Action type: AppDataAction (discriminated union of 21 action types)
- Context type: AppDataContextValue (state + typed actions object)

**Modified: `src/contexts/AppDataContext.tsx`**:
- Typed `initialState` as `AppDataState`
- Typed reducer as `(state: AppDataState, action: AppDataAction) => AppDataState`
- Added `as const` to `ActionTypes` constant — enables discriminated union narrowing in switch cases
- Typed context as `AppDataContextValue | null`
- Typed provider props as `{ children: ReactNode }`
- Typed all 21 action creators with specific domain types
- Typed `useAppData()` return as `AppDataContextValue`
- Typed `useAppDataSelector<T>()` with generic selector

### Key insight: `as const` on ActionTypes

Without `as const`, `ActionTypes.SET_USERS` has type `string` (not `'SET_USERS'`), so TypeScript can't narrow the `AppDataAction` union in switch cases. With `as const`, each value becomes a string literal, enabling full discriminated union narrowing. This single change eliminated ALL 45 errors.

### Cumulative G1 progress

| Step | noImplicitAny | Delta |
|------|---------------|-------|
| Baseline | 5,417 | — |
| G1-A (event handlers) | 5,406 | -11 |
| G1-B (api/ partial) | 5,322 | -84 |
| G1-B2 (hooks/ partial) | 5,316 | -6 |
| G1-C (AppDataContext) | 5,271 | -45 |
| **Total** | **5,271** | **-146 (-2.7%)** |

G1-A milestone target: ≤4,500 (need ~771 more).

This confirms the user's prediction: typing contexts/ reducers with proper State/Action interfaces has the highest cascade ROI — 45 errors eliminated in a single file, vs 6 errors in 4 hooks files (G1-B2).