### PR TITLE
🎨 Palette: Ensure proper error announcement for form fields

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-12 - Missing aria-busy on Complex Loading States
 **Learning:** While buttons effectively communicated their loading states via `aria-busy`, larger container components in the design system (Tables, Lists, Stat Cards) with custom loading skeletons or empty states completely lacked this attribute. This creates a confusing experience for screen reader users who aren't notified when these regions are processing or waiting for data.
 **Action:** Always add `aria-busy="true"` (or `aria-busy={loading}`) to the root container of complex UI components that handle asynchronous data loading, especially when rendering custom loading skeletons or empty states instead of standard UI elements.
+
+## 2024-07-26 - Missing aria-invalid on Custom Inputs
+**Learning:** Custom form wrappers like `Input`, `Textarea`, and `Select` often manage visual error states well (e.g., via red borders or text) but frequently fail to pass `aria-invalid={!!error}` to the underlying native element. This leaves screen reader users completely unaware that a field is in an invalid state.
+**Action:** Always ensure that custom form wrappers correctly map their `error` prop (even if it's a boolean or a string) to the `aria-invalid` attribute of the underlying native element (`<input>`, `<textarea>`, or the trigger `<button>` for selects).

--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -174,6 +174,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         className={className}
         style={inputStyle}
         disabled={disabled}
+        aria-invalid={!!error}
         onFocus={handleFocus}
         onBlur={handleBlur}
         {...props}

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -255,6 +255,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           style={trigger}
           aria-haspopup="listbox"
           aria-expanded={isOpen}
+          aria-invalid={!!error}
           disabled={disabled}
           {...props}
         >

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -141,6 +141,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       className={className}
       style={textareaStyles}
       disabled={disabled}
+      aria-invalid={!!error}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}


### PR DESCRIPTION
💡 **What**: Added `aria-invalid={!!error}` to the core form components (`Input`, `Textarea`, and `Select`).
🎯 **Why**: Custom form wrappers often visually indicate errors (e.g., red borders) but fail to communicate this semantic state to screen readers.
♿ **Accessibility**: Improves the experience for screen reader users by properly announcing when a form field is invalid.

---
*PR created automatically by Jules for task [2009729189484673081](https://jules.google.com/task/2009729189484673081) started by @drsapaev*