### PR TITLE
audit/phase-3: opt-in CSRF strict mode + verify useTelegramAuth endpoint (BS-28, BS-56)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -21,6 +21,13 @@ const API_BASE = getApiBaseUrl();
 // PR-39 / Medium-11: CSRF bootstrap defaults to ON. Set VITE_CSRF_BOOTSTRAP=0
 // to explicitly disable (e.g., for local dev without backend CSRF support).
 const CSRF_BOOTSTRAP_ENABLED = import.meta.env.VITE_CSRF_BOOTSTRAP !== '0';
+// audit/phase-3, BS-56: opt-in fail-closed mode for CSRF.
+// When `VITE_CSRF_STRICT === '1'`, state-changing requests WITHOUT a CSRF
+// token are REJECTED locally instead of being sent to the backend.
+// Default is fail-open (current behaviour) to avoid breaking deployments
+// that don't expose `/auth/csrf-token`. Enable in production once the
+// backend is confirmed to serve the endpoint reliably.
+const CSRF_STRICT_MODE = import.meta.env.VITE_CSRF_STRICT === '1';
 const GLOBAL_RATE_LIMIT_COOLDOWN_MS = 60_000;
 let globalRateLimitUntil = 0;
 let globalRateLimitLogAt = 0;
@@ -224,6 +231,27 @@ api.interceptors.request.use(async (config: InternalAxiosRequestConfig) => {
     const csrfToken = await ensureCSRFToken();
     if (csrfToken) {
       config.headers.set('X-CSRF-Token', csrfToken);
+    } else if (CSRF_STRICT_MODE) {
+      // audit/phase-3, BS-56: fail-closed path. Without this branch, a
+      // misconfigured backend (no `/auth/csrf-token`, cookie miss, transient
+      // network error) silently allowed every state-changing request to
+      // proceed without CSRF protection for the entire session — the
+      // `csrfEndpointUnavailable` flag is sticky. In strict mode we reject
+      // the request locally so the operator sees a clear failure instead of
+      // a silent security gap. The auth endpoints (login/refresh) are
+      // exempt because they bootstrap the CSRF token itself.
+      const url = config.url || '';
+      const isAuthEndpoint = url.endsWith('/auth/login')
+        || url.endsWith('/auth/refresh')
+        || url.endsWith('/authentication/refresh')
+        || url.endsWith('/auth/csrf-token')
+        || url.endsWith('/auth/logout');
+      if (!isAuthEndpoint) {
+        return Promise.reject(new Error(
+          `[FIX:CSRF] Strict mode: refusing ${method.toUpperCase()} ${url} without CSRF token. `
+          + `Set VITE_CSRF_STRICT=0 to revert to fail-open behaviour.`
+        ));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Phase 3 of verification-pass roadmap: 2 findings addressed (BS-28 verified moot, BS-56 CSRF strict mode).
- 4 findings deferred (BS-25, 26, 27, 59) - require auth-flow regression testing and BE coordination.
- BS-28: `useTelegramAuth` was removed as dead code in Phase 0; backend confirmed to expose `/mobile/auth/refresh` for patient flow.

## Cyclic Execution Evidence

- Fresh main sync: branch `audit/phase-3-api-consistency` based on `audit/phase-2-security` (PR #2488).
- Clean workspace: 1 file changed, +28 lines.
- Branch: `audit/phase-3-api-consistency`
- Scope gate: allowed `src/api/client.ts` (CSRF strict mode flag); denied any backend changes, any OpenAPI changes, any test changes.
- Red-check handling: `npx tsc --noEmit` clean, `npx eslint --quiet` clean, `npx vitest run src/api/__tests__` 45/45 pass.

## Contract Impact

- Canonical surface: `src/api/client.ts` (new `VITE_CSRF_STRICT` env var + fail-closed branch in request interceptor).
- Request shape: not applicable - no API request shapes modified
- Response shape: not applicable - no API response shapes modified
- Status codes: not applicable - no HTTP status code handling changed
- Frontend consumer: when `VITE_CSRF_STRICT=1`, state-changing requests without a CSRF token are rejected locally with a clear error. Default (`VITE_CSRF_STRICT=0` or unset) preserves current fail-open behavior.
- Compatibility path or alias: not applicable - no compatibility paths or aliases broken - feature flag defaults to off; no existing deployment breaks.
- Contract proof: BE verification confirmed `/mobile/auth/refresh` exists in `backend/app/api/v1/endpoints/mobile_api.py` for patient flow (separate from staff `/authentication/refresh`); BS-28 finding is moot because `useTelegramAuth.tsx` was deleted in Phase 0.

## RBAC / Permissions

- Roles allowed: not applicable - no auth logic touched in this phase
- Roles denied: not applicable - no role checks or gating modified
- Positive auth proof: BS-56 - auth endpoints (`/auth/login`, `/auth/refresh`, `/authentication/refresh`, `/auth/csrf-token`, `/auth/logout`) are explicitly exempt from CSRF strict mode because they bootstrap or tear down the CSRF token itself.
- Negative auth proof: not applicable - no auth code paths changed by this refactor

## Notification / Realtime

- Event type or websocket channel: not applicable - no WebSocket event types or channels changed
- Payload version / ack behavior: not applicable - no message payload versions or ack semantics changed
- Read/unread or delivery semantics: not applicable - no read/unread or delivery logic changed
- Reconnect/resync proof: not applicable - no reconnect or resync logic changed

## Frontend Resilience

- Empty data proof: not applicable - no runtime behavior change in this phase - CSRF flag default is fail-open.
- Partial data proof: not applicable - no partial-data rendering path affected
- Forbidden secondary path behavior: not applicable - no secondary or forbidden path introduced
- Missing draft/resource behavior: not applicable - no draft or resource creation logic in scope
- Stale route/deep-link behavior: not applicable - no route or deep-link state read by CSRF interceptor.

## Scope Gate

- Allowed paths: `src/api/client.ts` only.
- Denied paths: tsconfig changes, any new dependencies, backend changes, OpenAPI changes, test changes, any file other than `client.ts`.
- Migration/docs/test impact: no migration; documented in commit body; no test changes (existing `interceptors.test.ts` 8/8 pass).
- Rollback note: `git revert 31a8d9fd` removes the strict-mode branch; default behavior unchanged.

## Validation

- Targeted tests or smoke run: `npx tsc --noEmit` (clean), `npx eslint --quiet` (clean), `npx vitest run src/api/__tests__` (45/45 pass - interceptors, authLoginRoute, authRefreshRoute contracts intact).
- Result: passed locally.
- Not checked: full `vitest run` (hangs in environment); production deployment with `VITE_CSRF_STRICT=1` (deferred to ops).

---

### Deferred findings (require manual review)

| ID | Risk | Reason |
|----|------|--------|
| BS-25 | High | Delete `services/api.ts`, migrate 3 consumers - auth flow regression risk |
| BS-26 | High | Consolidate double interceptor registration - auth behavior change |
| BS-27 | High | Remove uncoordinated refresh path from `interceptors.ts` - refresh-token rotation race |
| BS-59 | Medium | Migrate `ChatContext` WS to subprotocol auth - requires BE coordination |

Generated with Claude - verification-pass audit