### PR TITLE
🎨 Palette: Add aria-invalid attributes for better error state accessibility

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,33 @@
+## Summary
+- Added aria-invalid to ui components
+- No contract changes
+
+## Cyclic Execution Evidence
+- Fresh main sync: yes
+- Clean workspace: yes
+- Branch: palette/aria-invalid-inputs
+- Scope gate: ui components
+- Red-check handling: fix before merge
+
+## Contract Impact
+not applicable - UI component attribute changes only, no API contract changes.
+
+## RBAC / Permissions
+not applicable - UI components only, no auth changes.
+
+## Notification / Realtime
+not applicable - UI components only, no realtime changes.
+
+## Frontend Resilience
+not applicable - purely stylistic a11y attributes on components, no data flow changes.
+
+## Scope Gate
+- Allowed paths: frontend/src/components/ui/macos/
+- Denied paths: backend
+- Migration/docs/test impact: none
+- Rollback note: revert the UI components changes
+
+## Validation
+- Targeted tests or smoke run: ran pnpm lint:check and tested the specific components
+- Result: passed
+- Not checked: backend tests

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,13 +1,18 @@
+**💡 What:** Added `aria-invalid={!!error}` to the `Input`, `Textarea`, and `Select` components within `frontend/src/components/ui/macos/`.
+**🎯 Why:** To ensure that screen readers properly announce form validation error states on these controls, improving accessibility for visually impaired users.
+**📸 Before/After:** Screen readers previously did not consistently read out the error state of these fields automatically. With `aria-invalid`, they now detect and announce it properly when validation fails.
+**♿ Accessibility:** Enhanced ARIA attribute adherence for native accessibility notifications.
+
 ## Summary
-- Added aria-invalid to ui components
-- No contract changes
+- Added `aria-invalid` attribute to macos UI components (Input, Textarea, Select).
+- Improves accessibility by letting screen readers announce form validation error states.
 
 ## Cyclic Execution Evidence
 - Fresh main sync: yes
 - Clean workspace: yes
-- Branch: palette/aria-invalid-inputs
-- Scope gate: ui components
-- Red-check handling: fix before merge
+- Branch: palette/aria-invalid-inputs-v2
+- Scope gate: allowed paths: frontend/src/components/ui/macos/
+- Red-check handling: fix any before merge
 
 ## Contract Impact
 not applicable - UI component attribute changes only, no API contract changes.

--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -3,36 +3,46 @@
 **📸 Before/After:** Screen readers previously did not consistently read out the error state of these fields automatically. With `aria-invalid`, they now detect and announce it properly when validation fails.
 **♿ Accessibility:** Enhanced ARIA attribute adherence for native accessibility notifications.
 
+---
+*PR created automatically by Jules for task [11575317694781192704](https://jules.google.com/task/11575317694781192704) started by @drsapaev*
+
 ## Summary
-- Added `aria-invalid` attribute to macos UI components (Input, Textarea, Select).
-- Improves accessibility by letting screen readers announce form validation error states.
+
+Added `aria-invalid` attribute to macos UI components (Input, Textarea, Select). Improves accessibility by letting screen readers announce form validation error states.
 
 ## Cyclic Execution Evidence
+
 - Fresh main sync: yes
 - Clean workspace: yes
 - Branch: palette/aria-invalid-inputs-v2
-- Scope gate: allowed paths: frontend/src/components/ui/macos/
-- Red-check handling: fix any before merge
+- Scope gate: frontend UI components only
+- Red-check handling: fix before merge
 
 ## Contract Impact
+
 not applicable - UI component attribute changes only, no API contract changes.
 
 ## RBAC / Permissions
+
 not applicable - UI components only, no auth changes.
 
 ## Notification / Realtime
+
 not applicable - UI components only, no realtime changes.
 
 ## Frontend Resilience
+
 not applicable - purely stylistic a11y attributes on components, no data flow changes.
 
 ## Scope Gate
+
 - Allowed paths: frontend/src/components/ui/macos/
 - Denied paths: backend
 - Migration/docs/test impact: none
 - Rollback note: revert the UI components changes
 
 ## Validation
+
 - Targeted tests or smoke run: ran pnpm lint:check and tested the specific components
 - Result: passed
 - Not checked: backend tests

--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -174,6 +174,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         className={className}
         style={inputStyle}
         disabled={disabled}
+        aria-invalid={!!error}
         onFocus={handleFocus}
         onBlur={handleBlur}
         {...props}

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -256,6 +256,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           aria-haspopup="listbox"
           aria-expanded={isOpen}
           disabled={disabled}
+          aria-invalid={!!error}
           {...props}
         >
           <span>{selected ? (selected.label ?? String(selected.value)) : <span style={{ color: 'var(--mac-text-secondary)' }}>{placeholder}</span>}</span>

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -141,6 +141,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       className={className}
       style={textareaStyles}
       disabled={disabled}
+        aria-invalid={!!error}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}


### PR DESCRIPTION
**💡 What:** Added `aria-invalid={!!error}` to the `Input`, `Textarea`, and `Select` components within `frontend/src/components/ui/macos/`.
**🎯 Why:** To ensure that screen readers properly announce form validation error states on these controls, improving accessibility for visually impaired users.
**📸 Before/After:** Screen readers previously did not consistently read out the error state of these fields automatically. With `aria-invalid`, they now detect and announce it properly when validation fails.
**♿ Accessibility:** Enhanced ARIA attribute adherence for native accessibility notifications.

---
*PR created automatically by Jules for task [11575317694781192704](https://jules.google.com/task/11575317694781192704) started by @drsapaev*