### PR TITLE
audit/phase-8: runtime fixes — deletedIds TTL, request-ID guards, no module mutation (BS-22,36,40)

### DIFF
--- a/frontend/src/hooks/useAppointments.ts
+++ b/frontend/src/hooks/useAppointments.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 
 import { api } from '../api/client';
 import type { Appointment, Doctor } from '../types/domain/clinic';
@@ -60,18 +60,30 @@ const useAppointments = (doctors: Doctor[] = []) => {
   const [filterDate, setFilterDate] = useState('');
   const [filterDoctor, setFilterDoctor] = useState('');
 
+  // audit/phase-8, BS-22: request-ID guard against overlapping loads.
+  // Each create/update/delete calls `await loadAppointments()`; if the user
+  // triggers two mutations quickly, two loads are in flight and the later-
+  // started one might resolve first, then the earlier overwrites with stale
+  // data. The ref tracks the latest request; stale responses are discarded.
+  const loadAppointmentsRequestIdRef = useRef(0);
+
   const loadAppointments = useCallback(async () => {
+    const requestId = ++loadAppointmentsRequestIdRef.current;
     setLoading(true);
     setError(null);
 
     try {
       const response = await api.get('/admin/appointments');
+      if (requestId !== loadAppointmentsRequestIdRef.current) return;
       const items = Array.isArray(response.data) ? response.data : [];
       setAppointments(items.map(normalizeAppointment));
     } catch (err) {
+      if (requestId !== loadAppointmentsRequestIdRef.current) return;
       setError(String(err));
     } finally {
-      setLoading(false);
+      if (requestId === loadAppointmentsRequestIdRef.current) {
+        setLoading(false);
+      }
     }
   }, []);
 

--- a/frontend/src/hooks/useDoctorQueue.ts
+++ b/frontend/src/hooks/useDoctorQueue.ts
@@ -2,7 +2,7 @@
  * Hook for Doctor Queue Management.
  * Provides queue data and actions for the doctor panel.
  */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import api from '../services/api';
 import logger from '../utils/logger';
 import type {
@@ -97,12 +97,23 @@ const useDoctorQueue = (specialty: string = 'general'): UseDoctorQueueReturn => 
   });
   const normalizedSpecialty = specialty || 'general';
 
+  // audit/phase-8, BS-22: request-ID guard against overlapping loads.
+  // Previously, the 30s polling interval could overlap with mutation-induced
+  // loadQueue() calls — the later-started request could resolve first, then
+  // the earlier request overwrote with stale data. The ref tracks the latest
+  // request; stale responses are silently discarded.
+  const loadQueueRequestIdRef = useRef(0);
+
   const loadQueue = useCallback(async (): Promise<void> => {
+    const requestId = ++loadQueueRequestIdRef.current;
     setLoading(true);
     setError(null);
 
     try {
       const response = await api.get(`/doctor/${encodeURIComponent(normalizedSpecialty)}/queue/today`);
+      // Discard stale responses — a newer loadQueue() has been triggered since.
+      if (requestId !== loadQueueRequestIdRef.current) return;
+
       const data = response.data as DoctorQueuePayload;
       const entries = Array.isArray(data?.entries) ? data.entries : [];
       const apiStats: QueueStats = (data?.stats as QueueStats) || {};
@@ -126,6 +137,7 @@ const useDoctorQueue = (specialty: string = 'general'): UseDoctorQueueReturn => 
         queueIds: data?.queue_ids || [],
       });
     } catch (err) {
+      if (requestId !== loadQueueRequestIdRef.current) return;
       const e = err as CatchError;
       logger.error('[useDoctorQueue] Error loading queue:', err);
       setQueue([]);
@@ -133,7 +145,9 @@ const useDoctorQueue = (specialty: string = 'general'): UseDoctorQueueReturn => 
       setQueueControls({ canCallNext: false, nextCallEntryId: null });
       setError(e?.response?.data?.detail || e?.message || 'Ошибка загрузки очереди');
     } finally {
-      setLoading(false);
+      if (requestId === loadQueueRequestIdRef.current) {
+        setLoading(false);
+      }
     }
   }, [normalizedSpecialty]);
 

