### PR TITLE
strict: re-fix services/ after PR #2528 regression (BS-66)

### DIFF
--- a/frontend/src/services/payment.ts
+++ b/frontend/src/services/payment.ts
@@ -19,7 +19,7 @@ export const paymentService = {
     } catch (error) {
       return {
         success: false,
-        error: error.response?.data?.detail || 'Ошибка получения провайдеров'
+        error: (error as { response?: { data?: { detail?: string } } })?.response?.data?.detail || 'Ошибка получения провайдеров'
       };
     }
   },
@@ -27,7 +27,7 @@ export const paymentService = {
   /**
    * Инициализация платежа
    */
-  async initPayment(paymentData) {
+  async initPayment(paymentData: Record<string, unknown>) {
     try {
       const response = await api.post('/payments/init', paymentData);
       
@@ -38,7 +38,7 @@ export const paymentService = {
     } catch (error) {
       return {
         success: false,
-        error: error.response?.data?.detail || 'Ошибка инициализации платежа'
+        error: (error as { response?: { data?: { detail?: string } } })?.response?.data?.detail || 'Ошибка инициализации платежа'
       };
     }
   },
@@ -46,7 +46,7 @@ export const paymentService = {
   /**
    * Получение статуса платежа
    */
-  async getPaymentStatus(paymentId) {
+  async getPaymentStatus(paymentId: string | number) {
     try {
       const response = await api.get(`/payments/${paymentId}`);
       
@@ -57,7 +57,7 @@ export const paymentService = {
     } catch (error) {
       return {
         success: false,
-        error: error.response?.data?.detail || 'Ошибка получения статуса платежа'
+        error: (error as { response?: { data?: { detail?: string } } })?.response?.data?.detail || 'Ошибка получения статуса платежа'
       };
     }
   },
@@ -65,7 +65,7 @@ export const paymentService = {
   /**
    * Генерация квитанции
    */
-  async generateReceipt(paymentId, format = 'pdf') {
+  async generateReceipt(paymentId: string | number, format = 'pdf') {
     try {
       const response = await api.get(`/payments/${paymentId}/receipt`, {
         params: { format_type: format }
@@ -78,7 +78,7 @@ export const paymentService = {
     } catch (error) {
       return {
         success: false,
-        error: error.response?.data?.detail || 'Ошибка генерации квитанции'
+        error: (error as { response?: { data?: { detail?: string } } })?.response?.data?.detail || 'Ошибка генерации квитанции'
       };
     }
   },
@@ -86,7 +86,7 @@ export const paymentService = {
   /**
    * Скачивание квитанции
    */
-    async downloadReceipt(paymentId) {
+    async downloadReceipt(paymentId: string | number) {
     try {
       const response = await api.get(`/payments/${paymentId}/receipt/download`, {
         responseType: 'blob'
@@ -111,7 +111,7 @@ export const paymentService = {
     } catch (error) {
       return {
         success: false,
-        error: error.response?.data?.detail || 'Ошибка скачивания квитанции'
+        error: (error as { response?: { data?: { detail?: string } } })?.response?.data?.detail || 'Ошибка скачивания квитанции'
       };
     }
   },
@@ -123,8 +123,8 @@ export const paymentService = {
    * основной валюте (som/tenge), не в тийинах/копейках. Раньше все суммы
    * отображались в 100 раз меньше реальной (15000 UZS → "150 сум").
    */
-  formatAmount(amount, currency = 'UZS') {
-    const numAmount = parseFloat(amount) || 0;
+  formatAmount(amount: number | string, currency = 'UZS') {
+    const numAmount = parseFloat(String(amount)) || 0;
 
     if (currency === 'UZS') {
       return `${numAmount.toLocaleString('ru-RU')} сум`;
@@ -138,8 +138,8 @@ export const paymentService = {
   /**
    * Получение названия провайдера
    */
-  getProviderName(providerCode) {
-    const names = {
+  getProviderName(providerCode: string): string {
+    const names: Record<string, string> = {
       click: 'Click',
       payme: 'Payme',
       kaspi: 'Kaspi Pay'
@@ -150,12 +150,12 @@ export const paymentService = {
   /**
    * Получение статуса платежа (локализованный)
    */
-  getStatusText(status) {
+  getStatusText(status: string): string {
     // PAY-REAUDIT-28 P1-10: добавлены отсутствовавшие статусы `paid`,
     // `refunded`, `void`, `canceled`. Backend использует `paid` как
     // основной статус успеха (PaymentStatus.PAID.value), но фронтенд
     // показывал сырую английскую строку "paid".
-    const texts = {
+    const texts: Record<string, string> = {
       pending: 'Ожидает',
       processing: 'Обработка',
       paid: 'Оплачено',

--- a/frontend/src/services/print.ts
+++ b/frontend/src/services/print.ts
@@ -4,7 +4,7 @@
  */
 import { api } from '../api/client';
 
-const normalizePrintResponse = (responseData, fallbackErrorMessage: string) => {
+const normalizePrintResponse = (responseData: Record<string, unknown>, fallbackErrorMessage: string) => {
   if (responseData?.success === false) {
     return {
       success: false,
@@ -19,9 +19,9 @@ const normalizePrintResponse = (responseData, fallbackErrorMessage: string) => {
   };
 };
 
-const normalizePrintError = (error, fallbackMessage: string) => ({
+const normalizePrintError = (error: unknown, fallbackMessage: string) => ({
   success: false,
-  error: error.response?.data?.detail || fallbackMessage
+  error: (error as { response?: { data?: { detail?: string } } })?.response?.data?.detail || fallbackMessage
 });
 
 export const printService = {
@@ -44,7 +44,7 @@ export const printService = {
   /**
    * Печать талона очереди
    */
-  async printTicket(ticketData) {
+  async printTicket(ticketData: Record<string, unknown>) {
     try {
       const response = await api.post('/print/ticket', ticketData);
 
@@ -57,7 +57,7 @@ export const printService = {
   /**
    * Печать рецепта (PDF)
    */
-  async printPrescription(prescriptionData) {
+  async printPrescription(prescriptionData: Record<string, unknown>) {
     try {
       const response = await api.post('/print/prescription', prescriptionData);
 
@@ -70,7 +70,7 @@ export const printService = {
   /**
    * Печать справки
    */
-  async printCertificate(certificateData) {
+  async printCertificate(certificateData: Record<string, unknown>) {
     try {
       const response = await api.post('/print/certificate', certificateData);
 
@@ -83,7 +83,7 @@ export const printService = {
   /**
    * Печать лабораторных результатов
    */
-  async printLabResults(labResultsData) {
+  async printLabResults(labResultsData: Record<string, unknown>) {
     try {
       const response = await api.post('/print/lab-results', labResultsData);
 
@@ -96,7 +96,7 @@ export const printService = {
   /**
    * Печать чека
    */
-  async printReceipt(receiptData) {
+  async printReceipt(receiptData: Record<string, unknown>) {
     try {
       const response = await api.post('/print/receipt', receiptData);
 
@@ -109,7 +109,7 @@ export const printService = {
   /**
    * Быстрая печать
    */
-  async quickPrint(text, printerName = 'default') {
+  async quickPrint(text: string, printerName = 'default') {
     return {
       success: false,
       error:
@@ -120,7 +120,7 @@ export const printService = {
   /**
    * Быстрая печать талона очереди
    */
-  async quickQueueTicket(ticketData) {
+  async quickQueueTicket(ticketData: Record<string, unknown>) {
     try {
       const response = await api.post('/print/quick/queue-ticket', ticketData);
 
@@ -133,7 +133,7 @@ export const printService = {
   /**
    * Быстрая печать чека
    */
-  async quickPaymentReceipt(receiptData) {
+  async quickPaymentReceipt(receiptData: Record<string, unknown>) {
     try {
       const response = await api.post('/print/quick/payment-receipt', receiptData);
 
@@ -146,7 +146,7 @@ export const printService = {
   /**
    * Получение шаблонов печати
    */
-  async getTemplates(templateType, language = 'ru') {
+  async getTemplates(templateType: string, language = 'ru') {
     try {
       const response = await api.get('/print/templates/templates', {
         params: { template_type: templateType, language }
@@ -164,7 +164,7 @@ export const printService = {
   /**
    * Проверка статуса принтера
    */
-  async checkPrinterStatus(printerName) {
+  async checkPrinterStatus(printerName: string) {
     try {
       const response = await api.get(`/print/printers/${printerName}/status`);
 
@@ -177,7 +177,7 @@ export const printService = {
   /**
    * Тестовая печать
    */
-  async testPrint(printerName) {
+  async testPrint(printerName: string) {
     try {
       const response = await api.post(
         `/print/printers/${encodeURIComponent(printerName)}/test`


### PR DESCRIPTION
## Summary

- Re-fix services/ after PR #2528 (G8 strict islands) overwrote payment.ts + print.ts with untyped versions.
- services/ (excl panelPrint) now strict-clean again: 0 errors.

## Cyclic Execution Evidence

- Fresh main sync: synced from origin/main at commit 54466ab4. Checked PR #2528 changes — it overwrote our type annotations in payment.ts + print.ts.
- Checked parallel branches: phase-g8-strict-islands-v2, 20+ open PRs — no conflicts.
- Red-check handling: eslint clean; 31/31 regression PASS; 202/202 tests pass.

## Contract Impact

- not applicable - type annotations only.

## RBAC / Permissions

- not applicable.

## Notification / Realtime

- not applicable.

## Frontend Resilience

- not applicable - type annotations only.

## Scope Gate

- Allowed paths: src/services/payment.ts, src/services/print.ts only.
- Rollback note: git revert HEAD.

## Validation

- eslint clean; regression 31/31 pass; vitest 202/202 pass.

Generated with Claude - verification-pass audit