### PR TITLE
G8: fix 5 files strict errors via 2 subagents (Modal, Toast, EMRDiffViewer, ProtocolTemplates, panelPrint)

### DIFF
--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -10,7 +10,7 @@ const t18 = i18n.t as unknown as (key: string, options?: Record<string, unknown>
 
 // Контекст для модальных окон
 const ModalContext = createContext<any>(null);
-let openModalExternal = null;
+let openModalExternal: ((modal: unknown) => number) | null = null;
 
 const getFontSize = (size) => {
   // t accessed via closure or t18()
@@ -27,7 +27,7 @@ const getFontSize = (size) => {
  * Провайдер контекста модальных окон
  */
 export function ModalProvider({ children }) {
-  const [modals, setModals] = useState([]);
+  const [modals, setModals] = useState<ModalEntry[]>([]);
   const theme = useTheme();
 
   const openModal = useCallback((modal) => {

--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -16,7 +16,7 @@ let addToastExternal: ((toast: unknown) => void) | null = null;
  */
 export function ToastProvider({ children }) {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
-  const [toasts, setToasts] = useState([]);
+  const [toasts, setToasts] = useState<Record<string, unknown>[]>([]);
   const theme = useTheme();
 
   const addToast = useCallback((toast) => {
@@ -231,8 +231,8 @@ function ToastItem({ toast, onRemove, theme }: { toast: Record<string, unknown>;
     <div style={getToastStyles(toast.type as string) as unknown as CSSProperties}>
       {getIcon(toast.type as string)}
       <div style={contentStyle as unknown as CSSProperties}>
-        {toast.title && <div style={titleStyle as unknown as CSSProperties}>{toast.title as string}</div>}
-        {toast.message && <div style={messageStyle}>{toast.message as string}</div>}
+        {Boolean(toast.title) && <div style={titleStyle as unknown as CSSProperties}>{toast.title as string}</div>}
+        {Boolean(toast.message) && <div style={messageStyle}>{toast.message as string}</div>}
       </div>
       <button
         style={closeButtonStyle}

--- a/frontend/src/components/dental/ProtocolTemplates.tsx
+++ b/frontend/src/components/dental/ProtocolTemplates.tsx
@@ -223,9 +223,9 @@ const ProtocolTemplates = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [filterCategory, setFilterCategory] = useState('all');
   const [filterDifficulty, setFilterDifficulty] = useState('all');
-  const [selectedTemplate, setSelectedTemplate] = useState(null);
+  const [selectedTemplate, setSelectedTemplate] = useState<typeof templates[number] | null>(null);
   const [, setIsEditing] = useState(false);
-  const [, setEditingTemplate] = useState(null);
+  const [, setEditingTemplate] = useState<typeof templates[number] | null>(null);
 
   // Фильтрация шаблонов
   const filteredTemplates = templates.filter((template) => {
@@ -266,7 +266,7 @@ const ProtocolTemplates = ({
   };
 
   useEffect(() => {
-    const handlers = [];
+    const handlers: Array<[Element, (event: any) => void]> = [];
 
     document.querySelectorAll('button[data-protocol-template-select="true"]').forEach((button) => {
       const templateId = button.getAttribute('data-template-id');

--- a/frontend/src/components/emr-v2/EMRDiffViewer.tsx
+++ b/frontend/src/components/emr-v2/EMRDiffViewer.tsx
@@ -23,6 +23,24 @@ import './EMRDiffViewer.css';
 import { useTranslation } from '../../i18n/useTranslation';
 
 /**
+ * Shape of a single field-level change returned by the EMR diff endpoint.
+ */
+interface EMRDiffChange {
+    field: string;
+    change_type: string;
+    old_value?: unknown;
+    new_value?: unknown;
+}
+
+/**
+ * Shape of the EMR diff payload returned from the API.
+ */
+interface EMRDiffData {
+    changes?: EMRDiffChange[];
+    summary?: string;
+}
+
+/**
  * Human-readable field labels (Russian)
  */
 const getFieldLabels = (t) => ({
@@ -103,9 +121,9 @@ export function EMRDiffViewer({
     onClose,
 }) {
     const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
-    const [diff, setDiff] = useState(null);
+    const [diff, setDiff] = useState<EMRDiffData | null>(null);
     const [loading, setLoading] = useState(false);
-    const [error, setError] = useState(null);
+    const [error, setError] = useState<string | null>(null);
 
     // Load diff when versions change
     useEffect(() => {

--- a/frontend/src/services/panelPrint.ts
+++ b/frontend/src/services/panelPrint.ts
@@ -95,7 +95,7 @@ function normalizeTimeOnly(value: unknown): string | null {
   return parsed ? formatPrintableTime(parsed) : null;
 }
 
-function formatTicketTimeWindow(row: Record<string, unknown>): string {
+function formatTicketTimeWindow(row: Record<string, unknown>): string | null {
   const fullDateTimeCandidate = getFirstDefined(
     row?.appointment_time,
     row?.queue_time,
@@ -349,7 +349,7 @@ function normalizeTicketSources(row: Record<string, unknown>, overrides: Record<
   return [];
 }
 
-function resolveServicePriceForTicket(row: Record<string, unknown>, source: Record<string, unknown>, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function resolveServicePriceForTicket(row: Record<string, unknown>, source: Record<string, unknown>, overrides: Record<string, unknown> = {}): Record<string, unknown> | null {
   const directPrice = getFirstDefined(
     overrides.servicePrice,
     source?.service_price,


### PR DESCRIPTION
## Summary

- Fix 25 strict TypeScript errors in 5 files using 2 parallel subagents (Modal, Toast, EMRDiffViewer, ProtocolTemplates, panelPrint).
- Common patterns: typed `useState` arrays, typed function variables, widened return types to include `| null`, typed event handler arrays, added interfaces for diff data.
- Strict-baseline improved: noImplicitAny **-1168** (was -1160), strictNullChecks **-829** (was -804).

## Cyclic Execution Evidence

- Fresh main sync: yes — branch created from `origin/main` (currently `a84919d7`).
- Clean workspace: yes — `git status` reports `nothing to commit, working tree clean` on `9880aef0`.
- Branch: `phase-g8-v9` (head `9880aef0`, base `main` @ `a84919d7`).
- Scope gate: allowed `frontend/src/components/{common,emr-v2,dental}/`, `frontend/src/services/`; denied unrelated files.
- Red-check handling: none — all changes are type-only, no runtime behavior changed.

## Contract Impact

- Canonical surface: no backend endpoint, websocket channel, or event payload changed.
- Request shape: not applicable - no API request payload or signature changed.
- Response shape: not applicable - no API response handling rewritten.
- Status codes: not applicable - no HTTP status handling touched.
- Frontend consumer: `panelPrint.ts` widened return types from `string` to `string | null` and from `Record<string, unknown>` to `Record<string, unknown> | null` — callers already handle null via optional chaining. No behavioral change.
- Compatibility path or alias: not applicable - no alias added or removed.
- Contract proof: `npx tsc -p tsconfig.strict.json` exits 0.

## RBAC / Permissions

not applicable - no route guard, endpoint authorization, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - no user-facing data flow changed (type-only refactor).
- Partial data proof: not applicable - type annotations don't affect runtime data handling.
- Forbidden secondary path behavior: not applicable - no secondary path in changed files.
- Missing draft/resource behavior: not applicable - no draft/resource creation changed.
- Stale route/deep-link behavior: not applicable - no route handling changed.

## Scope Gate

- Allowed paths: `frontend/src/components/common/Modal.tsx`, `frontend/src/components/common/Toast.tsx`, `frontend/src/components/emr-v2/EMRDiffViewer.tsx`, `frontend/src/components/dental/ProtocolTemplates.tsx`, `frontend/src/services/panelPrint.ts`.
- Denied paths: all other files.
- Migration/docs/test impact: no migration; no docs; no test files changed.
- Rollback note: revert 1 commit. Safe — pure type-level refactor, no behavioral change.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: `npx tsc --noEmit -p tsconfig.strict.json` (strict gate), `npx tsc --noEmit` (full type-check), `npm run strict:baseline` (regression gate).
- Result: strict-gate PASSES (0 errors). tsc reports 24 errors (same as origin/main). `npm run strict:baseline` PASSES: noImplicitAny 3087 (baseline 4255, delta **-1168**), strictNullChecks 3959 (baseline 4788, delta **-829**).
- Not checked: full Vitest suite (type-only changes, no behavioral test added/removed).

