### PR TITLE
audit/phase-2: security — PHI leaks, auth, XSS, Sentry scrubbing (BS-29,32,33,37,38,52,53,57)

### DIFF
--- a/frontend/src/components/chat/ChatWindow.tsx
+++ b/frontend/src/components/chat/ChatWindow.tsx
@@ -23,6 +23,12 @@ import FileUploader from './FileUploader';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useToast } from '../../components/common/Toast';
 import logger from '../../utils/logger';
+// audit/phase-2, BS-53: import sanitizeURL to filter `javascript:` and other
+// dangerous protocols from chat message `content` before using it as
+// `<img src>`, `<a href>`, or `window.open()` argument. ReactMarkdown already
+// has its own URL filter (urlTransform) — this import covers the image/file
+// branches which were previously unprotected.
+import { sanitizeURL } from '../../utils/sanitizer';
 import './Chat.css';
 import { Input } from '../ui/macos';
 import { useTranslation } from '../../i18n/useTranslation';
@@ -35,6 +41,17 @@ const groupReactions = (reactions: { reaction: string; user_id: number }[] | und
     groups[r.reaction].push(r.user_id);
   });
   return groups;
+};
+
+// audit/phase-2, BS-53: helper that sanitizes chat message `content` for use
+// as a URL. Returns the safe URL string, or null if the URL is dangerous
+// (e.g., `javascript:alert(...)`, `data:text/html,...`, `vbscript:...`).
+// Callers should render a fallback (e.g., "blocked" placeholder) when null.
+// We intentionally do NOT log the rejected URL — it could itself contain
+// sensitive data the user typed into a chat message.
+const safeMessageURL = (raw: unknown): string | null => {
+  if (raw === null || raw === undefined) return null;
+  return sanitizeURL(String(raw));
 };
 
 const COMPACT_CHAT_BREAKPOINT = 768;
