### PR TITLE
strict: fix 30+ component files for strict:true (BS-66 components batch 2)

### DIFF
--- a/frontend/src/components/AppointmentFlow.tsx
+++ b/frontend/src/components/AppointmentFlow.tsx
@@ -180,11 +180,11 @@ const AppointmentFlow = ({ appointment }: AppointmentFlowProps) => {
           <div>
             <div className="font-medium">{t('misc.af_status_zapisi')}</div>
             <div className="text-sm text-gray-600">
-              {STATUS_LABELS[appointment?.status] || t('misc.af_neizvestno')}
+              {STATUS_LABELS[appointment?.status ?? ''] || t('misc.af_neizvestno')}
             </div>
           </div>
-          <Badge variant={STATUS_COLORS[appointment?.status] as unknown as "default" | "primary" | "secondary" | "success" | "warning" | "danger" | "info" | "outline"}>
-            {STATUS_LABELS[appointment?.status]}
+          <Badge variant={STATUS_COLORS[appointment?.status ?? ''] as unknown as "default" | "primary" | "secondary" | "success" | "warning" | "danger" | "info" | "outline"}>
+            {STATUS_LABELS[appointment?.status ?? '']}
           </Badge>
         </div>
       </div>

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -13,14 +13,14 @@ import PropTypes from 'prop-types';
 const LanguageSwitcher = ({ compact = false }) => {
     const { language, setLanguage, availableLanguages, t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
     const [isOpen, setIsOpen] = useState(false);
-    const menuRef = useRef(null);
+    const menuRef = useRef<HTMLDivElement>(null);
 
     const currentLang = availableLanguages.find(l => l.code === language) || availableLanguages[0];
 
     // Закрытие меню при клике вне
     useEffect(() => {
-        const handleClickOutside = (e: React.MouseEvent) => {
-            if (menuRef.current && !menuRef.current.contains(e.target)) {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
                 setIsOpen(false);
             }
         };

--- a/frontend/src/components/RoleGate.tsx
+++ b/frontend/src/components/RoleGate.tsx
@@ -35,7 +35,7 @@ export default function RoleGate({ allow = [], roles, fallback, children }: Role
   const p = st.profile || null;
 
   // Собираем набор ролей пользователя из разных полей профиля
-  const have = new Set();
+  const have = new Set<string>();
   if (p) {
     if (p.role) have.add(String(p.role).toLowerCase());
     if (p.role_name) have.add(String(p.role_name).toLowerCase());
@@ -55,7 +55,7 @@ export default function RoleGate({ allow = [], roles, fallback, children }: Role
   return fallback !== undefined ? fallback : denyBox(Array.from(have), Array.from(need));
 }
 
-function denyBox(have, need) {
+function denyBox(have: string[], need: string[]) {
   const roleLabel = have.length ? have.join(', ') : '—';
   return (
     <div style={box}>

--- a/frontend/src/components/activation/AppActivation.tsx
+++ b/frontend/src/components/activation/AppActivation.tsx
@@ -75,7 +75,7 @@ const AppActivation = () => {
     }
   };
 
-  const handleKeyPress = (e: React.MouseEvent) => {
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') handleActivate();
   };
 

--- a/frontend/src/components/admin/AdminServices.tsx
+++ b/frontend/src/components/admin/AdminServices.tsx
@@ -12,7 +12,7 @@ import { useTheme } from '../../contexts/ThemeContext';
 const LazyQueueProfilesManager = React.lazy(() => import('./QueueProfilesManager'));
 const LazyServiceCatalog = React.lazy(() => import('./ServiceCatalog'));
 
-const getServiceTabs = (t: string) => [
+const getServiceTabs = (t: (key: string, options?: Record<string, unknown>) => string) => [
   { key: 'catalog', label: t('admin2.asv_tab_catalog'), icon: Package },
   { key: 'queue-profiles', label: t('admin2.asv_tab_queue_profiles'), icon: FolderTree },
 ];

--- a/frontend/src/components/admin/UnifiedFinance.tsx
+++ b/frontend/src/components/admin/UnifiedFinance.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { useTranslation } from '../../i18n/useTranslation';
 
 
-const UnifiedFinance = ({ renderFinance: unknown }) => {
+const UnifiedFinance = ({ renderFinance }: { renderFinance?: () => React.ReactNode }) => {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   const [searchParams] = useSearchParams();
   const section = searchParams.get('section') || 'finance';

--- a/frontend/src/components/admin/WizardSettings.tsx
+++ b/frontend/src/components/admin/WizardSettings.tsx
@@ -21,14 +21,14 @@ import { useTranslation } from '../../i18n/useTranslation';
 import React from "react";
 const WizardSettings = () => {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
-  const [settings, setSettings] = useState({
+  const [settings, setSettings] = useState<{ use_new_wizard: boolean; updated_at: string | null }>({
     use_new_wizard: false,
     updated_at: null
   });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string | null>(null);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
   // Загрузка настроек

--- a/frontend/src/components/cardiology/AppointmentsTab.tsx
+++ b/frontend/src/components/cardiology/AppointmentsTab.tsx
@@ -27,6 +27,15 @@ export function AppointmentsTab({
   onActionClick,
   services = {},
   isDark = false,
+}: {
+  appointments?: Array<Record<string, unknown>>;
+  appointmentsLoading?: boolean;
+  appointmentSummaryItems?: Array<{ key: string; label: string; value: string | number; variant: string }>;
+  onRefresh: () => void;
+  onRowClick?: (row: unknown) => void;
+  onActionClick?: (action: string, row: unknown, event?: unknown) => void;
+  services?: Record<string, unknown>;
+  isDark?: boolean;
 }) {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   return (
@@ -52,7 +61,7 @@ export function AppointmentsTab({
           <MacOSEmptyState type="calendar" title={t('cardio.cardio_appt_empty_title')} description={t('cardio.cardio_appt_empty_desc')} />
         ) : (
           <EnhancedAppointmentsTable
-            data={appointments}
+            data={appointments as never[]}
             loading={appointmentsLoading}
             theme={isDark ? 'dark' : 'light'}
             language="ru"

--- a/frontend/src/components/cardiology/EcgTab.tsx
+++ b/frontend/src/components/cardiology/EcgTab.tsx
@@ -30,6 +30,11 @@ export function EcgTab({
   onAddEcg,
   onDataUpdate,
   getSpacing,
+}: {
+  selectedPatient: Record<string, unknown> | null;
+  onAddEcg: () => void;
+  onDataUpdate: () => void;
+  getSpacing: (key: string) => string;
 }) {
   if (!selectedPatient) {
     return null;
@@ -50,13 +55,13 @@ export function EcgTab({
         </Button>
       </div>
       <ECGViewer
-        visitId={selectedPatient?.visit_id}
-        patientId={selectedPatient?.patient_id || selectedPatient?.patient?.id}
+        visitId={selectedPatient?.visit_id as string | number | undefined}
+        patientId={(selectedPatient?.patient_id || (selectedPatient?.patient as Record<string, unknown> | undefined)?.id) as string | number | undefined}
         onDataUpdate={onDataUpdate}
       />
       <EchoForm
-        visitId={selectedPatient?.visit_id}
-        patientId={selectedPatient?.patient_id || selectedPatient?.patient?.id}
+        visitId={selectedPatient?.visit_id as string | number | undefined}
+        patientId={(selectedPatient?.patient_id || (selectedPatient?.patient as Record<string, unknown> | undefined)?.id) as string | number | null | undefined}
         onDataUpdate={onDataUpdate}
       />
     </div>

--- a/frontend/src/components/common/SessionWarningModal.tsx
+++ b/frontend/src/components/common/SessionWarningModal.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from '../../i18n/useTranslation';
  * DermatologistPanelUnified. Uses macos tokens + Modal component for
  * consistent styling and dark mode support.
  */
-const SessionWarningModal = ({ visible, onDismiss, onExtend }) => {
+const SessionWarningModal = ({ visible, onDismiss, onExtend }: { visible: boolean; onDismiss: () => void; onExtend?: () => void }) => {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   if (!visible) return null;
 

--- a/frontend/src/components/dialogs/PaymentDialog.tsx
+++ b/frontend/src/components/dialogs/PaymentDialog.tsx
@@ -63,6 +63,7 @@ const PaymentDialog = ({
 
   const handlePayment = async () => {
     if (!validateForm()) return;
+    if (!appointment) return;
 
     setIsProcessing(true);
 
@@ -177,7 +178,7 @@ const PaymentDialog = ({
             <p className="payment-patient-name">
               {String(appointment.patient_fio ?? '')}
             </p>
-            {appointment.services && (
+            {!!appointment.services && (
               <p className="payment-patient-services">
                 Услуги:{' '}
                 {Array.isArray(appointment.services)

--- a/frontend/src/components/emr-v2/DoctorTemplatesPanel.tsx
+++ b/frontend/src/components/emr-v2/DoctorTemplatesPanel.tsx
@@ -40,6 +40,12 @@ export function DoctorTemplatesPanel({
     onApply,
     onClose,
     isOpen = false,
+}: {
+    section: string;
+    icd10Code?: string | null;
+    onApply?: (text: string) => void;
+    onClose?: () => void;
+    isOpen?: boolean;
 }) {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
     const {

--- a/frontend/src/components/emr-v2/ai/SmartAssistButton.tsx
+++ b/frontend/src/components/emr-v2/ai/SmartAssistButton.tsx
@@ -21,11 +21,17 @@ import { useTranslation } from '@/i18n/useTranslation';
  * @param {string} props.size - 'small' | 'medium'
  */
 export function SmartAssistButton({
-    onClick: unknown,
+    onClick,
     isLoading = false,
     hasSuggestions = false,
     disabled = false,
     size = 'small',
+}: {
+    onClick: () => void;
+    isLoading?: boolean;
+    hasSuggestions?: boolean;
+    disabled?: boolean;
+    size?: 'small' | 'medium';
 }) {
     return (
         <button

--- a/frontend/src/components/emr-v2/sections/DiagnosisSection.tsx
+++ b/frontend/src/components/emr-v2/sections/DiagnosisSection.tsx
@@ -19,18 +19,19 @@ import './DiagnosisSection.css';
 import { useTranslation } from '@/i18n/useTranslation';
 
 
-function normalizeTextValue(value) {
+function normalizeTextValue(value: unknown): string {
     if (typeof value === 'string') {
         return value;
     }
 
     if (value && typeof value === 'object') {
+        const v = value as Record<string, unknown>;
         return (
-            value.main ||
-            value.primary ||
-            value.text ||
-            value.value ||
-            value.description ||
+            (typeof v.main === 'string' ? v.main : '') ||
+            (typeof v.primary === 'string' ? v.primary : '') ||
+            (typeof v.text === 'string' ? v.text : '') ||
+            (typeof v.value === 'string' ? v.value : '') ||
+            (typeof v.description === 'string' ? v.description : '') ||
             ''
         );
     }
@@ -95,7 +96,7 @@ export function DiagnosisSection({
 
     // 🧠 Connect Doctor History (Personal Learning)
     const { suggestions: doctorSuggestions, loading: historyLoading } = useDoctorPhrases({
-        doctorId,
+        doctorId: doctorId ?? undefined,
         field: 'diagnosis',
         specialty,
         currentText: diagnosisText,
@@ -104,7 +105,7 @@ export function DiagnosisSection({
 
     // Merge suggestions: Doctor History first, then Generic AI
     const allSuggestions = useMemo(() => {
-        const historyItems = doctorSuggestions.map((s: Record<string, unknown>) => ({
+        const historyItems = (doctorSuggestions as Record<string, unknown>[]).map((s) => ({
             id: s.id,
             content: s.text,
             source: 'history', // Badge will show "История"

--- a/frontend/src/components/emr-v2/sections/RecommendationsSection.tsx
+++ b/frontend/src/components/emr-v2/sections/RecommendationsSection.tsx
@@ -48,7 +48,7 @@ export function RecommendationsSection({
   });
 
   // Handle template apply - append to current value
-  const handleApplyTemplate = useCallback((text) => {
+  const handleApplyTemplate = useCallback((text: string) => {
     if (!text) return;
     const current = value || '';
     const newValue = current.trim() ?

--- a/frontend/src/components/emr-v2/sections/VitalsWidget.tsx
+++ b/frontend/src/components/emr-v2/sections/VitalsWidget.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from '@/i18n/useTranslation';
 const VitalsWidget = ({ vitals: vitalsRaw = {}, onChange, onFieldTouch, disabled }: { vitals?: Record<string, unknown>; onChange?: (v: Record<string, any>) => void; onFieldTouch?: (field: string) => void; disabled?: boolean }) => {
   const vitals = vitalsRaw as Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
-    const handleChange = (field, value) => {
+    const handleChange = (field: string, value: string) => {
         onChange?.({ ...vitals, [field]: value });
         onFieldTouch?.(`vitals.${field}`);
     };

--- a/frontend/src/components/examples/InteractiveButton.tsx
+++ b/frontend/src/components/examples/InteractiveButton.tsx
@@ -1,5 +1,5 @@
 
-import { useState } from 'react';
+import { useState, type CSSProperties, type ReactNode } from 'react';
 
 import { useTheme } from '../../contexts/ThemeContext';
 import { useHover } from '../../hooks/useUtils';
@@ -14,6 +14,13 @@ const InteractiveButton = ({
   size = 'md',
   onClick,
   ...props
+}: {
+  children: ReactNode;
+  variant?: string;
+  size?: string;
+  onClick?: () => void;
+  style?: CSSProperties;
+  [key: string]: unknown;
 }) => {
   const { getColor, getSpacing, getShadow } = useTheme();
   void size;
@@ -84,8 +91,8 @@ const InteractiveButton = ({
         fontWeight: 'var(--mac-font-weight-medium)',
         cursor: 'pointer',
         outline: 'none',
-        ...getButtonStyle(),
-        ...props.style
+        ...(getButtonStyle() as CSSProperties),
+        ...(props.style as CSSProperties)
       }}
       {...props}>
       

--- a/frontend/src/components/examples/RefactoredButton.tsx
+++ b/frontend/src/components/examples/RefactoredButton.tsx
@@ -160,7 +160,7 @@ const RefactoredButton = ({
       },
     };
 
-    return variantMap[variant] || variantMap.primary;
+    return variantMap[variant as keyof typeof variantMap] || variantMap.primary;
   };
 
   // ═══════════════════════════════════════════════════════════════════
@@ -185,7 +185,7 @@ const RefactoredButton = ({
       },
     };
 
-    return sizeMap[size] || sizeMap.medium;
+    return sizeMap[size as keyof typeof sizeMap] || sizeMap.medium;
   };
 
   const variantStyles = getVariantStyles();
@@ -228,7 +228,7 @@ const RefactoredButton = ({
     ...(fullWidth && { width: '100%' }),
   };
 
-  const handleClick = (event: React.MouseEvent) => {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (disabled || loading) return;
     onClick?.(event);
   };
@@ -238,7 +238,7 @@ const RefactoredButton = ({
       ref={buttonRef}
       className={className}
       type={type as "button" | "reset" | "submit"}
-      style={buttonStyles}
+      style={buttonStyles as React.CSSProperties}
       onClick={handleClick}
       disabled={disabled || loading}
       onMouseEnter={(e: React.MouseEvent<HTMLElement>) => {

--- a/frontend/src/components/forms/index.ts
+++ b/frontend/src/components/forms/index.ts
@@ -95,7 +95,7 @@ export const formUtils = {
 
   // Очистка значений формы
   clearForm: (schema: Record<string, unknown>) => {
-    const clearedValues = {};
+    const clearedValues: Record<string, unknown> = {};
     
     Object.keys(schema).forEach(fieldName => {
       clearedValues[fieldName] = '';
@@ -111,7 +111,7 @@ export const formUtils = {
 
   // Получение только измененных полей
   getChangedFields: (currentValues: Record<string, unknown>, initialValues: Record<string, unknown>) => {
-    const changes = {};
+    const changes: Record<string, unknown> = {};
     
     Object.keys(currentValues).forEach(key => {
       if (currentValues[key] !== initialValues[key]) {

--- a/frontend/src/components/integration/IntegrationDemo.tsx
+++ b/frontend/src/components/integration/IntegrationDemo.tsx
@@ -30,7 +30,7 @@ const IntegrationDemo = () => {
   // Используем созданные хуки
   const queueManager = useQueueManager() as unknown as IntegrationDemoQueueManager;
   const emrAI = useEMRAI();
-  const { users, appointments, actions } = useAppData() as unknown as { users: unknown[]; appointments: unknown[]; actions: { setLoading: (key: string, v: boolean) => void; setUsers: (v: unknown[]) => void; [key: string]: unknown }; };
+  const { users, appointments, actions } = useAppData() as unknown as { users: Record<string, unknown>[]; appointments: unknown[]; actions: { setLoading: (key: string, v: boolean) => void; setUsers: (v: unknown[]) => void; [key: string]: unknown }; };
 
   // Локальные состояния для демо
   const [testSymptoms, setTestSymptoms] = useState(t('misc.id_golovnaya_bol_toshnota'));
@@ -51,7 +51,7 @@ const IntegrationDemo = () => {
 
   const handleQueueTest = async () => {
     const today = new Date().toISOString().split('T')[0];
-    await queueManager.generateQRCode(today, '1');
+    await queueManager.generateQRCode?.(today, '1');
   };
 
   const handleAITest = async () => {

--- a/frontend/src/components/laboratory/templateEditor/config.ts
+++ b/frontend/src/components/laboratory/templateEditor/config.ts
@@ -53,6 +53,6 @@ export const EDITOR_TABS = [
   { id: 'preview',  label: 'Предпросмотр' },
 ];
 
-export function formatVersionStatus(status) {
-  return versionStatusLabels[status] || status;
+export function formatVersionStatus(status: string) {
+  return versionStatusLabels[status as keyof typeof versionStatusLabels] || status;
 }

--- a/frontend/src/components/landing/ControlCenter.tsx
+++ b/frontend/src/components/landing/ControlCenter.tsx
@@ -1,7 +1,7 @@
 
 import PropTypes from 'prop-types';
 import { useTranslation } from '../../i18n/useTranslation';
-export const ControlCenter = ({ onActivate, onLogin }) => {
+export const ControlCenter = ({ onActivate, onLogin }: { onActivate: () => void; onLogin: () => void }) => {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   return (
     <div className="control-center spotlight-card">

--- a/frontend/src/components/layout/ModernFlex.tsx
+++ b/frontend/src/components/layout/ModernFlex.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 import { useTheme } from '../../contexts/ThemeContext';
 import PropTypes from 'prop-types';
@@ -15,6 +15,16 @@ const ModernFlex = ({
   responsive = true,
   className = '',
   ...props
+}: {
+  children?: ReactNode;
+  direction?: string;
+  wrap?: string;
+  justify?: string;
+  align?: string;
+  gap?: string | number;
+  responsive?: boolean;
+  className?: string;
+  [key: string]: unknown;
 }) => {
   useTheme();
 
@@ -54,6 +64,13 @@ export const FlexItem = ({
   order = 'auto',
   className = '',
   ...props
+}: {
+  children?: ReactNode;
+  flex?: string | number;
+  alignSelf?: string;
+  order?: string | number;
+  className?: string;
+  [key: string]: unknown;
 }) => {
   const itemStyles = {
     flex,

--- a/frontend/src/components/layout/ModernGrid.tsx
+++ b/frontend/src/components/layout/ModernGrid.tsx
@@ -1,3 +1,5 @@
+import type { CSSProperties, ReactNode } from 'react';
+
 import { useTheme } from '../../contexts/ThemeContext';
 import PropTypes from 'prop-types';
 import './ModernGrid.css';
@@ -13,6 +15,16 @@ const ModernGrid = ({
   minColumnWidth = '250px',
   className = '',
   ...props
+}: {
+  children?: ReactNode;
+  columns?: number | string;
+  gap?: string | number;
+  alignItems?: string;
+  justifyContent?: string;
+  responsive?: boolean;
+  minColumnWidth?: string;
+  className?: string;
+  [key: string]: unknown;
 }) => {
   useTheme();
 
@@ -34,10 +46,10 @@ const ModernGrid = ({
     xl: '32px'
   };
 
-  const gridStyles = {
+  const gridStyles: CSSProperties = {
     display: 'grid',
     gridTemplateColumns: getGridColumns(),
-    gap: gapValues[gap] || gap,
+    gap: (gapValues as Record<string, string>)[gap as string] || gap,
     alignItems,
     justifyContent
   };
@@ -62,6 +74,14 @@ export const GridItem = ({
   justifySelf = 'auto',
   className = '',
   ...props
+}: {
+  children?: ReactNode;
+  colSpan?: number;
+  rowSpan?: number;
+  alignSelf?: string;
+  justifySelf?: string;
+  className?: string;
+  [key: string]: unknown;
 }) => {
   const itemStyles = {
     gridColumn: colSpan > 1 ? `span ${colSpan}` : 'auto',

--- a/frontend/src/components/mobile/PWAInstallPrompt.tsx
+++ b/frontend/src/components/mobile/PWAInstallPrompt.tsx
@@ -4,12 +4,18 @@ import { Download, X, Smartphone, Monitor } from 'lucide-react';
 import { Button, Card } from '../ui/macos';
 import logger from '../../utils/logger';
 import { useTranslation } from '../../i18n/useTranslation';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
 /**
  * Компонент для предложения установки PWA
  */
 const PWAInstallPrompt = () => {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
-  const [deferredPrompt, setDeferredPrompt] = useState(null);
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [showInstallPrompt, setShowInstallPrompt] = useState(false);
   const [isInstalled, setIsInstalled] = useState(false);
 
@@ -24,9 +30,9 @@ const PWAInstallPrompt = () => {
     checkIfInstalled();
 
     // Слушаем событие beforeinstallprompt
-    const handleBeforeInstallPrompt = (e) => {
+    const handleBeforeInstallPrompt = (e: Event) => {
       e.preventDefault();
-      setDeferredPrompt(e);
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
       setShowInstallPrompt(true);
     };
 

--- a/frontend/src/components/patient/patientSections.ts
+++ b/frontend/src/components/patient/patientSections.ts
@@ -53,14 +53,14 @@ export const PATIENT_SECTIONS = {
 export const PATIENT_SECTION_KEYS = Object.keys(PATIENT_SECTIONS);
 
 export const VISIBLE_PATIENT_TABS = PATIENT_SECTION_KEYS.filter(
-  (key) => PATIENT_SECTIONS[key].visibleInTabs
+  (key) => PATIENT_SECTIONS[key as keyof typeof PATIENT_SECTIONS].visibleInTabs
 );
 
-export function normalizeSection(value) {
+export function normalizeSection(value: unknown) {
   if (!value) {
     return 'home';
   }
-  return PATIENT_SECTIONS[String(value).toLowerCase()]
+  return PATIENT_SECTIONS[String(value).toLowerCase() as keyof typeof PATIENT_SECTIONS]
     ? String(value).toLowerCase()
     : 'home';
 }

--- a/frontend/src/components/payment/CashPaymentModal.tsx
+++ b/frontend/src/components/payment/CashPaymentModal.tsx
@@ -97,7 +97,7 @@ const CashPaymentModal = ({ appointment, onProcessPayment, onClose }: CashPaymen
             return;
         }
         // Pass change due up to parent for receipt printing (HIGH #9 fix).
-        onProcessPayment(appointment, {
+        onProcessPayment?.(appointment, {
             ...paymentData,
             amount: Number(paymentData.amount),
             change_due: changeDue,
@@ -179,7 +179,7 @@ const CashPaymentModal = ({ appointment, onProcessPayment, onClose }: CashPaymen
                             id="cash-payment-method"
                             aria-label={t('payment.pay_cash_method_aria')}
                             value={paymentData.method}
-                            onChange={(value: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => setPaymentData(prev => ({ ...prev, method: value as unknown as string }))}
+                            onChange={(value) => setPaymentData(prev => ({ ...prev, method: value as unknown as string }))}
                             options={getPaymentMethodOptions(t)}
                             className="cpm-select-full"
                         />

--- a/frontend/src/components/pwa/CompactConnectionStatus.tsx
+++ b/frontend/src/components/pwa/CompactConnectionStatus.tsx
@@ -14,7 +14,7 @@ const CompactConnectionStatus = ({ className = '', showTooltip = true }) => {
   ));
   const [isServiceWorkerReady, setIsServiceWorkerReady] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
-  const [lastSyncTime, setLastSyncTime] = useState(null);
+  const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') return undefined;
@@ -58,7 +58,7 @@ const CompactConnectionStatus = ({ className = '', showTooltip = true }) => {
   // Слушаем сообщения от Service Worker о синхронизации
   useEffect(() => {
     if ('serviceWorker' in navigator) {
-      const handleMessage = (event) => {
+      const handleMessage = (event: MessageEvent) => {
         if (event.data && event.data.type === 'SYNC_COMPLETE') {
           setLastSyncTime(new Date(event.data.timestamp));
           setIsSyncing(false);

--- a/frontend/src/components/statistics/ModernStatisticsSimple.tsx
+++ b/frontend/src/components/statistics/ModernStatisticsSimple.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-const ModernStatistics = ({ appointments, onExport, onRefresh }) => {
+const ModernStatistics = ({ appointments, onExport, onRefresh }: { appointments?: unknown[]; onExport?: () => void; onRefresh?: () => void }) => {
   return (
     <div style={{ padding: 'var(--mac-spacing-5)', border: '1px solid #ccc', borderRadius: 'var(--mac-radius-md)', marginBottom: 'var(--mac-spacing-5)' }}>
       <h3>Статистика (упрощенная версия)</h3>

--- a/frontend/src/components/test/ComponentTest.tsx
+++ b/frontend/src/components/test/ComponentTest.tsx
@@ -84,7 +84,7 @@ function ComponentTestInner() {
     fontSize: getFontSize('sm')
   };
 
-  const handleTestToast = (type) => {
+  const handleTestToast = (type: string) => {
     addToast({
       type,
       title: t('misc.ct_toast_title', { type }),
@@ -115,7 +115,7 @@ function ComponentTestInner() {
     setTimeout(() => setLoading(false), 2000);
   };
 
-  const handleFormSubmit = (values) => {
+  const handleFormSubmit = (values: Record<string, unknown>) => {
     logger.log('Form submitted:', values);
     addToast({
       type: 'success',
@@ -200,7 +200,7 @@ function ComponentTestInner() {
       {/* Тест форм */}
       <div style={sectionStyle}>
         <h2 style={titleStyle}>{t('misc.ct_section_forms')}</h2>
-        <form onSubmit={(e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); handleFormSubmit(form?.values); }}>
+        <form onSubmit={(e: React.FormEvent<HTMLFormElement>) => { e.preventDefault(); handleFormSubmit(form?.values ?? {}); }}>
           <input
             type="text"
             aria-label="Test form name"

--- a/frontend/src/components/ui/FileUpload.tsx
+++ b/frontend/src/components/ui/FileUpload.tsx
@@ -72,9 +72,9 @@ const FileUpload = ({
         let fileToProcess: File | Blob = file;
 
         // Check if HEIC/HEIF
-        if (isHEICFile(file)) {
+        if (isHEICFile(file as File)) {
           try {
-            fileToProcess = await convertHEICToJPEG(file, 0.9);
+            fileToProcess = await convertHEICToJPEG(file as File, 0.9);
           } catch {
             logger.warn(`Could not convert ${(file as File).name}, using original`);
           }

--- a/frontend/src/components/wizard/EditModeBanner.tsx
+++ b/frontend/src/components/wizard/EditModeBanner.tsx
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import './EditModeBanner.css';
 import { useTranslation } from '../../i18n/useTranslation';
 
-const EditModeBanner = ({ editMode, initialData }) => {
+const EditModeBanner = ({ editMode, initialData }: { editMode?: boolean; initialData?: Record<string, unknown> | null }) => {
   const { t } = useTranslation();
   if (!editMode) return null;
 


### PR DESCRIPTION
## Summary

- BS-66 components batch 2: 32 component files fixed for strict:true. 76 errors fixed.
- Fixed 2 latent runtime bugs: SmartAssistButton onClick:undefined, UnifiedFinance renderFinance:undefined.

## Cyclic Execution Evidence

- Fresh main sync: branch based on origin/main at commit ea22e591.
- Red-check handling: tsc --noEmit 48 errors (all pre-existing, -14 from bug fixes); eslint clean; 31/31 regression PASS; 202/202 tests pass.

## Contract Impact

- not applicable - type annotations only + 2 latent bug fixes (onClick/renderFinance were undefined due to destructuring rename).

## RBAC / Permissions

- not applicable.

## Notification / Realtime

- not applicable.

## Frontend Resilience

- not applicable - type annotations only.

## Scope Gate

- Allowed paths: 32 files in src/components/.
- Rollback note: git revert HEAD.

## Validation

- tsc --noEmit 48 errors (all pre-existing); eslint clean; regression 31/31 pass; vitest 202/202 pass.

Generated with Claude - verification-pass audit