### PR TITLE
strict: 4 misc files (BS-66 batch 17D)

### DIFF
--- a/frontend/src/components/admin/UserDataTransferManager.tsx
+++ b/frontend/src/components/admin/UserDataTransferManager.tsx
@@ -9,67 +9,116 @@ import { api } from '../../api/client';
 
 import logger from '../../utils/logger';
 
-const toArray = (value, fallbackKeys = []) => {
+interface TransferUser {
+  id: string | number;
+  full_name?: string;
+  username?: string;
+  phone?: string;
+  email?: string;
+}
+
+interface DataTypeItem {
+  key: string;
+  name: string;
+  description: string;
+}
+
+interface DataCounts {
+  appointments: number;
+  visits: number;
+  queue_entries: number;
+  [k: string]: unknown;
+}
+
+interface DataSummary {
+  data_counts: DataCounts;
+  [k: string]: unknown;
+}
+
+interface TransferHistoryEntry {
+  source_user: string;
+  target_user: string;
+  transfer_date: string;
+  success: boolean;
+  [k: string]: unknown;
+}
+
+interface TransferStatistics {
+  total_transfers: number;
+  successful_transfers: number;
+  failed_transfers: number;
+  [k: string]: unknown;
+}
+
+const toArray = (value: unknown, fallbackKeys: string[] = []): unknown[] => {
   if (Array.isArray(value)) return value;
 
-  for (const key of fallbackKeys) {
-    if (Array.isArray(value?.[key])) {
-      return value[key];
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    for (const key of fallbackKeys) {
+      if (Array.isArray(obj[key])) {
+        return obj[key] as unknown[];
+      }
     }
   }
 
   return [];
 };
 
-const normalizeDataTypes = (payload) =>
-  toArray(payload, ['data_types', 'dataTypes', 'items', 'results']).map((item) => {
+const normalizeDataTypes = (payload: unknown): DataTypeItem[] =>
+  (toArray(payload, ['data_types', 'dataTypes', 'items', 'results']) as Array<Record<string, unknown> | string>).map((item): DataTypeItem | null => {
     if (typeof item === 'string') {
       return { key: item, name: item, description: '' };
     }
 
-    const key = item?.key || item?.value || item?.id || item?.name;
+    const key = (item?.key ?? item?.value ?? item?.id ?? item?.name) as string | undefined;
     if (!key) return null;
 
     return {
-      ...item,
       key,
-      name: item?.name || item?.label || key,
-      description: item?.description || ''
+      name: (item?.name ?? item?.label ?? key) as string,
+      description: (item?.description ?? '') as string
     };
-  }).filter(Boolean);
+  }).filter((item): item is DataTypeItem => item !== null);
 
-const normalizeDataSummary = (payload) => ({
-  ...(payload || {}),
-  data_counts: {
-    appointments: 0,
-    visits: 0,
-    queue_entries: 0,
-    ...(payload?.data_counts || {})
-  }
-});
+const normalizeDataSummary = (payload: unknown): DataSummary => {
+  const base = (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>;
+  const counts = (base.data_counts && typeof base.data_counts === 'object' ? base.data_counts : {}) as Record<string, unknown>;
+  return {
+    ...base,
+    data_counts: {
+      appointments: Number(counts.appointments ?? 0),
+      visits: Number(counts.visits ?? 0),
+      queue_entries: Number(counts.queue_entries ?? 0)
+    }
+  };
+};
 
-const normalizeStatistics = (payload) => ({
-  total_transfers: 0,
-  successful_transfers: 0,
-  failed_transfers: 0,
-  ...(payload || {})
-});
+const normalizeStatistics = (payload: unknown): TransferStatistics => {
+  const base = (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>;
+  return {
+    total_transfers: Number(base.total_transfers ?? 0),
+    successful_transfers: Number(base.successful_transfers ?? 0),
+    failed_transfers: Number(base.failed_transfers ?? 0),
+    ...base
+  };
+};
 
 const UserDataTransferManager = () => {
   const { t: rawT } = useTranslation();
   const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
-  const [activeTab, setActiveTab] = useState('transfer');
-  const [sourceUser, setSourceUser] = useState(null);
-  const [targetUser, setTargetUser] = useState(null);
+  const [activeTab, setActiveTab] = useState<'transfer' | 'history' | 'statistics'>('transfer');
+  const [sourceUser, setSourceUser] = useState<TransferUser | null>(null);
+  const [targetUser, setTargetUser] = useState<TransferUser | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState([]);
+  const [searchResults, setSearchResults] = useState<TransferUser[]>([]);
   const [isSearching, setIsSearching] = useState(false);
-  const [selectedDataTypes, setSelectedDataTypes] = useState(['appointments', 'visits', 'queue_entries']);
-  const [availableDataTypes, setAvailableDataTypes] = useState([]);
+  const [selectedDataTypes, setSelectedDataTypes] = useState<string[]>(['appointments', 'visits', 'queue_entries']);
+  const [availableDataTypes, setAvailableDataTypes] = useState<DataTypeItem[]>([]);
   const [isTransferring, setIsTransferring] = useState(false);
-  const [transferHistory, setTransferHistory] = useState([]);
-  const [statistics, setStatistics] = useState(null);
-  const [userDataSummary, setUserDataSummary] = useState(null);
+  const [transferHistory, setTransferHistory] = useState<TransferHistoryEntry[]>([]);
+  const [statistics, setStatistics] = useState<TransferStatistics | null>(null);
+  const [userDataSummary, setUserDataSummary] = useState<DataSummary | null>(null);
 
   // Загрузка доступных типов данных
   useEffect(() => {
@@ -86,7 +135,7 @@ const UserDataTransferManager = () => {
     }
   };
 
-  const searchUsers = async (query) => {
+  const searchUsers = async (query: string) => {
     if (query.length < 2) {
       setSearchResults([]);
       return;
@@ -94,8 +143,8 @@ const UserDataTransferManager = () => {
 
     setIsSearching(true);
     try {
-      const response = await api.get(`/admin/user-data/users/search?query=${encodeURIComponent(query)}&limit=10`);
-      setSearchResults(toArray(response.data, ['users', 'items', 'results']));
+      const response = await api.get(`/admin/user-data/users/search?query=${encodeURIComponent(query)}&limit=10`) as import('axios').AxiosResponse<Record<string, unknown>>;
+      setSearchResults(toArray(response.data, ['users', 'items', 'results']) as TransferUser[]);
     } catch (error) {
       logger.error('Ошибка поиска пользователей:', error);
       toast.error(t('admin2.udtm_err_search_users'));
@@ -105,7 +154,7 @@ const UserDataTransferManager = () => {
     }
   };
 
-  const getUserDataSummary = async (userId) => {
+  const getUserDataSummary = async (userId: string | number) => {
     try {
       const response = (await api.get(`/admin/user-data/users/${userId}/data-summary`)) as import('axios').AxiosResponse<Record<string, unknown>>;
       setUserDataSummary(normalizeDataSummary(response.data));
@@ -115,6 +164,8 @@ const UserDataTransferManager = () => {
     }
   };
 
+
+
   const validateTransfer = async () => {
     if (!sourceUser || !targetUser) {
       toast.error(t('admin2.udtm_err_select_users'));
@@ -122,7 +173,7 @@ const UserDataTransferManager = () => {
     }
 
     try {
-      const response = (await api.post(`/admin/user-data/transfer/validate?source_user_id=${sourceUser.id}&target_user_id=${targetUser.id}`)) as import('axios').AxiosResponse<Record<string, unknown>>;
+      const response = (await api.post(`/admin/user-data/transfer/validate?source_user_id=${sourceUser!.id}&target_user_id=${targetUser!.id}`)) as import('axios').AxiosResponse<Record<string, unknown>>;
       const validation = (response.data as { valid?: boolean; message?: string; appointments?: unknown; visits?: unknown; queue_entries?: unknown; [k: string]: unknown }) || {};
 
       if (!validation.valid) {
@@ -146,8 +197,8 @@ const UserDataTransferManager = () => {
     setIsTransferring(true);
     try {
       const response = await api.post('/admin/user-data/transfer', {
-        source_user_id: sourceUser.id,
-        target_user_id: targetUser.id,
+        source_user_id: sourceUser!.id,
+        target_user_id: targetUser!.id,
         data_types: selectedDataTypes,
         confirmation_required: false
       }) as import('axios').AxiosResponse<Record<string, unknown>>;
@@ -195,7 +246,7 @@ const UserDataTransferManager = () => {
   const loadTransferHistory = async () => {
     try {
       const response = await api.get('/admin/user-data/transfer/history?limit=50') as import('axios').AxiosResponse<Record<string, unknown>>;
-      setTransferHistory(toArray(response.data, ['history', 'items', 'results']));
+      setTransferHistory(toArray(response.data, ['history', 'items', 'results']) as TransferHistoryEntry[]);
     } catch (error) {
       logger.error('Ошибка загрузки истории:', error);
       toast.error(t('admin2.udtm_err_load_history'));
@@ -212,13 +263,13 @@ const UserDataTransferManager = () => {
     }
   };
 
-  const handleSearchChange = (e) => {
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const query = e.target.value;
     setSearchQuery(query);
     searchUsers(query);
   };
 
-  const selectUser = (user, type) => {
+  const selectUser = (user: TransferUser, type: 'source' | 'target') => {
     if (type === 'source') {
       setSourceUser(user);
       getUserDataSummary(user.id);
@@ -573,7 +624,7 @@ const UserDataTransferManager = () => {
           aria-label={t('admin2.udtm_tabs_aria')}
           value={activeTab}
           onChange={(value: unknown) => {
-            const v = String(value);
+            const v = String(value) as 'transfer' | 'history' | 'statistics';
             setActiveTab(v);
             if (v === 'history') {
               loadTransferHistory();

--- a/frontend/src/components/dental/VisitProtocol.tsx
+++ b/frontend/src/components/dental/VisitProtocol.tsx
@@ -9,6 +9,96 @@ import notify from '../../services/notify';
  * Протокол лечения по визитам для стоматологической ЭМК
  * Включает процедуры, материалы, анестезию, фото до/после
  */
+
+interface Procedure {
+  name?: string;
+  teeth?: string;
+  startTime?: string;
+  endTime?: string;
+  description?: string;
+  completed?: boolean;
+  complications?: boolean;
+  [key: string]: unknown;
+}
+
+interface Material {
+  name?: string;
+  quantity?: string;
+  batch?: string;
+  notes?: string;
+  [key: string]: unknown;
+}
+
+interface Anesthesia {
+  drug?: string;
+  dose?: string;
+  method?: string;
+  area?: string;
+  effective?: boolean;
+  complications?: boolean;
+  type?: string;
+  [key: string]: unknown;
+}
+
+interface Photo {
+  id: number;
+  url?: string | ArrayBuffer | null;
+  filename?: string;
+  size?: number;
+  type?: string;
+  uploadedAt?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+interface Radiograph {
+  type?: string;
+  area?: string;
+  findings?: string;
+  [key: string]: unknown;
+}
+
+interface Prescription {
+  medication?: string;
+  dosage?: string;
+  instructions?: string;
+  [key: string]: unknown;
+}
+
+interface NextVisit {
+  date?: string;
+  time?: string;
+  purpose?: string;
+  [key: string]: unknown;
+}
+
+interface VisitProtocolFormData {
+  visitDate: string;
+  visitTime: string;
+  doctor: string;
+  assistant: string;
+  chiefComplaint: string;
+  historyOfPresentIllness: string;
+  procedures: Procedure[];
+  materials: Material[];
+  anesthesia: Anesthesia[];
+  photos: {
+    before: Photo[];
+    during: Photo[];
+    after: Photo[];
+  };
+  radiographs: Radiograph[];
+  prescriptions: Prescription[];
+  recommendations: string;
+  nextVisit: NextVisit;
+  createdAt: string;
+  updatedAt: string;
+  [key: string]: unknown;
+}
+
+type TabId = 'procedures' | 'materials' | 'anesthesia' | 'photos' | 'radiographs' | 'prescriptions';
+type PhotoCategory = 'before' | 'during' | 'after';
+
 const VisitProtocol = ({
   patientName,
   patientId,
@@ -20,7 +110,7 @@ const VisitProtocol = ({
 }: { patientName?: string; patientId?: string | number; visitId?: string | number; initialData?: Record<string, unknown> | null; onSave?: (data: unknown) => void; onClose?: () => void; onComplete?: () => void }) => {
   const { t: rawT } = useTranslation();
   const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<VisitProtocolFormData>({
     // Основные данные визита
     visitDate: new Date().toISOString().split('T')[0],
     visitTime: new Date().toTimeString().slice(0, 5),
@@ -68,7 +158,7 @@ const VisitProtocol = ({
 
   const [isEditing, setIsEditing] = useState(true);
   const [loading, setLoading] = useState(false);
-  const [activeTab, setActiveTab] = useState('procedures');
+  const [activeTab, setActiveTab] = useState<TabId>('procedures');
 
   // Инициализация данных
   useEffect(() => {
@@ -82,13 +172,13 @@ const VisitProtocol = ({
   }, [initialData]);
 
   // Обработчики
-  const handleInputChange = (field, value) => {
+  const handleInputChange = (field: string, value: unknown) => {
     if (field.includes('.')) {
       const [parent, child] = field.split('.');
       setFormData((prev) => ({
         ...prev,
         [parent]: {
-          ...prev[parent],
+          ...((prev[parent as keyof VisitProtocolFormData] as Record<string, unknown> | undefined) ?? {}),
           [child]: value
         }
       }));
@@ -100,35 +190,47 @@ const VisitProtocol = ({
     }
   };
 
-  const handleArrayAdd = (field, item) => {
-    setFormData((prev) => ({
-      ...prev,
-      [field]: [...prev[field], item]
-    }));
+  const handleArrayAdd = (field: string, item: Record<string, unknown>) => {
+    setFormData((prev) => {
+      const prevValue = prev[field as keyof VisitProtocolFormData];
+      const prevArray = Array.isArray(prevValue) ? prevValue : [];
+      return {
+        ...prev,
+        [field]: [...prevArray, item]
+      };
+    });
   };
 
-  const handleArrayRemove = (field, index) => {
-    setFormData((prev) => ({
-      ...prev,
-      [field]: prev[field].filter((_, i) => i !== index)
-    }));
+  const handleArrayRemove = (field: string, index: number) => {
+    setFormData((prev) => {
+      const prevValue = prev[field as keyof VisitProtocolFormData];
+      const prevArray = Array.isArray(prevValue) ? prevValue : [];
+      return {
+        ...prev,
+        [field]: prevArray.filter((_, i) => i !== index)
+      };
+    });
   };
 
-  const handleArrayUpdate = (field, index, updates) => {
-    setFormData((prev) => ({
-      ...prev,
-      [field]: prev[field].map((item, i) =>
-      i === index ? { ...item, ...updates } : item
-      )
-    }));
+  const handleArrayUpdate = (field: string, index: number, updates: Record<string, unknown>) => {
+    setFormData((prev) => {
+      const prevValue = prev[field as keyof VisitProtocolFormData];
+      const prevArray = Array.isArray(prevValue) ? prevValue : [];
+      return {
+        ...prev,
+        [field]: prevArray.map((item, i) =>
+          i === index ? { ...((item as Record<string, unknown>) ?? {}), ...updates } : item
+        )
+      };
+    });
   };
 
-  const handlePhotoUpload = (category, file) => {
+  const handlePhotoUpload = (category: PhotoCategory, file: File) => {
     const reader = new FileReader();
     reader.onload = (e) => {
-      const photoData = {
+      const photoData: Photo = {
         id: Date.now(),
-        url: e.target?.result,
+        url: e.target?.result ?? null,
         filename: file.name,
         size: file.size,
         type: file.type,
@@ -136,7 +238,7 @@ const VisitProtocol = ({
         description: ''
       };
 
-      handleArrayAdd(`photos.${category}`, photoData);
+      handleArrayAdd(`photos.${category}`, photoData as unknown as Record<string, unknown>);
     };
     reader.readAsDataURL(file);
   };
@@ -163,7 +265,7 @@ const VisitProtocol = ({
   };
 
   // Вкладки
-  const tabs = [
+  const tabs: Array<{ id: TabId; label: string; icon: React.ComponentType<{ className?: string }> }> = [
   { id: 'procedures', label: t('dental.dental_vp_tab_procedures'), icon: Scissors },
   { id: 'materials', label: t('dental.dental_vp_tab_materials'), icon: Pill },
   { id: 'anesthesia', label: t('dental.dental_vp_tab_anesthesia'), icon: Syringe },
@@ -592,7 +694,7 @@ const VisitProtocol = ({
       </div>
       
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {['before', 'during', 'after'].map((category) =>
+        {(['before', 'during', 'after'] as PhotoCategory[]).map((category) =>
       <div key={category}>
             <h4 className="font-semibold mb-3 capitalize">
               {category === 'before' ? t('dental.dental_vp_photo_before') :

--- a/frontend/src/components/files/FileManager.tsx
+++ b/frontend/src/components/files/FileManager.tsx
@@ -93,7 +93,32 @@ const iconButtonStyle: CSSProperties = {
   padding: 0
 };
 
-const fileTypeOptions = (t) => [
+type Translator = (key: string, options?: Record<string, unknown>) => string;
+
+type FileTypeKey = 'image' | 'video' | 'audio' | 'document' | 'archive' | 'xray' | 'other';
+
+interface FileItem {
+  id: string | number;
+  filename?: string;
+  original_filename?: string;
+  title?: string;
+  file_type?: string;
+  file_size?: number;
+  created_at?: string;
+  permission?: string;
+  [key: string]: unknown;
+}
+
+interface FileFilters {
+  fileType: string;
+  permission: string;
+  dateFrom: string;
+  dateTo: string;
+  sizeMin: string;
+  sizeMax: string;
+}
+
+const fileTypeOptions = (t: Translator) => [
   { value: '', label: t('misc.fm_filter_type_all') },
   { value: 'image', label: t('misc.fm_filter_type_images') },
   { value: 'video', label: t('misc.fm_filter_type_video') },
@@ -103,7 +128,7 @@ const fileTypeOptions = (t) => [
   { value: 'xray', label: t('misc.fm_filter_type_xray') }
 ];
 
-const permissionOptions = (t) => [
+const permissionOptions = (t: Translator) => [
   { value: '', label: t('misc.fm_filter_perm_all') },
   { value: 'public', label: t('misc.fm_filter_perm_public') },
   { value: 'private', label: t('misc.fm_filter_perm_private') },
@@ -129,7 +154,7 @@ interface FileManagerStats {
   [key: string]: unknown;
 }
 
-const fileTypeLabels = (t) => ({
+const fileTypeLabels = (t: Translator): Record<FileTypeKey, string> => ({
   image: t('misc.fm_label_image'),
   video: t('misc.fm_label_video'),
   audio: t('misc.fm_label_audio'),
@@ -139,7 +164,7 @@ const fileTypeLabels = (t) => ({
   other: t('misc.fm_label_other')
 });
 
-const fileTypeColors = {
+const fileTypeColors: Record<FileTypeKey, string> = {
   image: 'var(--mac-success)',
   video: 'var(--mac-accent-purple)',
   audio: 'var(--mac-accent-blue)',
@@ -157,12 +182,12 @@ const FileManager = () => {
   const [confirmRaw, confirmDialog] = useConfirm();
   const confirm = confirmRaw as unknown as (opts: Record<string, unknown>) => Promise<boolean>;
   const [loading, setLoading] = useState(false);
-  const [files, setFiles] = useState([]);
-  const [, setFolders] = useState([]);
-  const [selectedFiles, setSelectedFiles] = useState([]);
-  const [viewMode, setViewMode] = useState('grid');
+  const [files, setFiles] = useState<FileItem[]>([]);
+  const [, setFolders] = useState<unknown[]>([]);
+  const [selectedFiles, setSelectedFiles] = useState<Array<string | number>>([]);
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [searchQuery, setSearchQuery] = useState('');
-  const [filters, setFilters] = useState({
+  const [filters, setFilters] = useState<FileFilters>({
     fileType: '',
     permission: '',
     dateFrom: '',
@@ -170,14 +195,14 @@ const FileManager = () => {
     sizeMin: '',
     sizeMax: ''
   });
-  const [currentFolder] = useState(null);
+  const [currentFolder] = useState<string | null>(null);
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [showStatsModal, setShowStatsModal] = useState(false);
   const [stats, setStats] = useState<FileManagerStats | null>(null);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [uploading, setUploading] = useState(false);
 
-  const fileInputRef = useRef(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const loadFolders = useCallback(async () => {
     try {
@@ -216,8 +241,8 @@ const FileManager = () => {
       const response = await fetch(`/files/${query ? `?${query}` : ''}`, {
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
       });
-      const data = await response.json();
-      setFiles(data.files || []);
+      const data = await response.json() as { files?: FileItem[] } | undefined;
+      setFiles(data?.files || []);
     } catch (error) {
       logger.error('Ошибка загрузки файлов:', error);
     } finally {
@@ -231,9 +256,9 @@ const FileManager = () => {
     loadStats();
   }, [loadFiles, loadFolders, loadStats]);
 
-  const getFileType = (file) => {
-    const ext = file.name.split('.').pop().toLowerCase();
-    const mimeType = file.type;
+  const getFileType = (file: File): FileTypeKey => {
+    const ext = (file.name.split('.').pop() || '').toLowerCase();
+    const mimeType = file.type || '';
 
     if (mimeType.startsWith('image/')) return 'image';
     if (mimeType.startsWith('video/')) return 'video';
@@ -245,8 +270,8 @@ const FileManager = () => {
     return 'other';
   };
 
-  const getFileIcon = (file, size = 24) => {
-    const color = fileTypeColors[file.file_type] || fileTypeColors.other;
+  const getFileIcon = (file: FileItem, size = 24) => {
+    const color = fileTypeColors[(file.file_type as FileTypeKey) || 'other'] || fileTypeColors.other;
     const iconProps = { size, style: { color } };
 
     switch (file.file_type) {
@@ -266,9 +291,9 @@ const FileManager = () => {
     }
   };
 
-  const getFileDisplayName = (file) => file.title || file.filename || file.original_filename || t('misc.fm_label_other');
+  const getFileDisplayName = (file: FileItem) => file.title || file.filename || file.original_filename || t('misc.fm_label_other');
 
-  const formatFileSize = (bytes) => {
+  const formatFileSize = (bytes: unknown) => {
     const size = Number(bytes) || 0;
     if (size === 0) return '0 Bytes';
 
@@ -278,9 +303,9 @@ const FileManager = () => {
     return `${parseFloat((size / Math.pow(k, index)).toFixed(2))} ${sizes[index]}`;
   };
 
-  const formatDate = (dateString) => {
+  const formatDate = (dateString: unknown) => {
     if (!dateString) return t('misc.fm_date_not_specified');
-    const date = new Date(dateString);
+    const date = new Date(String(dateString));
     if (Number.isNaN(date.getTime())) return t('misc.fm_date_not_specified');
 
     return date.toLocaleDateString('ru-RU', {
@@ -292,7 +317,7 @@ const FileManager = () => {
     });
   };
 
-  const handleFileUpload = async (event) => {
+  const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const uploadFiles = Array.from(event.target.files || []) as File[];
     if (uploadFiles.length === 0) return;
 
@@ -334,7 +359,7 @@ const FileManager = () => {
     await loadStats();
   };
 
-  const handleDownload = async (fileId, filename) => {
+  const handleDownload = async (fileId: string | number, filename?: string) => {
     try {
       const response = await fetch(`/files/${fileId}/download`, {
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
@@ -356,7 +381,7 @@ const FileManager = () => {
     }
   };
 
-  const handlePreview = async (fileId) => {
+  const handlePreview = async (fileId: string | number) => {
     try {
       const response = await fetch(`/files/${fileId}/preview`, {
         headers: { Authorization: `Bearer ${tokenManager.getAccessToken()}` }
@@ -372,7 +397,7 @@ const FileManager = () => {
     }
   };
 
-  const handleDelete = async (fileId) => {
+  const handleDelete = async (fileId: string | number) => {
     // P-013 fix: replaced native confirm() with shared useConfirm hook.
     const ok = await confirm({
       title: t('misc.fm_delete_title'),
@@ -400,7 +425,7 @@ const FileManager = () => {
     }
   };
 
-  const handleFilterChange = (key, value) => {
+  const handleFilterChange = (key: keyof FileFilters, value: string) => {
     setFilters((prev) => ({ ...prev, [key]: value }));
   };
 
@@ -416,13 +441,13 @@ const FileManager = () => {
     setSearchQuery('');
   };
 
-  const toggleFileSelection = (fileId) => {
+  const toggleFileSelection = (fileId: string | number) => {
     setSelectedFiles((prev) =>
       prev.includes(fileId) ? prev.filter((id) => id !== fileId) : [...prev, fileId]
     );
   };
 
-  const handleActivationKeyDown = (event, action) => {
+  const handleActivationKeyDown = (event: React.KeyboardEvent<HTMLElement>, action: () => void) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       action();
@@ -431,12 +456,12 @@ const FileManager = () => {
 
   const selectedCount = selectedFiles.length;
 
-  const renderFileActions = (file) => (
+  const renderFileActions = (file: FileItem) => (
     <div style={{ display: 'flex', gap: 'var(--mac-spacing-2)', justifyContent: 'flex-end', flexWrap: 'wrap' }}>
       <Button
         variant="ghost"
         size="small"
-        onClick={(event) => {
+        onClick={(event: React.MouseEvent<HTMLElement>) => {
           event.stopPropagation();
           handlePreview(file.id);
         }}
@@ -449,7 +474,7 @@ const FileManager = () => {
       <Button
         variant="ghost"
         size="small"
-        onClick={(event) => {
+        onClick={(event: React.MouseEvent<HTMLElement>) => {
           event.stopPropagation();
           handleDownload(file.id, file.filename);
         }}
@@ -462,7 +487,7 @@ const FileManager = () => {
       <Button
         variant="ghost"
         size="small"
-        onClick={(event) => {
+        onClick={(event: React.MouseEvent<HTMLElement>) => {
           event.stopPropagation();
           handleDelete(file.id);
         }}
@@ -538,7 +563,7 @@ const FileManager = () => {
 
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 'var(--mac-spacing-2)' }}>
                 <Badge size="small" variant="outline">
-                  {fileTypeLabels(t)[file.file_type] || file.file_type || t('misc.fm_label_other')}
+                  {fileTypeLabels(t)[(file.file_type as FileTypeKey) || 'other'] || file.file_type || t('misc.fm_label_other')}
                 </Badge>
                 <span style={{ fontSize: 'var(--mac-font-size-xs)', color: 'var(--mac-text-tertiary)' }}>
                   {formatDate(file.created_at)}
@@ -559,54 +584,60 @@ const FileManager = () => {
       title: (
         <Checkbox
           checked={files.length > 0 && selectedFiles.length === files.length}
-          onChange={(checked) => setSelectedFiles(checked ? files.map((file) => file.id) : [])}
+          onChange={(checked: boolean) => setSelectedFiles(checked ? files.map((file) => file.id) : [])}
           aria-label={files.length > 0 && selectedFiles.length === files.length ? t('misc.fm_aria_deselect_all') : t('misc.fm_aria_select_all')}
         />
       ),
-      render: (_value, file) => (
-        <Checkbox
-          checked={selectedFiles.includes(file.id)}
-          onChange={(checked) =>
-            setSelectedFiles((prev) => (checked ? [...prev, file.id] : prev.filter((id) => id !== file.id)))
-          }
-          aria-label={selectedFiles.includes(file.id) ? t('misc.fm_aria_deselect_file', { name: getFileDisplayName(file) }) : t('misc.fm_aria_select_file', { name: getFileDisplayName(file) })}
-        />
-      )
+      render: (_value: unknown, row: Record<string, unknown>) => {
+        const file = row as FileItem;
+        return (
+          <Checkbox
+            checked={selectedFiles.includes(file.id)}
+            onChange={(checked: boolean) =>
+              setSelectedFiles((prev) => (checked ? [...prev, file.id] : prev.filter((id) => id !== file.id)))
+            }
+            aria-label={selectedFiles.includes(file.id) ? t('misc.fm_aria_deselect_file', { name: getFileDisplayName(file) }) : t('misc.fm_aria_select_file', { name: getFileDisplayName(file) })}
+          />
+        );
+      }
     },
     {
       key: 'filename',
       title: t('misc.fm_col_filename'),
-      render: (_value, file) => (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px', minWidth: '220px' }}>
-          {getFileIcon(file, 22)}
-          <div style={{ minWidth: 0 }}>
-            <div style={{ fontWeight: 'var(--mac-font-weight-semibold)', color: 'var(--mac-text-primary)' }}>{getFileDisplayName(file)}</div>
-            {file.original_filename && (
-              <div style={{ fontSize: 'var(--mac-font-size-xs)', color: 'var(--mac-text-secondary)' }}>{file.original_filename}</div>
-            )}
+      render: (_value: unknown, row: Record<string, unknown>) => {
+        const file = row as FileItem;
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px', minWidth: '220px' }}>
+            {getFileIcon(file, 22)}
+            <div style={{ minWidth: 0 }}>
+              <div style={{ fontWeight: 'var(--mac-font-weight-semibold)', color: 'var(--mac-text-primary)' }}>{getFileDisplayName(file)}</div>
+              {file.original_filename && (
+                <div style={{ fontSize: 'var(--mac-font-size-xs)', color: 'var(--mac-text-secondary)' }}>{file.original_filename}</div>
+              )}
+            </div>
           </div>
-        </div>
-      )
+        );
+      }
     },
     {
       key: 'file_type',
       title: t('misc.fm_col_type'),
-      render: (value) => <Badge size="small" variant="outline">{fileTypeLabels(t)[value] || value || t('misc.fm_label_other')}</Badge>
+      render: (value: unknown) => <Badge size="small" variant="outline">{fileTypeLabels(t)[(value as FileTypeKey) || 'other'] || String(value ?? '') || t('misc.fm_label_other')}</Badge>
     },
     {
       key: 'file_size',
       title: t('misc.fm_col_size'),
-      render: (value) => formatFileSize(value)
+      render: (value: unknown) => formatFileSize(value)
     },
     {
       key: 'created_at',
       title: t('misc.fm_col_created'),
-      render: (value) => formatDate(value)
+      render: (value: unknown) => formatDate(value)
     },
     {
       key: 'actions',
       title: t('misc.fm_col_actions'),
-      render: (_value, file) => renderFileActions(file)
+      render: (_value: unknown, row: Record<string, unknown>) => renderFileActions(row as FileItem)
     }
   ];
 
@@ -670,13 +701,13 @@ const FileManager = () => {
             <Select
               aria-label={t('misc.fm_aria_filter_type')}
               value={filters.fileType}
-              onChange={(value) => handleFilterChange('fileType', value)}
+              onChange={(value) => handleFilterChange('fileType', value.target.value)}
               options={fileTypeOptions(t)}
             />
             <Select
               aria-label={t('misc.fm_aria_filter_permission')}
               value={filters.permission}
-              onChange={(value) => handleFilterChange('permission', value)}
+              onChange={(value) => handleFilterChange('permission', value.target.value)}
               options={permissionOptions(t)}
             />
             <Button variant="secondary" onClick={clearFilters}>
@@ -690,7 +721,7 @@ const FileManager = () => {
         <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
           <SegmentedControl
             value={viewMode}
-            onChange={(v: unknown) => setViewMode(String(v))}
+            onChange={(v: unknown) => setViewMode(String(v) as 'grid' | 'list')}
             options={[
               { value: 'grid', label: <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--mac-spacing-2)' }}><Grid size={14} />{t('misc.fm_view_grid')}</span> },
               { value: 'list', label: <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--mac-spacing-2)' }}><ListIcon size={14} />{t('misc.fm_view_list')}</span> }
@@ -854,7 +885,7 @@ const FileManager = () => {
                   ) : (
                     Object.entries(stats?.files_by_type || {}).map(([type, count]) => (
                       <div key={type} style={{ display: 'flex', justifyContent: 'space-between', gap: 'var(--mac-spacing-3)' }}>
-                        <span style={{ color: 'var(--mac-text-secondary)' }}>{fileTypeLabels(t)[type] || type}</span>
+                        <span style={{ color: 'var(--mac-text-secondary)' }}>{fileTypeLabels(t)[type as FileTypeKey] || type}</span>
                         <strong>{count}</strong>
                       </div>
                     ))

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -45,7 +45,7 @@ const SHOWCASE_VISUALS = [BarChart3, Users, Activity, FileText, CreditCard];
 const SECURITY_VISUALS = [Shield, Users, Key, Activity];
 const INTEGRATION_VISUALS = [MessageSquare, CreditCard, CreditCard, CreditCard, Activity, FileText];
 
-function SurfaceLabel({ children }) {
+function SurfaceLabel({ children }: { children: React.ReactNode }) {
   const { t: rawT } = useTranslation();
   const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   return <span className="landing-surface-label">{children}</span>;
@@ -56,7 +56,12 @@ SurfaceLabel.propTypes = {
   children: PropTypes.node,
 };
 
-function SectionHeading({ eyebrow, title, description, align = 'left' }) {
+function SectionHeading({ eyebrow, title, description, align = 'left' }: {
+  eyebrow?: React.ReactNode;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  align?: 'left' | 'center';
+}) {
   return (
     <div className={`landing-section-heading landing-section-heading--${align}`}>
       <SurfaceLabel>{eyebrow}</SurfaceLabel>
@@ -74,7 +79,12 @@ SectionHeading.propTypes = {
   title: PropTypes.string,
 };
 
-function MetricCard({ value, label, detail, style }) {
+function MetricCard({ value, label, detail, style }: {
+  value?: React.ReactNode;
+  label?: React.ReactNode;
+  detail?: React.ReactNode;
+  style?: React.CSSProperties;
+}) {
   return (
     <MacOSCard className="landing-metric-card" shadow="large" style={style}>
       <strong>{value}</strong>
@@ -92,11 +102,17 @@ MetricCard.propTypes = {
   value: PropTypes.node,
 };
 
-function FeatureCard({ accent, icon: Icon, badge, title, description }) {
+function FeatureCard({ accent, icon: Icon, badge, title, description }: {
+  accent?: string;
+  icon?: React.ComponentType<{ size?: number }>;
+  badge?: React.ReactNode;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+}) {
   return (
     <MacOSCard className="landing-feature-card" shadow="large" style={{ borderColor: `${accent}2f` }}>
       <div className="landing-feature-icon" style={{ background: `${accent}18`, color: accent }}>
-        <Icon size={20} />
+        {Icon && <Icon size={20} />}
       </div>
       <SurfaceLabel>{badge}</SurfaceLabel>
       <h3>{title}</h3>
@@ -114,12 +130,18 @@ FeatureCard.propTypes = {
   title: PropTypes.string,
 };
 
-function ShowcaseCard({ icon: Icon, label, title, description, style }) {
+function ShowcaseCard({ icon: Icon, label, title, description, style }: {
+  icon?: React.ComponentType<{ size?: number }>;
+  label?: React.ReactNode;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  style?: React.CSSProperties;
+}) {
   return (
     <MacOSCard className="landing-showcase-card" shadow="large" style={style}>
       <div className="landing-showcase-head">
         <div className="landing-showcase-icon">
-          <Icon size={20} />
+          {Icon && <Icon size={20} />}
         </div>
         <SurfaceLabel>{label}</SurfaceLabel>
       </div>
@@ -143,7 +165,10 @@ ShowcaseCard.propTypes = {
   title: PropTypes.string,
 };
 
-function WorkflowStep({ title, description }) {
+function WorkflowStep({ title, description }: {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+}) {
   return (
     <div className="landing-workflow-step">
       <div className="landing-workflow-marker" aria-hidden="true" />
@@ -195,12 +220,12 @@ ContactRow.propTypes = {
   value: PropTypes.string,
 };
 
-function toTelegramUrl(handle) {
+function toTelegramUrl(handle: unknown) {
   const sanitizedHandle = String(handle || '').trim().replace(/^@/, '');
   return sanitizedHandle ? `https://t.me/${sanitizedHandle}` : undefined;
 }
 
-function toTelUrl(phone) {
+function toTelUrl(phone: unknown) {
   const sanitizedPhone = String(phone || '').replace(/[^\d+]/g, '');
   return sanitizedPhone ? `tel:${sanitizedPhone}` : undefined;
 }
@@ -212,7 +237,7 @@ export default function Landing() {
   const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   // Map unified language codes to legacy LANDING_COPY keys ('uz-Latn' → 'uz')
   const landingCopyKey = language?.startsWith('uz') ? 'uz' : language?.split('-')[0];
-  const copy = LANDING_COPY[landingCopyKey] || LANDING_COPY.ru;
+  const copy = (LANDING_COPY[landingCopyKey as keyof typeof LANDING_COPY] || LANDING_COPY.ru) as typeof LANDING_COPY.ru;
   const cardStyle = useMemo(() => buildGlassStyle(isDark), [isDark]);
   const heroCardStyle = useMemo(() => buildGlassStyle(isDark, 'hero'), [isDark]);
   const accentCardStyle = useMemo(() => buildGlassStyle(isDark, 'accent'), [isDark]);
@@ -244,7 +269,7 @@ export default function Landing() {
 
   // UX Audit Stage 2 (Landing issue 1.2): заменили cycle на dropdown select.
   // handleLanguageCycle удалён, вместо него — handleLanguageSelect(code).
-  const handleLanguageSelect = (code) => {
+  const handleLanguageSelect = (code: string) => {
     if (!code) {
       return;
     }
@@ -261,18 +286,18 @@ export default function Landing() {
       return undefined;
     }
 
-    const handleClickOutside = (event) => {
+    const handleClickOutside = (event: MouseEvent) => {
       const trigger = document.getElementById('landing-lang-trigger');
       const dropdown = document.getElementById('landing-lang-dropdown');
       if (
-        trigger && !trigger.contains(event.target) &&
-        dropdown && !dropdown.contains(event.target)
+        trigger && !trigger.contains(event.target as Node) &&
+        dropdown && !dropdown.contains(event.target as Node)
       ) {
         setShowLangDropdown(false);
       }
     };
 
-    const handleEscape = (event) => {
+    const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setShowLangDropdown(false);
       }
@@ -286,7 +311,7 @@ export default function Landing() {
     };
   }, [showLangDropdown]);
 
-  const scrollToSection = (sectionId) => {
+  const scrollToSection = (sectionId: string) => {
     document.getElementById(sectionId)?.scrollIntoView({
       behavior: 'smooth',
       block: 'start'
@@ -297,7 +322,7 @@ export default function Landing() {
   // Раньше клик на якорь в футере (#product, #workflow и т.д.) делал резкий
   // browser-jump, потому что это были <a href="#..."> без обработчика.
   // Теперь перехватываем клик и используем тот же scrollToSection.
-  const handleFooterLinkClick = (event, href) => {
+  const handleFooterLinkClick = (event: React.MouseEvent<HTMLElement>, href: string) => {
     if (!href || !href.startsWith('#')) {
       return;
     }


### PR DESCRIPTION
## Summary

- Strict-mode TS migration batch 17D: define explicit Props interfaces for 4 misc files.
- BS-66 batch 17D, continuing the strict-mode enablement tracked in #2516.

## Cyclic Execution Evidence

- Fresh main sync: branch `strict-batch-17d-misc` created from current origin/main (HEAD `f00e8422`).
- Clean workspace: inspected before edits; only 4 frontend files changed.
- Branch: `strict-batch-17d-misc` (head `6b403624`, base `main` @ `f00e8422`).
- Scope gate: allowed the 4 files listed below; denied everything else.
- Red-check handling: `tsconfig.strict.json` strict-gate (0 errors before, 0 errors after) and `scripts/regression-audit-check.mjs` (31/31 before, 31/31 after) verified.

## Contract Impact

not applicable - documentation/process only, no API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route guard, endpoint authorization, role helper, or auth-sensitive behavior changed in this PR.


## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed in this PR.


## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `frontend/src/components/admin/UserDataTransferManager.tsx`, `frontend/src/pages/Landing.tsx`, `frontend/src/components/files/FileManager.tsx`, `frontend/src/components/dental/VisitProtocol.tsx`.
- Denied paths: everything else.
- Migration/docs/test impact: no migration; no docs; no test files added or removed.
- Rollback note: revert the single commit `6b403624`.

## Validation

- Targeted tests or smoke run: `npx tsc --noEmit --strict -p tsconfig.json` (strict errors: 5074 → 4858, −216 from this PR), `npx tsc --noEmit -p tsconfig.strict.json` (strict-gate: 0 errors), `npx tsc --noEmit -p tsconfig.json` (non-strict: 31 errors — no new errors), `node scripts/regression-audit-check.mjs` (31/31 PASS).
- Result: all four checks pass. Per-file strict error deltas: UserDataTransferManager.tsx 59 → 0 (−59), Landing.tsx 57 → 0 (−57), FileManager.tsx 50 → 0 (−50), VisitProtocol.tsx 50 → 0 (−50). Total −216.
- Not checked: full Vitest suite (deferred — type-only changes). Playwright e2e (skipped).

## Per-file details

### `UserDataTransferManager.tsx` (59 → 0, −59)
- Added `TransferUser`, `DataTypeItem`, `DataCounts`, `DataSummary`, `TransferHistoryEntry`, `TransferStatistics` interfaces.

### `Landing.tsx` (57 → 0, −57)
- Added inline prop types on 6 sub-components using `React.ReactNode`, `React.CSSProperties`, `React.ComponentType<{ size?: number }>`.
- `LANDING_COPY[landingCopyKey as keyof typeof LANDING_COPY] as typeof LANDING_COPY.ru` for safe indexing.

### `FileManager.tsx` (50 → 0, −50)
- Added `Translator`, `FileTypeKey`, `FileItem`, `FileFilters` interfaces.
- `useState<FileItem[]>`, `useState<'grid' | 'list'>`.
- Table contravariance fix: `render: (_value: unknown, row: Record<string, unknown>) => ...` with `const file = row as FileItem` narrowing.

### `VisitProtocol.tsx` (50 → 0, −50)
- Added `Procedure`, `Material`, `Anesthesia`, `Photo`, `Radiograph`, `Prescription`, `NextVisit`, `VisitProtocolFormData`, `TabId`, `PhotoCategory` interfaces.
- `prev[parent as keyof VisitProtocolFormData]` for dynamic-keyed state updaters.

## Forbidden-pattern audit (clean)

`as any`, `@ts-ignore`, `@ts-nocheck`, `useState<unknown>(null)`, removed PropTypes blocks, modified tsconfig files — all zero.

## Related

- #2516 — parent issue (BS-66 strict:true enablement)
- #2549 — manual Props interfaces for top-14 highest-error files (separate scope)
