### PR TITLE
G1-G: Type forms/index.ts validators + utils (33 params) — noImplicitAny 5198→5163 (-35)

### DIFF
--- a/frontend/src/components/forms/index.ts
+++ b/frontend/src/components/forms/index.ts
@@ -6,73 +6,73 @@ export { default as ModernForm, FormGroup, FormRow, FormColumn } from './ModernF
 
 // Валидаторы
 export const validators = {
-  required: (message = 'Поле обязательно для заполнения') => (value) => {
+  required: (message: string = 'Поле обязательно для заполнения') => (value: string) => {
     if (!value || (typeof value === 'string' && !value.trim())) {
       return message;
     }
     return true;
   },
 
-  email: (message = 'Введите корректный email') => (value) => {
+  email: (message: string = 'Введите корректный email') => (value: string) => {
     if (!value) return true;
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(value) ? true : message;
   },
 
-  phone: (message = 'Введите корректный номер телефона') => (value) => {
+  phone: (message: string = 'Введите корректный номер телефона') => (value: string) => {
     if (!value) return true;
     const phoneRegex = /^\+?[\d\s-()]{10,}$/;
     return phoneRegex.test(value) ? true : message;
   },
 
-  minLength: (min, message) => (value) => {
+  minLength: (min: number, message?: string) => (value: string) => {
     if (!value) return true;
     const actualMessage = message || `Минимум ${min} символов`;
     return value.length >= min ? true : actualMessage;
   },
 
-  maxLength: (max, message) => (value) => {
+  maxLength: (max: number, message?: string) => (value: string) => {
     if (!value) return true;
     const actualMessage = message || `Максимум ${max} символов`;
     return value.length <= max ? true : actualMessage;
   },
 
-  pattern: (regex, message = 'Неверный формат') => (value) => {
+  pattern: (regex: RegExp, message: string = 'Неверный формат') => (value: string) => {
     if (!value) return true;
     return regex.test(value) ? true : message;
   },
 
-  numeric: (message = 'Только цифры') => (value) => {
+  numeric: (message: string = 'Только цифры') => (value: string) => {
     if (!value) return true;
     return /^\d+$/.test(value) ? true : message;
   },
 
-  alphanumeric: (message = 'Только буквы и цифры') => (value) => {
+  alphanumeric: (message: string = 'Только буквы и цифры') => (value: string) => {
     if (!value) return true;
     return /^[a-zA-Zа-яА-Я0-9]+$/.test(value) ? true : message;
   },
 
-  min: (min, message) => (value) => {
+  min: (min: number, message?: string) => (value: string) => {
     if (!value) return true;
     const num = parseFloat(value);
     const actualMessage = message || `Минимальное значение: ${min}`;
     return num >= min ? true : actualMessage;
   },
 
-  max: (max, message) => (value) => {
+  max: (max: number, message?: string) => (value: string) => {
     if (!value) return true;
     const num = parseFloat(value);
     const actualMessage = message || `Максимальное значение: ${max}`;
     return num <= max ? true : actualMessage;
   },
 
-  match: (fieldName, message) => (value, allValues) => {
+  match: (fieldName: string, message?: string) => (value: unknown, allValues: Record<string, unknown>) => {
     if (!value) return true;
     const actualMessage = message || 'Поля не совпадают';
     return value === allValues[fieldName] ? true : actualMessage;
   },
 
-  custom: (validator, message = 'Неверное значение') => (value, allValues) => {
+  custom: (validator: (value: unknown, allValues: Record<string, unknown>) => boolean | string, message: string = 'Неверное значение') => (value: unknown, allValues: Record<string, unknown>) => {
     const result = validator(value, allValues);
     return result === true ? true : (typeof result === 'string' ? result : message);
   }
@@ -81,7 +81,7 @@ export const validators = {
 // Утилиты для работы с формами
 export const formUtils = {
   // Создание начальных значений из схемы
-  createInitialValues: (schema, defaultValues = {}) => {
+  createInitialValues: (schema: Record<string, unknown>, defaultValues: Record<string, unknown> = {}) => {
     const initialValues = { ...defaultValues };
     
     Object.keys(schema).forEach(fieldName => {
@@ -94,7 +94,7 @@ export const formUtils = {
   },
 
   // Очистка значений формы
-  clearForm: (schema) => {
+  clearForm: (schema: Record<string, unknown>) => {
     const clearedValues = {};
     
     Object.keys(schema).forEach(fieldName => {
@@ -105,12 +105,12 @@ export const formUtils = {
   },
 
   // Проверка изменений в форме
-  hasChanges: (currentValues, initialValues) => {
+  hasChanges: (currentValues: Record<string, unknown>, initialValues: Record<string, unknown>) => {
     return JSON.stringify(currentValues) !== JSON.stringify(initialValues);
   },
 
   // Получение только измененных полей
-  getChangedFields: (currentValues, initialValues) => {
+  getChangedFields: (currentValues: Record<string, unknown>, initialValues: Record<string, unknown>) => {
     const changes = {};
     
     Object.keys(currentValues).forEach(key => {
@@ -123,7 +123,7 @@ export const formUtils = {
   },
 
   // Форматирование данных для отправки
-  formatForSubmission: (values, formatters = {}) => {
+  formatForSubmission: (values: Record<string, unknown>, formatters: Record<string, (value: unknown) => unknown> = {}) => {
     const formatted = { ...values };
     
     Object.keys(formatters).forEach(fieldName => {

--- a/scripts/strict-baseline.json
+++ b/scripts/strict-baseline.json
@@ -3,7 +3,7 @@
   "description": "Baseline error counts for strict-mode migration (Phase G). This file is used by scripts/strict-baseline-check.mjs to prevent regression — new code must not increase the error count above these baselines.",
   "flags": {
     "noImplicitAny": {
-      "totalErrors": 5198,
+      "totalErrors": 5163,
       "topErrorCodes": {
         "TS7006": 3207,
         "TS7031": 943,


### PR DESCRIPTION
## Summary

- G1-G: typed 33 function parameters in forms/index.ts (validators + formUtils).
- Strict baseline: noImplicitAny 5,198 → 5,163 (-35). Biggest single-file reduction since G1-C (-45).
- Cumulative G1: 5,417 → 5,163 (-254, 4.7%).

## Cyclic Execution Evidence

- Fresh main sync: branch `phase-g1g-forms-index` created from origin/main after PR #2467 merge
- Clean workspace: 2 files changed (forms/index.ts + baseline JSON)
- Branch: `phase-g1g-forms-index`
- Scope gate: allowed forms/index.ts parameter typing; denied tsconfig changes, other files, test changes
- Red-check handling: all parameters typed in one pass — validators are well-understood patterns, no downstream errors

## Contract Impact

- Canonical surface: src/components/forms/index.ts (33 params typed across 12 validators + 5 formUtils functions)
- Request shape: not applicable - no API request shapes modified
- Response shape: not applicable - no API response shapes modified
- Status codes: not applicable - no HTTP status code handling changed
- Frontend consumer: 33 function parameters now explicitly typed. No runtime behavior change.
- Compatibility path or alias: not applicable - type annotations are additive, no existing functionality removed
- Contract proof: local npx tsc --noEmit (0 errors) + node scripts/type-debt-check.mjs (baseline=0) + node scripts/strict-baseline-check.mjs (noImplicitAny=5163 delta=0)

## RBAC / Permissions

- Roles allowed: not applicable - type-only changes, no auth logic touched
- Roles denied: not applicable - no role checks modified by type-only refactor
- Positive auth proof: not applicable - no auth code paths changed; type-only refactor
- Negative auth proof: not applicable - no auth code paths changed; type-only refactor

## Notification / Realtime

- Event type or websocket channel: not applicable - no WebSocket event types or channels changed
- Payload version / ack behavior: not applicable - no message payload versions or ack semantics changed
- Read/unread or delivery semantics: not applicable - no read/unread or delivery logic changed
- Reconnect/resync proof: not applicable - no reconnect or resync logic changed

## Frontend Resilience

- Empty data proof: not applicable - no runtime behavior change (type annotations are compile-time only)
- Partial data proof: not applicable - no frontend rendering changes; type annotations are compile-time only
- Forbidden secondary path behavior: not applicable - no secondary path used; type annotations are additive
- Missing draft/resource behavior: not applicable - no draft or resource creation logic in scope
- Stale route/deep-link behavior: not applicable - no route or deep-link state read by forms

## Scope Gate

- Allowed paths: components/forms/index.ts, scripts/strict-baseline.json
- Denied paths: tsconfig.json changes, other files, test changes, backend changes
- Migration/docs/test impact: strict-baseline.json updated; no migration; no test changes
- Rollback note: revert commit on phase-g1g-forms-index; baseline returns to 5198

## Validation

- Targeted tests or smoke run: npx tsc --noEmit (0 errors), node scripts/type-debt-check.mjs (baseline=0), node scripts/strict-baseline-check.mjs (noImplicitAny=5163 delta=0)
- Result: passed locally
- Not checked: full browser smoke

---

### Cumulative G1 progress

| Step | noImplicitAny | Delta | Domain types |
|------|---------------|-------|--------------|
| Baseline | 5,417 | — | 0 |
| G1-A | 5,406 | -11 | 0 |
| G1-B | 5,322 | -84 | 0 |
| G1-B2 | 5,316 | -6 | 0 |
| G1-C | 5,271 | -45 | 12 |
| G1-C2 | 5,254 | -17 | 12 |
| G1-C3 | 5,237 | -17 | 12 |
| G1-D | 5,217 | -20 | 20 |
| G1-E | 5,203 | -14 | 27 |
| G1-F | 5,198 | -5 | 27 |
| G1-G | 5,163 | -35 | 27 |
| **Total** | **5,163** | **-254 (-4.7%)** | **27** |