### PR TITLE
fix(test): store-backed localStorage mock + useFinance BS-36 assertions

### DIFF
--- a/frontend/src/hooks/__tests__/useFinance.test.tsx
+++ b/frontend/src/hooks/__tests__/useFinance.test.tsx
@@ -32,10 +32,13 @@ const apiMock = api as unknown as {
   delete: ReturnType<typeof vi.fn>;
 };
 
-// localStorage spies so .mockImplementation and toHaveBeenCalledWith work.
-const localStorageGetItem = vi.spyOn(Storage.prototype, 'getItem');
-const localStorageSetItem = vi.spyOn(Storage.prototype, 'setItem');
-const localStorageRemoveItem = vi.spyOn(Storage.prototype, 'removeItem');
+// localStorage refs so .mockImplementation and toHaveBeenCalledWith work.
+// The global test setup (src/test/setup.ts) replaces window.localStorage
+// with a store-backed vi.fn() mock, so we reference those mock functions
+// directly instead of spying on Storage.prototype.
+const localStorageGetItem = localStorage.getItem as unknown as ReturnType<typeof vi.fn>;
+const localStorageSetItem = localStorage.setItem as unknown as ReturnType<typeof vi.fn>;
+const localStorageRemoveItem = localStorage.removeItem as unknown as ReturnType<typeof vi.fn>;
 
 interface FinanceTransaction {
   id: number;
@@ -266,9 +269,11 @@ describe('useFinance', () => {
     });
 
     expect(result.current.allTransactions).toHaveLength(0);
+    // BS-36: deletedIds are now stored as { id, deletedAt } entries (not bare numbers)
+    // so the persisted cache contains an entry with id:777.
     expect(localStorageSetItem).toHaveBeenCalledWith(
       CACHE_KEY,
-      expect.stringContaining('"deletedIds":[777]')
+      expect.stringContaining('"id":777')
     );
 
     unmount();

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -23,12 +23,16 @@ if (typeof window !== 'undefined') {
     })),
   });
 
-  // Mock localStorage
+  // Mock localStorage — store-backed so tests that write then read
+  // (e.g. useFinance cache persistence) work without per-test spy setup.
+  // `vi.fn()` wrappers preserve `.mockImplementation` override capability
+  // for tests that need to control the return value explicitly.
+  const _localStorageStore: Record<string, string> = {};
   const localStorageMock = {
-    getItem: vi.fn(),
-    setItem: vi.fn(),
-    removeItem: vi.fn(),
-    clear: vi.fn(),
+    getItem: vi.fn((key: string) => _localStorageStore[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { _localStorageStore[key] = String(value); }),
+    removeItem: vi.fn((key: string) => { delete _localStorageStore[key]; }),
+    clear: vi.fn(() => { for (const k of Object.keys(_localStorageStore)) delete _localStorageStore[k]; }),
   };
   Object.defineProperty(window, 'localStorage', {
     value: localStorageMock,


### PR DESCRIPTION
## Summary

Fixes the 2 useFinance test failures documented in issue #2514 (full vitest run report). The failures were **not** an audit-introduced runtime regression — they were stale tests + a too-strict test setup.

Root causes:
1. `src/test/setup.ts` replaced `window.localStorage` with a no-op mock (`vi.fn()` returning `undefined`, discarding `setItem` calls). The `useFinance` cache persistence tests write then read back, so they always saw an empty cache.
2. The useFinance test used `vi.spyOn(Storage.prototype, ...)` which never fires because the global mock replaces `window.localStorage` (not `Storage.prototype`).
3. The BS-36 assertion expected `"deletedIds":[777]` (bare number array), but BS-36 (commit 4c618a08, June 2026) changed the format to `{ id, deletedAt }[]` for 7-day TTL support — and the test was never updated.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main HEAD (e3bd4942)
- Clean workspace: 2 files changed, 19 insertions, 10 deletions
- Branch: fix/useFinance-tests-bs36
- Scope gate: test infrastructure + one test file; no production code changes
- Red-check handling: useFinance 0/3 → 3/3 pass; verified no regression in 7 other localStorage-touching test files

## Contract Impact

- Canonical surface: N/A because no API changes
- Request shape: N/A because no request changes
- Response shape: N/A because no response changes
- Status codes: N/A because no status code changes
- Frontend consumer: N/A because test-only change
- Compatibility path or alias: N/A because no alias changes
- Contract proof: N/A because test infrastructure only

## RBAC / Permissions

- Roles allowed: N/A because no role changes
- Roles denied: N/A because no role changes
- Positive auth proof: N/A because no auth logic changes
- Negative auth proof: N/A because no auth logic changes

## Notification / Realtime

- Event type or websocket channel: N/A because no WS changes
- Payload version / ack behavior: N/A because no payload changes
- Read/unread or delivery semantics: N/A because no notification changes
- Reconnect/resync proof: N/A because no reconnect changes

## Frontend Resilience

- Empty data proof: N/A because no runtime logic changed
- Partial data proof: N/A because no data rendering changed
- Forbidden secondary path behavior: N/A because no navigation changes
- Missing draft/resource behavior: N/A because no draft/resource changes
- Stale route/deep-link behavior: N/A because no routing changes

## Scope Gate

- Allowed paths: frontend/src/test/setup.ts, frontend/src/hooks/__tests__/useFinance.test.tsx
- Denied paths: backend, production frontend code, API routes, DB, routing, RBAC
- Migration/docs/test impact: test-only; no migration/docs
- Rollback note: revert the commit; production code unchanged

## Validation

- Targeted tests or smoke run: `npx vitest run src/hooks/__tests__/useFinance.test.tsx` (3/3 pass); `npx vitest run` on 7 localStorage-touching test files (72/73 pass — the 1 HeaderNew failure is pre-existing from #2439 and unrelated)
- Result: useFinance fixed, no new regressions
- Not checked: full 149-file vitest suite (covered by #2514)

## Changes

### `frontend/src/test/setup.ts`
Replaced the no-op `localStorage` mock with a store-backed mock (matches the existing `sessionStorage` pattern). `vi.fn()` wrappers preserve `.mockImplementation` override capability for tests that need to control the return value explicitly.

### `frontend/src/hooks/__tests__/useFinance.test.tsx`
- Replaced `vi.spyOn(Storage.prototype, ...)` with direct references to the global localStorage mock functions.
- Updated the BS-36 deletedIds assertion: the cache now contains an entry with `"id":777` (BS-36 changed `number[]` → `{id, deletedAt}[]`).
