### PR TITLE
🎨 Palette: Add aria-invalid attributes to input components

### DIFF
--- a/frontend/src/components/ui/macos/Checkbox.tsx
+++ b/frontend/src/components/ui/macos/Checkbox.tsx
@@ -130,7 +130,8 @@ const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>(({
         tabIndex={disabled ? -1 : 0}
         role="checkbox"
         aria-checked={checked}
-        aria-disabled={disabled}>
+        aria-disabled={disabled}
+        aria-invalid={!!error}>
 
         <div
           ref={ref}

--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -174,6 +174,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         className={className}
         style={inputStyle}
         disabled={disabled}
+        aria-invalid={!!error}
         onFocus={handleFocus}
         onBlur={handleBlur}
         {...props}

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -255,6 +255,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           style={trigger}
           aria-haspopup="listbox"
           aria-expanded={isOpen}
+          aria-invalid={!!error}
           disabled={disabled}
           {...props}
         >

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -141,6 +141,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       className={className}
       style={textareaStyles}
       disabled={disabled}
+      aria-invalid={!!error}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}


### PR DESCRIPTION
### 💡 What
Added `aria-invalid={!!error}` to the core macOS UI form components:
- `Input.tsx` (on the `<input>`)
- `Textarea.tsx` (on the `<textarea>`)
- `Select.tsx` (on the `<button>` trigger)
- `Checkbox.tsx` (on the `role="checkbox"` element)

### 🎯 Why
When a form field enters an error state (e.g., failed validation), sighted users can typically tell by the visual cues like red borders. However, screen reader users may not be aware of this state change unless explicitly communicated. Adding `aria-invalid` provides this semantic information to assistive technologies.

### ♿ Accessibility
- Improves WCAG 3.3.1 (Error Identification) compliance by semantically linking error states to their respective form controls, allowing screen readers to announce "invalid entry" when focusing on them.

---
*PR created automatically by Jules for task [17056028335817370633](https://jules.google.com/task/17056028335817370633) started by @drsapaev*