--- a/frontend/src/hooks/useFinance.ts
+++ b/frontend/src/hooks/useFinance.ts
@@ -5,6 +5,12 @@ import logger from '../utils/logger';
 import type { Transaction } from '../types/domain/clinic';
 
 const FINANCE_CACHE_KEY = 'admin_finance_transactions_cache';
+// audit/phase-8, BS-36: TTL for deletedIds. Previously deletedIds grew
+// monotonically and never expired — after a DB restore or ID recycling,
+// deleted IDs would filter out valid new transactions forever. 7-day TTL
+// is long enough to cover the "delete then refresh" use case but short
+// enough to self-heal after ID recycling.
+const DELETED_IDS_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 const normalizeTransaction = (transaction: Record<string, unknown> = {}) => ({
   id: (transaction as Record<string, unknown>).id,
@@ -42,6 +48,40 @@ const normalizeDeletedIds = (deletedIds: unknown[] = []): number[] => {
   return [...new Set(deletedIds.map((id) => Number(id)).filter((id) => Number.isFinite(id)))];
 };
 
+// audit/phase-8, BS-36: deletedIds with TTL. Each entry stores { id, deletedAt }.
+// Entries older than DELETED_IDS_TTL_MS are pruned on read + write.
+// This prevents the unbounded growth + ID-recycling false-filter bug.
+interface DeletedIdEntry {
+  id: number;
+  deletedAt: number;
+}
+
+const normalizeDeletedIdEntries = (raw: unknown[]): DeletedIdEntry[] => {
+  const now = Date.now();
+  const seen = new Set<number>();
+  const entries: DeletedIdEntry[] = [];
+  for (const item of raw) {
+    let id: number;
+    let deletedAt: number;
+    if (item && typeof item === 'object' && 'id' in item) {
+      id = Number((item as DeletedIdEntry).id);
+      deletedAt = Number((item as DeletedIdEntry).deletedAt) || now;
+    } else {
+      // Legacy format: bare numeric id (treat as deleted "now")
+      id = Number(item);
+      deletedAt = now;
+    }
+    if (!Number.isFinite(id) || seen.has(id)) continue;
+    // Prune expired entries during normalization
+    if (now - deletedAt > DELETED_IDS_TTL_MS) continue;
+    seen.add(id);
+    entries.push({ id, deletedAt });
+  }
+  return entries;
+};
+
+const entriesToIds = (entries: DeletedIdEntry[]): number[] => entries.map(e => e.id);
+
 const readFinanceCache = () => {
   try {
     const raw = localStorage.getItem(FINANCE_CACHE_KEY);
@@ -55,11 +95,14 @@ const readFinanceCache = () => {
       : Array.isArray(parsed?.transactions)
         ? parsed.transactions
         : [];
-    const deletedIds = new Set<number>(Array.isArray(parsed?.deletedIds) ? (parsed.deletedIds as number[]) : []);
+    // audit/phase-8, BS-36: read deletedIds with TTL pruning.
+    // Supports legacy format (bare number[]) and new format ({id, deletedAt}[]).
+    const rawDeletedIds = Array.isArray(parsed?.deletedIds) ? parsed.deletedIds : [];
+    const entries = normalizeDeletedIdEntries(rawDeletedIds as unknown[]);
 
     return {
       transactions: sortTransactions(cachedTransactions.map(normalizeTransaction)),
-      deletedIds: normalizeDeletedIds(Array.from(deletedIds as Set<number> | unknown[]))
+      deletedIds: entriesToIds(entries)
     };
   } catch (error) {
     logger.warn('[FIX:FINANCE] Не удалось прочитать локальный кэш финансов:', error);
@@ -69,12 +112,24 @@ const readFinanceCache = () => {
 
 const writeFinanceCache = (transactions, deletedIds: unknown[] = []) => {
   try {
+    // audit/phase-8, BS-36: write deletedIds with timestamps for TTL.
+    // Accept both legacy number[] and new DeletedIdEntry[] formats.
+    const now = Date.now();
+    const entries: DeletedIdEntry[] = normalizeDeletedIdEntries(deletedIds as unknown[]);
+    // For legacy bare-number entries, normalizeDeletedIdEntries already
+    // assigned deletedAt = now. For new entries, preserve their deletedAt.
+    // Re-stamp any entry that lost its timestamp.
+    const stampedEntries = entries.map(e => ({
+      id: e.id,
+      deletedAt: e.deletedAt || now,
+    }));
+
     localStorage.setItem(
       FINANCE_CACHE_KEY,
       JSON.stringify({
         updatedAt: new Date().toISOString(),
         transactions: sortTransactions(transactions.map(normalizeTransaction)),
-        deletedIds: normalizeDeletedIds(Array.from(deletedIds as Set<number> | unknown[]))
+        deletedIds: stampedEntries
       })
     );
   } catch (error) {
@@ -83,6 +138,8 @@ const writeFinanceCache = (transactions, deletedIds: unknown[] = []) => {
 };
 
 const mergeTransactions = (serverTransactions: unknown[] = [], cacheState = { transactions: [], deletedIds: [] }) => {
+  // audit/phase-8, BS-36: deletedIds are pruned by TTL on read, so this
+  // Set only contains IDs still within their TTL window.
   const deletedIds = new Set<number>(normalizeDeletedIds(cacheState.deletedIds as unknown[]));
   const merged = new Map();
 

--- a/frontend/src/utils/serviceCodeResolver.ts
+++ b/frontend/src/utils/serviceCodeResolver.ts
@@ -192,8 +192,8 @@ export function toServiceCode(value) {
         return normalized.toUpperCase();
     }
 
-    // Ищем в маппинге
-    return SPECIALTY_TO_CODE[normalized] || null;
+    // Ищем в маппинге (audit/phase-8, BS-40: use merged view, not the mutated const)
+    return getMergedSpecialtyToCode()[normalized] || null;
 }
 
 /**
@@ -221,9 +221,10 @@ export function getServiceDisplayName(code, servicesData = []) {
         if (service?.name) return service.name;
     }
 
-    // Приоритет 2: SSOT маппинг
-    if (CODE_TO_NAME[normalizedCode]) {
-        return CODE_TO_NAME[normalizedCode];
+    // Приоритет 2: SSOT маппинг (audit/phase-8, BS-40: use merged view, not the mutated const)
+    const mergedCodeToName = getMergedCodeToName();
+    if (mergedCodeToName[normalizedCode]) {
+        return mergedCodeToName[normalizedCode];
     }
 
     // Приоритет 3: Legacy маппинг
@@ -600,6 +601,12 @@ export function normalizeServicesFromInitialData(initialData, servicesData = [])
 let cachedMappings = null;
 let lastLoadTime = 0;
 const CACHE_TTL = 5 * 60 * 1000; // 5 минут
+// audit/phase-8, BS-40: backend overrides stored separately from the
+// exported static consts. `invalidateMappingsCache()` clears these,
+// restoring the original static-only behavior. Lookup functions merge
+// static + overrides at read time instead of mutating the static maps.
+let backendSpecialtyOverrides: Record<string, unknown> = {};
+let backendCodeNameOverrides: Record<string, unknown> = {};
 
 /**
  * Загружает маппинги с backend API
@@ -624,10 +631,20 @@ export async function loadMappingsFromBackend() {
             cachedMappings = response as Record<string, unknown>;
             lastLoadTime = now;
 
-            // Обновляем локальные маппинги
+            // audit/phase-8, BS-40: previously this called
+            // `Object.assign(SPECIALTY_TO_CODE, resp.specialty_to_code || {})`
+            // which MUTATED the exported const. All consumers holding a
+            // reference to SPECIALTY_TO_CODE saw values change underneath
+            // them between renders, and `invalidateMappingsCache()` did not
+            // restore the original static values — stale backend overrides
+            // accumulated permanently.
+            //
+            // Fix: maintain a separate `backendOverrides` map that is read
+            // by the lookup functions via a merged view. The exported
+            // SPECIALTY_TO_CODE / CODE_TO_NAME constants are never mutated.
             const resp = response as { specialty_to_code?: Record<string, unknown>; code_to_name?: Record<string, unknown> };
-            Object.assign(SPECIALTY_TO_CODE, resp.specialty_to_code || {});
-            Object.assign(CODE_TO_NAME, resp.code_to_name || {});
+            backendSpecialtyOverrides = { ...(resp.specialty_to_code || {}) };
+            backendCodeNameOverrides = { ...(resp.code_to_name || {}) };
 
             return response;
         }
@@ -651,6 +668,24 @@ export async function loadMappingsFromBackend() {
 export function invalidateMappingsCache() {
     cachedMappings = null;
     lastLoadTime = 0;
+    // audit/phase-8, BS-40: clear backend overrides so the next loadMappingsFromBackend()
+    // starts fresh. Previously the mutated SPECIALTY_TO_CODE / CODE_TO_NAME
+    // were never restored, so stale backend values persisted permanently.
+    backendSpecialtyOverrides = {};
+    backendCodeNameOverrides = {};
+}
+
+/**
+ * audit/phase-8, BS-40: helper that returns the merged view of static
+ * specialty_to_code + backend overrides. Used by lookup functions so
+ * the exported SPECIALTY_TO_CODE const is never mutated.
+ */
+function getMergedSpecialtyToCode(): Record<string, unknown> {
+    return { ...SPECIALTY_TO_CODE, ...backendSpecialtyOverrides };
+}
+
+function getMergedCodeToName(): Record<string, unknown> {
+    return { ...CODE_TO_NAME, ...backendCodeNameOverrides };
 }
 
 export default {


### PR DESCRIPTION
## Summary

- Phase 8 of verification-pass roadmap: 3 runtime fixes from the medium-impact deferred bucket (BS-22, BS-36, BS-40).
- All changes are local (no API/BE/OpenAPI impact).
- BS-36 closes a data-integrity bug where deleted transaction IDs would permanently filter out valid new transactions after DB restore.
- BS-22 closes a race condition where stale load responses overwrote fresh data on rapid mutations.
- BS-40 stops `serviceCodeResolver` from mutating exported constants.

## Cyclic Execution Evidence

- Fresh main sync: branch `audit/phase-8-runtime-fixes` based on `origin/main` at commit ff66f245 (after Phase 7b merge).
- Clean workspace: 4 files changed, +133 / -15 lines; no overlap with in-flight branches.
- Branch: `audit/phase-8-runtime-fixes`
- Scope gate: allowed `useFinance.ts`, `useAppointments.ts`, `useDoctorQueue.ts`, `serviceCodeResolver.ts`; denied any backend changes, any OpenAPI changes, any test changes.
- Red-check handling: `npx tsc --noEmit` clean, `npx eslint --quiet` clean, `npx vitest run src/api src/utils/__tests__` 202/202 pass.

## Contract Impact

- Canonical surface: `src/hooks/useFinance.ts` (BS-36 deletedIds TTL), `src/hooks/useAppointments.ts` + `src/hooks/useDoctorQueue.ts` (BS-22 request-ID guards), `src/utils/serviceCodeResolver.ts` (BS-40 no module mutation).
- Request shape: not applicable - no API request shapes modified
- Response shape: not applicable - no API response shapes modified
- Status codes: not applicable - no HTTP status code handling changed
- Frontend consumer: no API contract change. BS-36 changes localStorage cache shape (`deletedIds` from `number[]` to `{id, deletedAt}[]`); legacy format auto-migrated on read. BS-22 adds request-ID ref (internal). BS-40 changes internal lookup to use merged view instead of mutated const.
- Compatibility path or alias: not applicable - no compatibility paths or aliases broken - `serviceCodeResolver` exported consts (`SPECIALTY_TO_CODE`, `CODE_TO_NAME`) preserved unchanged; only internal read path changed.
- Contract proof: `npx tsc --noEmit` clean; `serviceCodeResolver.test.ts` 2/2 pass; external consumers of `SPECIALTY_TO_CODE` (verified zero via grep) unaffected.

## RBAC / Permissions

- Roles allowed: not applicable - no auth logic touched in this phase
- Roles denied: not applicable - no role checks or gating modified
- Positive auth proof: not applicable - no auth code paths changed by this refactor
- Negative auth proof: not applicable - no auth code paths changed by this refactor

## Notification / Realtime

- Event type or websocket channel: not applicable - no WebSocket event types or channels changed
- Payload version / ack behavior: not applicable - no message payload versions or ack semantics changed
- Read/unread or delivery semantics: not applicable - no read/unread or delivery logic changed
- Reconnect/resync proof: not applicable - no reconnect or resync logic changed

## Frontend Resilience

- Empty data proof: BS-36 `deletedIds` TTL pruning runs on read; empty `deletedIds` array produces empty entries, no crash. BS-22 request-ID guard handles empty response data the same as before.
- Partial data proof: not applicable - no partial-data rendering path affected
- Forbidden secondary path behavior: not applicable - no secondary or forbidden path introduced
- Missing draft/resource behavior: not applicable - no draft or resource creation logic in scope
- Stale route/deep-link behavior: BS-22 fix specifically prevents stale data from overwriting fresh data on rapid navigation/mutation — stale responses are discarded via request-ID comparison.

## Scope Gate

- Allowed paths: `src/hooks/useFinance.ts`, `src/hooks/useAppointments.ts`, `src/hooks/useDoctorQueue.ts`, `src/utils/serviceCodeResolver.ts`.
- Denied paths: tsconfig changes, any new dependencies, backend changes, OpenAPI changes, test changes.
- Migration/docs/test impact: no migration; localStorage cache format change is backward-compatible (legacy `number[]` auto-migrated with `deletedAt=now`); no test changes.
- Rollback note: `git revert 0b56ce0f` restores previous behavior (race conditions + unbounded deletedIds + module mutation return).

## Validation

- Targeted tests or smoke run: `npx tsc --noEmit` (clean), `npx eslint --quiet` (clean), `npx vitest run src/api src/utils/__tests__` (202/202 pass).
- Result: passed locally.
- Not checked: full `vitest run` (hangs in environment); manual rapid-mutation test to verify request-ID guard in practice (deferred to QA).

---

### Runtime fixes

| ID | Severity | Issue | Fix |
|----|----------|-------|-----|
| BS-36 | Medium (data integrity) | `useFinance.deletedIds` grew monotonically, never expired; DB restore or ID recycling caused valid new transactions to be filtered out forever | 7-day TTL via `{id, deletedAt}[]` storage; read path prunes expired; legacy format auto-migrated |
| BS-22 | Medium (race) | `useAppointments` + `useDoctorQueue` had no request-ID guard; overlapping loads could overwrite fresh data with stale | `loadAppointmentsRequestIdRef` + `loadQueueRequestIdRef` track latest; stale responses discarded |
| BS-40 | Medium (design) | `serviceCodeResolver.loadMappingsFromBackend` mutated exported `SPECIALTY_TO_CODE` / `CODE_TO_NAME` consts via `Object.assign`; `invalidateMappingsCache` did not restore originals | Backend overrides stored in separate module-level vars; lookup functions use merged view helpers; `invalidateMappingsCache` clears overrides |

### Deferred (tracked in GitHub issues #2498-#2505)

- BS-15: useAIChat WS reconnect (dormant, `useWebSocket={false}` everywhere)
- BS-18: useEMR shared cache (1 consumer, self-heals after resolve)
- BS-66: enable `strict:true` (high risk, needs sub-PRs per directory) — issue #2498
- BS-5: Icon.size typing (visual regression risk) — issue #2499
- BS-6: i18n typed resources policy (team decision needed) — issue #2500
- BS-25,26,27,59: API client consolidation (auth regression risk) — issue #2501
- BS-58: WebAuthn RP ID + userVerification (BE validation needed) — issue #2503
- BS-63: vite manualChunks (bundle analysis needed) — issue #2504
- BS-45: `@/` alias codemod (style only) — issue #2505

See `VERIFICATION_AND_ROADMAP.md` + GitHub issues #2498-#2505 for full context.

Generated with Claude - verification-pass audit