@@ -1104,25 +1121,60 @@ const ChatWindow = ({ isOpen, onClose }) => {
                           <>
                                                                         <div className="message-content">
                                                                             {item.message_type === 'image' ?
-                              <div className="message-image">
-                                                                                    <img
-                                  src={String(item.content ?? '')}
-                                  alt="Attached"
-                                  role="button"
-                                  tabIndex={0}
-                                  aria-label={t('misc.cw_open_image_aria')}
-                                  onClick={() => window.open(String(item.content ?? ''), '_blank')}
-                                  onKeyDown={(event: React.KeyboardEvent<HTMLElement>) => handleActivationKeyDown(event, () => window.open(String(item.content ?? ''), '_blank'))}
-                                  style={{ cursor: 'pointer', maxWidth: '100%', borderRadius: 8 }} />
-                                
-                                                                                </div> :
+                              // audit/phase-2, BS-53: sanitize `content` before
+                              // using it as <img src> or window.open() argument.
+                              // A malicious backend (or a buggy one) could store
+                              // `javascript:alert(document.cookie)` as message
+                              // content; ReactMarkdown branch below already
+                              // filters protocols, but image/file branches did not.
+                              // We compute the safe URL once and skip rendering
+                              // the click target if it's null.
+                              (() => {
+                                const safeImgUrl = safeMessageURL(item.content);
+                                if (!safeImgUrl) {
+                                  return (
+                                    <div className="message-image" aria-label={t('misc.cw_file_default')}>
+                                      <span style={{ color: 'var(--text-secondary, #888)', fontStyle: 'italic' }}>
+                                        {t('misc.cw_file_default')}
+                                      </span>
+                                    </div>
+                                  );
+                                }
+                                return (
+                                  <div className="message-image">
+                                    <img
+                                      src={safeImgUrl}
+                                      alt="Attached"
+                                      role="button"
+                                      tabIndex={0}
+                                      aria-label={t('misc.cw_open_image_aria')}
+                                      onClick={() => window.open(safeImgUrl, '_blank')}
+                                      onKeyDown={(event: React.KeyboardEvent<HTMLElement>) => handleActivationKeyDown(event, () => window.open(safeImgUrl, '_blank'))}
+                                      style={{ cursor: 'pointer', maxWidth: '100%', borderRadius: 8 }} />
+                                  </div>
+                                );
+                              })() :
                               (item.message_type === 'file' || (item.file_id && item.file_url && item.message_type !== 'voice')) ?
-                              <div className="message-file">
-                                                                                    <a href={String(item.content ?? '')} target="_blank" rel="noopener noreferrer" className="file-link">
-                                                                                        <Paperclip size={16} />
-                                                                                        <span>{String(item.content).split('name=')[1] || t('misc.cw_file_default')}</span>
-                                                                                    </a>
-                                                                                </div> :
+                              // Same BS-53 sanitization for the file <a href> branch.
+                              (() => {
+                                const safeFileUrl = safeMessageURL(item.content);
+                                if (!safeFileUrl) {
+                                  return (
+                                    <div className="message-file">
+                                      <Paperclip size={16} />
+                                      <span>{t('misc.cw_file_default')}</span>
+                                    </div>
+                                  );
+                                }
+                                return (
+                                  <div className="message-file">
+                                    <a href={safeFileUrl} target="_blank" rel="noopener noreferrer" className="file-link">
+                                      <Paperclip size={16} />
+                                      <span>{String(item.content).split('name=')[1] || t('misc.cw_file_default')}</span>
+                                    </a>
+                                  </div>
+                                );
+                              })() :
 
                               <ReactMarkdown
                                 urlTransform={(url) => {

--- a/frontend/src/components/wizard/AppointmentWizardV2.tsx
+++ b/frontend/src/components/wizard/AppointmentWizardV2.tsx
@@ -1610,9 +1610,17 @@ interface PatientRecord {
           throw new Error(t('misc.aw_fio_required'));
         }
 
-        const token = tokenManager.getAccessToken();
-        logger.log('🔑 Токен для создания пациента:', token ? `${token.substring(0, 20)}...` : 'НЕТ ТОКЕНА');
-        logger.log('📊 Длина токена:', token ? token.length : 0);
+        // audit/phase-2, BS-52: removed two `logger.log` lines that printed
+        // the first 20 chars of the JWT to the browser console. The logger's
+        // PHI sanitizer only scrubs object arguments — primitive strings pass
+        // through unchanged, so the JWT substring was visible in devtools.
+        // PR-39/Medium-12 already removed the same pattern from api/client.ts;
+        // this is the same regression in the wizard. The presence of a token
+        // is implicit in the request succeeding; if we need explicit "no token"
+        // signalling for debugging, it should be a boolean flag, never a
+        // substring of the secret.
+        const _token = tokenManager.getAccessToken();
+        void _token;
 
         // Подготовка данных пациента - отправляем полное ФИО, backend нормализует
         const patientData: Record<string, unknown> = {

--- a/frontend/src/contexts/ChatContext.tsx
+++ b/frontend/src/contexts/ChatContext.tsx
@@ -587,13 +587,15 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
         // F-001: 4001 = auth rejected (invalid/expired token) — don't reconnect with same token
         if (e.code === 4001) {
           logger.warn('[FIX:WS] Chat WebSocket auth rejected (4001), invalidating token');
-          // tokenManager may expose invalidateAccessToken() in some builds.
-          // Probe via structural cast to avoid coupling this file to the
-          // concrete tokenManager implementation.
-          const tm = tokenManager as typeof tokenManager & { invalidateAccessToken?: () => void };
-          if (tm && typeof tm.invalidateAccessToken === 'function') {
-            tm.invalidateAccessToken();
-          }
+          // audit/phase-2, BS-29: previously this branch probed for a
+          // non-existent `tokenManager.invalidateAccessToken()` method via
+          // a structural cast — the cast satisfied TypeScript but the method
+          // was never defined, so the body was a no-op and the rejected
+          // access token survived. Replace with the real SSOT method:
+          // `tokenManager.clearAll()` wipes access_token + refresh_token +
+          // user data, so the next reconnect attempt will be forced through
+          // the full auth flow instead of retrying with the same bad token.
+          tokenManager.clearAll();
           return;
         }
         // Если не нормальное закрытие (1000) - пробуем переподключиться

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -26,6 +26,7 @@ import {
 import apiClient from '../api/client.js';
 import { mixColors, toRgbaString } from '../theme/colorUtils.js';
 import logger from '../utils/logger';
+import tokenManager from '../utils/tokenManager.js';
 import { isPublicRoutePath } from '../routing/routeSelectors.js';
 
 type ThemeMode = 'light' | 'dark';
@@ -87,17 +88,24 @@ interface AuthStateChangedEvent extends Event {
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 const THEME_PREFERENCE_SAVE_DEBOUNCE_MS = 400;
 const THEME_PREFERENCE_CACHE_MS = 30_000;
-const AUTH_TOKEN_STORAGE_KEY = 'auth_token';
 const themePreferenceCache = new Map<string, { cachedAt: number; theme: ColorScheme }>();
 const themePreferenceRequestPromiseByToken = new Map<string, Promise<ColorScheme | null>>();
 
+// audit/phase-2, BS-32: previously this read `localStorage.getItem('auth_token')`
+// directly, but PR-39 / P0-2 migrated tokens to sessionStorage (and the new
+// access point is `tokenManager.getAccessToken()`). The localStorage read was
+// ALWAYS null in production, so the `if (!authToken) return` guard short-
+// circuited every call and theme preferences were never loaded from the
+// backend. Delegating to tokenManager ensures we read from the same SSOT the
+// rest of the app uses, regardless of which storage backend tokenManager
+// internally chooses.
 function getAuthTokenSnapshot(): string | null {
   if (typeof window === 'undefined') {
     return null;
   }
 
   try {
-    return localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+    return tokenManager.getAccessToken();
   } catch {
     return null;
   }
@@ -269,7 +277,14 @@ export const ThemeProvider = ({ children }: ThemeProviderProps) => {
     };
 
     const handleStorage = (event: StorageEvent) => {
-      if (!event.key || event.key === AUTH_TOKEN_STORAGE_KEY) {
+      // audit/phase-2, BS-32: AUTH_TOKEN_STORAGE_KEY was removed when we
+      // switched to tokenManager. sessionStorage 'storage' events only fire
+      // cross-tab for localStorage, but tokenManager uses sessionStorage —
+      // so this branch will never fire for token changes. Keep the listener
+      // for the `null` key (clear-all) case which signals a logout sweep.
+      // The actual cross-component auth sync is handled by the
+      // 'authStateChanged' CustomEvent below.
+      if (!event.key) {
         syncAuthToken(event.newValue || null);
       }
     };

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -93,8 +93,15 @@ export const useUserPreferences = (userId: unknown = null, autoLoad: boolean = t
             logger.warn('Failed to load preferences:', err);
 
             // Если 401, значит токен протух - чистим его
+            // audit/phase-2, BS-33: previously this called
+            // `sessionStorage.removeItem('auth_token')` directly, which (a)
+            // bypassed tokenManager.clearAll() so refresh_token + user data
+            // survived, and (b) bypassed the central 401 handler in
+            // interceptors.ts (no auth-state notification fired). Use the
+            // SSOT method instead — it clears the full auth tuple and any
+            // future storage additions are picked up automatically.
             if (err.response && err.response.status === 401) {
-                sessionStorage.removeItem('auth_token');  // PR-39 / P0-2: token now in sessionStorage;
+                tokenManager.clearAll();
             }
 
             // ВАЖНО: Устанавливаем loadedRef = true чтобы прекратить повторные попытки

--- a/frontend/src/services/sentry.ts
+++ b/frontend/src/services/sentry.ts
@@ -25,12 +25,26 @@ const MEDICAL_PII_KEYS = [
   // Patient identifiers
   'iin', 'passport_number', 'passport_series', 'ssn', 'national_id',
   // Contact info
-  'phone', 'phone_number', 'email',
+  'phone', 'phone_number', 'email', 'address', 'street', 'city', 'postal_code',
+  // Names (audit/phase-2, BS-57: previously missing — only `patient_name`
+  // substring was matched, so standalone `full_name`, `first_name`,
+  // `last_name`, `middle_name`, `fio`, `patient_fio` leaked through).
+  'full_name', 'firstname', 'first_name', 'lastname', 'last_name',
+  'middle_name', 'surname', 'patronymic', 'fio', 'name',
+  // Dates of birth (previously missing)
+  'birth_date', 'date_of_birth', 'dob', 'patient_birth_date', 'patient_birth_year',
+  // Insurance / identity (previously missing)
+  'insurance_number', 'card_number', 'cvv', 'payment_method',
   // Medical
-  'diagnosis', 'diagnoses', 'icd10', 'icd10_codes', 'complaints',
+  'diagnosis', 'diagnoses', 'icd10', 'icd10_codes', 'complaints', 'complaint',
   'examination', 'prescription', 'medications', 'allergies',
+  'medical_history', 'symptoms', 'treatment', 'lab_results', 'blood_type',
   // Visit
   'visit_reason', 'patient_name', 'patient_id', 'doctor_notes',
+  // Auth tokens (defence-in-depth: Sentry SDK auto-scrubs these, but the
+  // custom scrubber runs first and we want redaction even if SDK behaviour
+  // changes in a future release)
+  'token', 'access_token', 'refresh_token', 'secret', 'api_key', 'password',
 ];
 
 function scrubPIIFromObject(obj) {
@@ -83,7 +97,10 @@ export function initSentry() {
       }),
     ],
     beforeSend(event) {
-      // Scrub PII from request bodies, breadcrumbs, extra context.
+      // Scrub PII from request bodies, breadcrumbs, extra context, and contexts.
+      // audit/phase-2, BS-57: previously `event.contexts` was not scrubbed,
+      // so PII attached by Sentry SDK integrations (e.g., device context,
+      // custom contexts set via Sentry.setContext()) leaked through.
       if (event.request) {
         event.request = scrubPIIFromObject(event.request);
       }
@@ -95,6 +112,9 @@ export function initSentry() {
       }
       if (event.extra) {
         event.extra = scrubPIIFromObject(event.extra);
+      }
+      if (event.contexts) {
+        event.contexts = scrubPIIFromObject(event.contexts);
       }
       return event;
     },

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -178,7 +178,47 @@ export function clearToken(): void {
     logger.warn('client.setToken(null) call failed:', e);
   }
 
-  logger.info('[FIX:AUTH] Cleared auth token and profile from local storage');
+  // audit/phase-2, BS-37 + BS-38: clear PHI/financial + patient-side keys
+  // that previously survived staff logout. Without this block, on a shared
+  // kiosk the next user could read previous user's data:
+  //   - admin_finance_transactions_cache: holds { patient_id, amount,
+  //     payment_method, patient_name, ... } — PHI + financial. Stored in
+  //     localStorage which persists across tab/browser restarts.
+  //   - cache_*: generic useCachedData writes arbitrary API responses
+  //     (potentially patient lists) to localStorage.
+  //   - patient_jwt_token / patient_refresh_token / patient_token_expires_at:
+  //     written by useTelegramAuth/useWebAuthn directly to sessionStorage,
+  //     bypassing tokenManager. Staff logout didn't touch them, so patient
+  //     Mini-App identity lingered after a staff session.
+  // Removing these keys is idempotent and safe — none are needed for the
+  // logout flow itself.
+  try {
+    localStorage.removeItem('admin_finance_transactions_cache');
+    // Sweep any cache_* keys written by useCachedData (useApi.ts).
+    // We do not enumerate ALL localStorage keys here because that would
+    // also clear unrelated app state (e.g., saved UI preferences); the
+    // cache_* prefix is specific to useCachedData.
+    const cacheKeys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith('cache_')) {
+        cacheKeys.push(key);
+      }
+    }
+    cacheKeys.forEach((k) => localStorage.removeItem(k));
+  } catch (e) {
+    logger.warn('clearToken localStorage PHI/financial sweep failed:', e);
+  }
+
+  try {
+    sessionStorage.removeItem('patient_jwt_token');
+    sessionStorage.removeItem('patient_refresh_token');
+    sessionStorage.removeItem('patient_token_expires_at');
+  } catch (e) {
+    logger.warn('clearToken sessionStorage patient-token sweep failed:', e);
+  }
+
+  logger.info('[FIX:AUTH] Cleared auth token, profile, PHI/financial cache, and patient tokens');
   notify();
 }
 


### PR DESCRIPTION
## Summary

- Phase 2 of verification-pass roadmap: 8 security fixes covering HIPAA compliance, auth correctness, XSS prevention, Sentry PII scrubbing.
- 2 HIPAA Critical (BS-37, BS-38), 1 XSS High (BS-53), 5 other High.
- All changes are local (no API/BE/OpenAPI impact).

## Cyclic Execution Evidence

- Fresh main sync: branch `audit/phase-2-security` based on `audit/phase-1-medical-safety` (PR #2487).
- Clean workspace: 7 files changed, +180 / -36 lines.
- Branch: `audit/phase-2-security`
- Scope gate: allowed security fixes in `stores/auth.ts`, `contexts/ChatContext.tsx`, `contexts/ThemeContext.tsx`, `hooks/useUserPreferences.ts`, `components/chat/ChatWindow.tsx`, `components/wizard/AppointmentWizardV2.tsx`, `services/sentry.ts`; denied any backend changes.
- Red-check handling: `npx tsc --noEmit` clean, `npx eslint --quiet` clean, `npx vitest run src/api src/utils/__tests__ src/contexts/__tests__ src/hooks/__tests__/useUserPreferences.contract.test.ts` 219/219 pass.

## Contract Impact

- Canonical surface: `src/stores/auth.ts` (`clearToken()` extended to sweep PHI/financial + patient-token keys), `src/services/sentry.ts` (PHI scrub list expanded), `src/contexts/ChatContext.tsx` (4001 handler fixed).
- Request shape: not applicable - no API request shapes modified
- Response shape: not applicable - no API response shapes modified
- Status codes: not applicable - no HTTP status code handling changed
- Frontend consumer: after logout, sessionStorage/localStorage no longer contains PHI (financial transactions, patient JWT) - HIPAA compliance restored on shared kiosks.
- Compatibility path or alias: not applicable - no compatibility paths or aliases broken - all storage key names preserved; only removal-on-logout added.
- Contract proof: `clearToken()` now removes `admin_finance_transactions_cache`, `cache_*` (swept), `patient_jwt_token`, `patient_refresh_token`, `patient_token_expires_at` - verified by reading existing `clearToken` body and extending it.

## RBAC / Permissions

- Roles allowed: not applicable - no auth logic touched in this phase
- Roles denied: not applicable - no role checks or gating modified
- Positive auth proof: BS-29 fix - `ChatContext` 4001 (WS auth rejected) now calls `tokenManager.clearAll()` (real method) instead of probing non-existent `invalidateAccessToken()` (was a no-op). Rejected access tokens are now actually invalidated.
- Negative auth proof: BS-37 + BS-38 - after staff logout, patient JWT (`patient_jwt_token`) and PHI cache (`admin_finance_transactions_cache`) are now removed. Previously survived logout on shared kiosks.

## Notification / Realtime

- Event type or websocket channel: not applicable - no WebSocket event types or channels changed
- Payload version / ack behavior: not applicable - no message payload versions or ack semantics changed
- Read/unread or delivery semantics: not applicable - no read/unread or delivery logic changed
- Reconnect/resync proof: BS-29 - when WS sends 4001 (auth rejected), `tokenManager.clearAll()` forces full re-auth on next reconnect instead of retrying with the same bad token.

## Frontend Resilience

- Empty data proof: not applicable - no runtime behavior change in this phase - security fixes do not affect empty-state rendering.
- Partial data proof: not applicable - no partial-data rendering path affected
- Forbidden secondary path behavior: BS-53 - `ChatWindow` image/file branches now sanitize URLs via `sanitizeURL()` from `utils/sanitizer.ts`. Dangerous protocols (`javascript:`, `data:text/html`, `vbscript:`) render a fallback instead of executing.
- Missing draft/resource behavior: not applicable - no draft or resource creation logic in scope
- Stale route/deep-link behavior: BS-32 - `ThemeContext` now reads token via `tokenManager.getAccessToken()` (was always null via `localStorage.getItem` after PR-39 migrated to sessionStorage). Theme preferences now actually load from backend for logged-in users.

## Scope Gate

- Allowed paths: `src/stores/auth.ts`, `src/contexts/ChatContext.tsx`, `src/contexts/ThemeContext.tsx`, `src/hooks/useUserPreferences.ts`, `src/components/chat/ChatWindow.tsx`, `src/components/wizard/AppointmentWizardV2.tsx`, `src/services/sentry.ts`.
- Denied paths: tsconfig changes, any new dependencies, backend changes, OpenAPI changes, test changes.
- Migration/docs/test impact: no migration; no test changes (existing `useUserPreferences.contract.test.ts` still passes after BS-33 fix).
- Rollback note: `git revert 8fbeb99a` restores previous behavior (security bugs return).

## Validation

- Targeted tests or smoke run: `npx tsc --noEmit` (clean), `npx eslint --quiet` (clean), `npx vitest run src/api src/utils/__tests__ src/contexts/__tests__ src/hooks/__tests__/useUserPreferences.contract.test.ts` (219/219 pass).
- Result: passed locally.
- Not checked: full `vitest run` (hangs in environment); manual XSS payload test in chat (deferred to security QA).

---

### Security fixes

| ID | Severity | Issue | Fix |
|----|----------|-------|-----|
| BS-52 | High | JWT prefix logged to console in `AppointmentWizardV2.tsx:1613` | Delete both `logger.log` lines |
| BS-29 | High | `ChatContext` 4001 handler probed non-existent `invalidateAccessToken()` - no-op | Call `tokenManager.clearAll()` |
| BS-32 | High | `ThemeContext` read `localStorage.getItem('auth_token')` - always null after PR-39 | Use `tokenManager.getAccessToken()` |
| BS-33 | High | `useUserPreferences` 401 handler did direct `removeItem` - left `refresh_token` | Call `tokenManager.clearAll()` |
| BS-37 | Critical (HIPAA) | `admin_finance_transactions_cache` (PHI+financial) survived logout | `clearToken()` sweeps localStorage |
| BS-38 | Critical (HIPAA) | `patient_jwt_token` etc. survived staff logout | `clearToken()` removes patient keys |
| BS-53 | High (XSS) | `ChatWindow` rendered unsanitized URLs in `<img>`/`<a>`/`window.open` | `safeMessageURL()` helper using `sanitizeURL()` |
| BS-57 | High (HIPAA) | Sentry PHI scrub list missing `full_name`, `birth_date`, `address`, `card_number`, etc. | Extended list to match `logger.ts` PHI_FIELDS; added `event.contexts` scrubbing |

Generated with Claude - verification-pass audit