### PR TITLE
🎨 Palette: Add aria-invalid to macOS form controls

### DIFF
--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -176,6 +176,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         disabled={disabled}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        aria-invalid={!!error}
         {...props}
       />
       {showClearButton && (

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -256,6 +256,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           aria-haspopup="listbox"
           aria-expanded={isOpen}
           disabled={disabled}
+          aria-invalid={!!error}
           {...props}
         >
           <span>{selected ? (selected.label ?? String(selected.value)) : <span style={{ color: 'var(--mac-text-secondary)' }}>{placeholder}</span>}</span>

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -145,6 +145,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}
       rows={minRows}
+      aria-invalid={!!error}
       {...props}
     />
   );


### PR DESCRIPTION
### 💡 What
Added the `aria-invalid` attribute to the underlying native form controls (`<input>`, `<textarea>`, and `<button>`) in the macOS UI component library (`Input.tsx`, `Textarea.tsx`, and `Select.tsx`). The attribute is dynamically set based on the presence of the `error` prop (`aria-invalid={!!error}`).

### 🎯 Why
While these form controls visually indicate an error state (e.g., via red borders or text), screen readers and assistive technologies were not programmatically notified of this invalid state. Adding `aria-invalid` ensures that visually impaired users receive explicit feedback when a form field contains an error or fails validation, significantly improving the form-filling experience.

### 📸 Before/After
*Before:* `aria-invalid` was omitted entirely.
*After:* `aria-invalid="true"` is added when the `error` prop is truthy, and `aria-invalid="false"` when falsy.

### ♿ Accessibility
*   **A11y Improved:** Form controls now correctly broadcast their validation state to assistive technologies, adhering to WCAG guidelines for form accessibility and error identification. Screen readers will now announce "invalid data" or similar when focused on an errored field.

---
*PR created automatically by Jules for task [18385075250242896263](https://jules.google.com/task/18385075250242896263) started by @drsapaev*