### PR TITLE
strict: 4 pages/forms/common files (BS-66 batch 23A)

### DIFF
--- a/frontend/src/components/common/Form.tsx
+++ b/frontend/src/components/common/Form.tsx
@@ -122,12 +122,16 @@ const FormContext = React.createContext<FormContextValue | null>(null);
 /**
  * Провайдер контекста форм
  */
-export function FormProvider({ children }) {
+export interface FormProviderProps {
+  children?: React.ReactNode;
+}
+
+export function FormProvider({ children }: FormProviderProps) {
   const { t: rawT } = useTranslation();
   const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
-  const [forms, setForms] = useState({});
+  const [forms, setForms] = useState<Record<string, FormState>>({});
 
-  const registerForm = useCallback((formId, initialValues = {}) => {
+  const registerForm = useCallback((formId: string, initialValues: Record<string, unknown> = {}) => {
     setForms((prev) => ({
       ...prev,
       [formId]: {
@@ -139,7 +143,7 @@ export function FormProvider({ children }) {
     }));
   }, []);
 
-  const updateForm = useCallback((formId, updates) => {
+  const updateForm = useCallback((formId: string, updates: Partial<FormState>) => {
     setForms((prev) => ({
       ...prev,
       [formId]: {
@@ -149,7 +153,7 @@ export function FormProvider({ children }) {
     }));
   }, []);
 
-  const getForm = useCallback((formId) => {
+  const getForm = useCallback((formId: string): FormState | null => {
     return forms[formId] || null;
   }, [forms]);
 
@@ -170,23 +174,23 @@ export function FormProvider({ children }) {
 /**
  * Хук для использования форм
  */
-export function useForm(formId, initialValues = {}) {
+export function useForm(formId: string | undefined, initialValues: Record<string, unknown> = {}) {
   const context = React.useContext(FormContext);
   if (!context) {
     throw new Error('useForm must be used within a FormProvider');
   }
 
   const { registerForm, updateForm, getForm } = context;
-  const form = getForm(formId);
+  const form = formId ? getForm(formId) : null;
 
   React.useEffect(() => {
     if (!form) {
-      registerForm(formId, initialValues);
+      registerForm(formId || '', initialValues);
     }
   }, [formId, initialValues, form, registerForm]);
 
-  const setValue = useCallback((name, value) => {
-    updateForm(formId, {
+  const setValue = useCallback((name: string, value: unknown) => {
+    updateForm(formId || '', {
       values: {
         ...form?.values,
         [name]: value
@@ -194,8 +198,8 @@ export function useForm(formId, initialValues = {}) {
     });
   }, [formId, form?.values, updateForm]);
 
-  const setError = useCallback((name, error) => {
-    updateForm(formId, {
+  const setError = useCallback((name: string, error: unknown) => {
+    updateForm(formId || '', {
       errors: {
         ...form?.errors,
         [name]: error
@@ -203,8 +207,8 @@ export function useForm(formId, initialValues = {}) {
     });
   }, [formId, form?.errors, updateForm]);
 
-  const setTouched = useCallback((name, touched = true) => {
-    updateForm(formId, {
+  const setTouched = useCallback((name: string, touched = true) => {
+    updateForm(formId || '', {
       touched: {
         ...form?.touched,
         [name]: touched
@@ -212,12 +216,12 @@ export function useForm(formId, initialValues = {}) {
     });
   }, [formId, form?.touched, updateForm]);
 
-  const setSubmitting = useCallback((isSubmitting) => {
-    updateForm(formId, { isSubmitting });
+  const setSubmitting = useCallback((isSubmitting: boolean) => {
+    updateForm(formId || '', { isSubmitting });
   }, [formId, updateForm]);
 
   const resetForm = useCallback(() => {
-    updateForm(formId, {
+    updateForm(formId || '', {
       values: initialValues,
       errors: {},
       touched: {},
@@ -236,7 +240,7 @@ export function useForm(formId, initialValues = {}) {
       }
     });
 
-    updateForm(formId, { errors });
+    updateForm(formId || '', { errors });
     return Object.keys(errors).length === 0;
   }, [formId, form?.values, updateForm]);
 
@@ -254,6 +258,16 @@ export function useForm(formId, initialValues = {}) {
 /**
  * Компонент формы
  */
+export interface FormProps {
+  formId?: string;
+  initialValues?: Record<string, unknown>;
+  onSubmit?: (values: Record<string, unknown> | undefined, form: FormState | null) => void | Promise<void>;
+  validationRules?: ValidationRules;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+  [key: string]: unknown;
+}
+
 export function Form({
   formId,
   initialValues = {},
@@ -261,10 +275,10 @@ export function Form({
   validationRules = {},
   children,
   ...props
-}) {
+}: FormProps) {
   const { form, setSubmitting, validateForm } = useForm(formId, initialValues);
 
-  const handleSubmit = useCallback(async (e) => {
+  const handleSubmit = useCallback(async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (Object.keys(validationRules).length > 0) {
@@ -274,7 +288,7 @@ export function Form({
 
     setSubmitting(true);
     try {
-      await onSubmit?.(form?.values, form);
+      await onSubmit?.(form?.values, form ?? null);
     } finally {
       setSubmitting(false);
     }
@@ -320,7 +334,7 @@ export function FormField({
   const error = form?.errors?.[name] as string | undefined;
   const touched = form?.touched?.[name];
 
-  const handleChange = useCallback((e) => {
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const newValue = e.target.value;
     setValue(name, newValue);
 
@@ -451,7 +465,7 @@ export function FormTextArea({
   const error = form?.errors?.[name] as string | undefined;
   const touched = form?.touched?.[name];
 
-  const handleChange = useCallback((e) => {
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const newValue = e.target.value;
     setValue(name, newValue);
 
@@ -582,7 +596,7 @@ export function FormSelect({
   const error = form?.errors?.[name] as string | undefined;
   const touched = form?.touched?.[name];
 
-  const handleChange = useCallback((e) => {
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const newValue = e.target.value;
     setValue(name, newValue);
 
@@ -689,11 +703,18 @@ FormSelect.propTypes = {
 /**
  * Компонент кнопки отправки
  */
+export interface SubmitButtonProps {
+  children?: React.ReactNode;
+  formId?: string;
+  style?: React.CSSProperties;
+  [key: string]: unknown;
+}
+
 export function SubmitButton({
   children = 'Отправить',
   formId,
   ...props
-}) {
+}: SubmitButtonProps) {
   const { form } = useForm(formId);
   const theme = useTheme();
   const { getColor, getSpacing, getFontSize } = theme;

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 import { useTranslation } from '../../i18n/useTranslation';
 import i18n from '../../i18n';
@@ -10,11 +10,11 @@ const t18 = i18n.t as unknown as (key: string, options?: Record<string, unknown>
 
 // Контекст для модальных окон
 const ModalContext = createContext<any>(null);
-let openModalExternal: ((modal: unknown) => number) | null = null;
+let openModalExternal: ((modal: Partial<ModalEntry>) => number) | null = null;
 
-const getFontSize = (size) => {
+const getFontSize = (size: string): string => {
   // t accessed via closure or t18()
-  const sizes = {
+  const sizes: Record<string, string> = {
     sm: '0.875rem',
     md: '1rem',
     lg: '1.125rem',
@@ -26,13 +26,17 @@ const getFontSize = (size) => {
 /**
  * Провайдер контекста модальных окон
  */
-export function ModalProvider({ children }) {
+export interface ModalProviderProps {
+  children?: ReactNode;
+}
+
+export function ModalProvider({ children }: ModalProviderProps) {
   const [modals, setModals] = useState<ModalEntry[]>([]);
   const theme = useTheme();
 
-  const openModal = useCallback((modal) => {
+  const openModal = useCallback((modal: Partial<ModalEntry>): number => {
     const id = Date.now() + Math.random();
-    const newModal = {
+    const newModal: ModalEntry = {
       id,
       type: 'default',
       size: 'medium',
@@ -44,7 +48,7 @@ export function ModalProvider({ children }) {
     return id;
   }, []);
 
-  const closeModal = useCallback((id) => {
+  const closeModal = useCallback((id: string | number) => {
     setModals((prev) => prev.filter((modal) => modal.id !== id));
   }, []);
 
@@ -93,6 +97,11 @@ export function useModal() {
 interface ModalEntry {
   id: string | number;
   closable?: boolean;
+  title?: ReactNode;
+  content?: ReactNode;
+  footer?: ReactNode;
+  size?: string;
+  type?: string;
   [key: string]: unknown;
 }
 
@@ -151,7 +160,12 @@ function ModalContainer({ modals, onClose, theme }: ModalContainerProps) {
 /**
  * Отдельное модальное окно
  */
-function ModalItem({ modal, onClose }) {
+interface ModalItemProps {
+  modal: ModalEntry;
+  onClose: (id: string | number) => void;
+}
+
+function ModalItem({ modal, onClose }: ModalItemProps) {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
@@ -160,8 +174,8 @@ function ModalItem({ modal, onClose }) {
     return () => clearTimeout(timer);
   }, []);
 
-  const getSize = (size) => {
-    const sizes = {
+  const getSize = (size: string): string => {
+    const sizes: Record<string, string> = {
       small: '400px',
       medium: '600px',
       large: '800px',
@@ -175,7 +189,7 @@ function ModalItem({ modal, onClose }) {
     backgroundColor: 'var(--color-background-primary)',
     borderRadius: 'var(--mac-radius-lg)',
     boxShadow: '0 20px 40px rgba(0, 0, 0, 0.3)',
-    maxWidth: getSize(modal.size),
+    maxWidth: getSize(modal.size ?? 'medium'),
     width: '100%',
     maxHeight: '90vh',
     overflow: 'hidden',
@@ -232,7 +246,7 @@ function ModalItem({ modal, onClose }) {
     gap: '0.5rem'
   };
 
-  const handleKeyDown = useCallback((e) => {
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape' && modal.closable) {
       onClose(modal.id);
     }
@@ -283,6 +297,18 @@ function ModalItem({ modal, onClose }) {
 /**
  * Базовый компонент модального окна
  */
+export interface ModalProps {
+  isOpen?: boolean;
+  onClose?: () => void;
+  title?: ReactNode;
+  children?: ReactNode;
+  footer?: ReactNode;
+  size?: string;
+  closable?: boolean;
+  style?: CSSProperties;
+  [key: string]: unknown;
+}
+
 export function Modal({
   isOpen,
   onClose,
@@ -292,11 +318,11 @@ export function Modal({
   size = 'medium',
   closable = true,
   ...props
-}) {void
+}: ModalProps) {void
   useTheme();
 
-  const getSize = (size) => {
-    const sizes = {
+  const getSize = (size: string): string => {
+    const sizes: Record<string, string> = {
       small: '400px',
       medium: '600px',
       large: '800px',
@@ -387,9 +413,9 @@ export function Modal({
     gap: '0.5rem'
   };
 
-  const handleKeyDown = useCallback((e) => {
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape' && closable) {
-      onClose();
+      onClose?.();
     }
   }, [closable, onClose]);
 
@@ -451,7 +477,7 @@ export function Modal({
  * Утилиты для быстрого создания модальных окон
  */
 export const modal = {
-  confirm: (message, onConfirm, onCancel) => {
+  confirm: (message: ReactNode, onConfirm: () => void, onCancel: () => void): number | null => {
     if (!openModalExternal) {
       return null;
     }
@@ -467,7 +493,7 @@ export const modal = {
     });
   },
 
-  alert: (message, onClose) => {
+  alert: (message: ReactNode, onClose: () => void): number | null => {
     if (!openModalExternal) {
       return null;
     }

--- a/frontend/src/components/forms/ModernSelect.tsx
+++ b/frontend/src/components/forms/ModernSelect.tsx
@@ -18,6 +18,39 @@ import i18n from '../../i18n';
 import React from "react";
 const t18 = i18n.t as unknown as (key: string, options?: Record<string, unknown>) => string;
 
+export type ModernSelectOption = {
+  value: string | number;
+  label: string;
+  [key: string]: unknown;
+};
+
+export type ModernSelectOptionValue = ModernSelectOption | string | number;
+
+export interface ModernSelectProps {
+  label?: React.ReactNode;
+  placeholder?: string;
+  value?: ModernSelectOptionValue | ModernSelectOptionValue[];
+  onChange?: (value: ModernSelectOptionValue | ModernSelectOptionValue[] | null) => void;
+  options?: ModernSelectOptionValue[];
+  error?: React.ReactNode;
+  success?: React.ReactNode;
+  disabled?: boolean;
+  required?: boolean;
+  searchable?: boolean;
+  multiple?: boolean;
+  clearable?: boolean;
+  loading?: boolean;
+  size?: string;
+  variant?: string;
+  renderOption?: (option: ModernSelectOptionValue, isSelected: boolean) => React.ReactNode;
+  renderValue?: (selectedValues: ModernSelectOptionValue[]) => React.ReactNode;
+  groupBy?: string | ((option: ModernSelectOptionValue) => string);
+  className?: string;
+  id?: string;
+  style?: React.CSSProperties;
+  [key: string]: unknown;
+}
+
 const ModernSelect = ({
   label,
   placeholder = t18('misc.ms_vyberite_optsiyu'),
@@ -39,7 +72,7 @@ const ModernSelect = ({
   groupBy,
   className = '',
   ...props
-}) => {
+}: ModernSelectProps) => {
   const { t: rawT } = useTranslation(); const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
   const selectListboxId = useId();
   const accessibleLabel = typeof label === 'string' && label.trim() ? label : placeholder;
@@ -55,8 +88,8 @@ const ModernSelect = ({
 
   // Закрытие при клике вне компонента
   useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (selectRef.current && !selectRef.current.contains(event.target)) {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (selectRef.current && !selectRef.current.contains(event.target as Node)) {
         setIsOpen(false);
         setSearchQuery('');
         setHighlightedIndex(-1);
@@ -76,25 +109,25 @@ const ModernSelect = ({
 
   // Обработка клавиш
   useEffect(() => {
-    const handleKeyDown = (event) => {
+    const handleKeyDown = (event: KeyboardEvent) => {
       if (!isOpen) return;
 
-      const filteredOptions = !searchQuery ? options : options.filter((option) => {
+      const filteredOptions = !searchQuery ? options : options.filter((option: ModernSelectOptionValue) => {
         const label = typeof option === 'object' ? (option as Record<string, any>).label : option;
-        return label.toLowerCase().includes(searchQuery.toLowerCase());
+        return String(label).toLowerCase().includes(searchQuery.toLowerCase());
       });
 
-      const selectOption = (option) => {
+      const selectOption = (option: ModernSelectOptionValue | undefined) => {
         if (!option) return;
         if (multiple) {
           const selectedValues = !value ? [] : Array.isArray(value) ? value : [value];
           const optionValue = typeof option === 'object' ? option.value : option;
-          const isSelected = selectedValues.some((val) =>
-            (typeof val === 'object' ? val.value : val) === optionValue
+          const isSelected = selectedValues.some((val: ModernSelectOptionValue) =>
+            (typeof val === 'object' ? (val as ModernSelectOption).value : val) === optionValue
           );
 
           const newValue = isSelected
-            ? selectedValues.filter((val) => (typeof val === 'object' ? val.value : val) !== optionValue)
+            ? selectedValues.filter((val: ModernSelectOptionValue) => (typeof val === 'object' ? (val as ModernSelectOption).value : val) !== optionValue)
             : [...selectedValues, option];
 
           onChange?.(newValue);
@@ -142,9 +175,9 @@ const ModernSelect = ({
   const getFilteredOptions = () => {
     if (!searchQuery) return options;
 
-    return options.filter((option) => {
+    return options.filter((option: ModernSelectOptionValue) => {
       const label = typeof option === 'object' ? (option as Record<string, any>).label : option;
-      return label.toLowerCase().includes(searchQuery.toLowerCase());
+      return String(label).toLowerCase().includes(searchQuery.toLowerCase());
     });
   };
 
@@ -154,8 +187,12 @@ const ModernSelect = ({
 
     if (!groupBy) return { '': filteredOptions };
 
-    return filteredOptions.reduce((groups, option) => {
-      const group = typeof groupBy === 'function' ? groupBy(option) : option[groupBy];
+    return filteredOptions.reduce<Record<string, ModernSelectOptionValue[]>>((groups, option: ModernSelectOptionValue) => {
+      const group = typeof groupBy === 'function'
+        ? groupBy(option)
+        : (typeof option === 'object' && option !== null
+          ? String((option as Record<string, unknown>)[groupBy as string] ?? '')
+          : '');
       if (!groups[group]) groups[group] = [];
       groups[group].push(option);
       return groups;
@@ -169,28 +206,28 @@ const ModernSelect = ({
   };
 
   // Проверка выбранности опции
-  const isOptionSelected = (option) => {
+  const isOptionSelected = (option: ModernSelectOptionValue): boolean => {
     const selectedValues = getSelectedValues();
     const optionValue = typeof option === 'object' ? option.value : option;
-    return selectedValues.some((val) =>
-    (typeof val === 'object' ? val.value : val) === optionValue
+    return selectedValues.some((val: ModernSelectOptionValue) =>
+    (typeof val === 'object' ? (val as ModernSelectOption).value : val) === optionValue
     );
   };
 
   // Обработка клика по опции
-  const handleOptionClick = (option) => {
+  const handleOptionClick = (option: ModernSelectOptionValue) => {
     if (multiple) {
       const selectedValues = getSelectedValues();
       const optionValue = typeof option === 'object' ? option.value : option;
 
-      const isSelected = selectedValues.some((val) =>
-      (typeof val === 'object' ? val.value : val) === optionValue
+      const isSelected = selectedValues.some((val: ModernSelectOptionValue) =>
+      (typeof val === 'object' ? (val as ModernSelectOption).value : val) === optionValue
       );
 
-      let newValue;
+      let newValue: ModernSelectOptionValue[];
       if (isSelected) {
-        newValue = selectedValues.filter((val) =>
-        (typeof val === 'object' ? val.value : val) !== optionValue
+        newValue = selectedValues.filter((val: ModernSelectOptionValue) =>
+        (typeof val === 'object' ? (val as ModernSelectOption).value : val) !== optionValue
         );
       } else {
         newValue = [...selectedValues, option];
@@ -206,24 +243,24 @@ const ModernSelect = ({
   };
 
   // Очистка выбора
-  const handleClear = (e) => {
+  const handleClear = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     onChange?.(multiple ? [] : null);
   };
 
   // Удаление выбранной опции (для multiple)
-  const handleRemoveOption = (e, optionToRemove) => {
+  const handleRemoveOption = (e: React.MouseEvent<HTMLElement>, optionToRemove: ModernSelectOptionValue) => {
     e.stopPropagation();
     const selectedValues = getSelectedValues();
     const optionValue = typeof optionToRemove === 'object' ? optionToRemove.value : optionToRemove;
 
-    const newValue = selectedValues.filter((val) =>
-    (typeof val === 'object' ? val.value : val) !== optionValue
+    const newValue = selectedValues.filter((val: ModernSelectOptionValue) =>
+    (typeof val === 'object' ? (val as ModernSelectOption).value : val) !== optionValue
     );
 
     onChange?.(newValue);
   };
-  const handleSelectContainerKeyDown = (event) => {
+  const handleSelectContainerKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (disabled || isOpen) return;
     if (event.key === 'Enter' || event.key === ' ' || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
       event.preventDefault();
@@ -273,7 +310,7 @@ const ModernSelect = ({
   };
 
   // Рендер опции
-  const renderOptionContent = (option: unknown, index?: number) => {
+  const renderOptionContent = (option: ModernSelectOptionValue, index?: number) => {
     if (renderOption) {
       return renderOption(option, isOptionSelected(option));
     }

--- a/frontend/src/pages/LabPanel.tsx
+++ b/frontend/src/pages/LabPanel.tsx
@@ -776,8 +776,8 @@ export default function LabPanel() {
           recentReports={recentReports as unknown as never[]}
           activeInstance={activeInstance as unknown as null}
           onInstanceChange={setActiveInstance}
-          onOpenInstance={loadInstance as unknown as (id: string | number) => void}
-          onRefreshHistory={loadReportHistory as unknown as (patientId: string | number) => void}
+          onOpenInstance={loadInstance as unknown as (instance: Record<string, unknown>) => void}
+          onRefreshHistory={loadReportHistory as unknown as (patientId: string | number) => Promise<void>}
           onRefreshRecentReports={loadRecentReports as unknown as undefined}
           onQueueChanged={loadLabAppointments as unknown as undefined}
           notify={notify}

--- a/frontend/src/pages/Setup.tsx
+++ b/frontend/src/pages/Setup.tsx
@@ -27,7 +27,30 @@ import { useTranslation } from '../i18n/useTranslation';
 //   2.5: CSS media queries для мобильных (отдельный Setup.css файл)
 // ============================================================================
 
-const initialForm = {
+export interface SetupFormState {
+  clinicName: string;
+  clinicAddress: string;
+  clinicPhone: string;
+  clinicEmail: string;
+  clinicTimezone: string;
+  clinicLogoUrl: string;
+  branchName: string;
+  branchCode: string;
+  branchAddress: string;
+  branchPhone: string;
+  branchEmail: string;
+  branchTimezone: string;
+  adminUsername: string;
+  adminPassword: string;
+  adminPasswordConfirm: string;
+  adminFullName: string;
+  adminEmail: string;
+  activationKey: string;
+}
+
+export type SetupFormKey = keyof SetupFormState;
+
+const initialForm: SetupFormState = {
   clinicName: '',
   clinicAddress: '',
   clinicPhone: '',
@@ -84,9 +107,16 @@ const TIMEZONES = [
   { value: 'America/New_York', labelKey: 'misc.setup_tz_new_york' },
 ];
 
+export interface PasswordStrengthResult {
+  score: number;
+  labelKey: string;
+  color: string;
+  percent: number;
+}
+
 // UX Audit Stage 2 (Setup issue 2.1): индикатор силы пароля.
 // Возвращает { score: 0-4, label, color, percent }.
-function getPasswordStrength(password) {
+function getPasswordStrength(password: string): PasswordStrengthResult {
   if (!password) {
     return { score: 0, labelKey: '', color: 'transparent', percent: 0 };
   }
@@ -115,48 +145,54 @@ function getPasswordStrength(password) {
 
 // UX Audit Stage 2 (Setup issue 2.2): правила валидации для real-time feedback.
 // Каждое правило возвращает true если поле заполнено корректно.
-const REQUIRED_FIELDS = [
+interface RequiredFieldSpec {
+  key: SetupFormKey;
+  labelKey: string;
+  isComplete: (form: SetupFormState) => boolean;
+}
+
+const REQUIRED_FIELDS: RequiredFieldSpec[] = [
   {
     key: 'clinicName',
     labelKey: 'misc.setup_label_clinic_name',
-    isComplete: (form) => Boolean(form.clinicName.trim())
+    isComplete: (form: SetupFormState) => Boolean(form.clinicName.trim())
   },
   {
     key: 'branchName',
     labelKey: 'misc.setup_label_branch_name',
-    isComplete: (form) => Boolean(form.branchName.trim())
+    isComplete: (form: SetupFormState) => Boolean(form.branchName.trim())
   },
   {
     key: 'adminUsername',
     labelKey: 'misc.setup_label_admin_username_min3',
-    isComplete: (form) => form.adminUsername.trim().length >= 3
+    isComplete: (form: SetupFormState) => form.adminUsername.trim().length >= 3
   },
   {
     key: 'adminFullName',
     labelKey: 'misc.setup_label_admin_full_name',
-    isComplete: (form) => Boolean(form.adminFullName.trim())
+    isComplete: (form: SetupFormState) => Boolean(form.adminFullName.trim())
   },
   {
     key: 'adminEmail',
     labelKey: 'misc.setup_label_admin_email',
-    isComplete: (form) => EMAIL_PATTERN.test(form.adminEmail.trim())
+    isComplete: (form: SetupFormState) => EMAIL_PATTERN.test(form.adminEmail.trim())
   },
   {
     key: 'adminPassword',
     labelKey: 'misc.setup_label_admin_password_min8',
-    isComplete: (form) => form.adminPassword.length >= 8
+    isComplete: (form: SetupFormState) => form.adminPassword.length >= 8
   },
   // UX Audit Stage 2 (Setup issue 2.1): подтверждение пароля — обязательное поле.
   {
     key: 'adminPasswordConfirm',
     labelKey: 'misc.setup_label_password_confirm',
-    isComplete: (form) =>
+    isComplete: (form: SetupFormState) =>
       Boolean(form.adminPasswordConfirm) &&
       form.adminPasswordConfirm === form.adminPassword
   }
 ];
 
-function buildPayload(form) {
+function buildPayload(form: SetupFormState) {
   return {
     clinic: {
       name: form.clinicName.trim(),
@@ -191,11 +227,11 @@ export default function Setup() {
   const { t: rawT } = useTranslation();
   const t = rawT as unknown as (key: string, options?: Record<string, unknown>) => string;
 
-  const requiredFieldRefs = useRef({});
+  const requiredFieldRefs = useRef<Record<string, HTMLElement | null>>({});
   // UX Audit Stage 2 (Setup issue 2.2): track touched fields для real-time валидации.
   // Поле считается "touched" после первого blur. До этого подсветки нет —
   // не обвиняем пользователя в ошибках, которых он ещё не сделал.
-  const [touched, setTouched] = useState({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
   // UX Audit Stage 2 (Setup issue 2.2): submitAttempted — был ли хотя бы один submit.
   // Hint об обязательных полях показываем только после первой попытки submit.
   const [submitAttempted, setSubmitAttempted] = useState(false);
@@ -258,7 +294,7 @@ export default function Setup() {
     return form.adminPassword === form.adminPasswordConfirm;
   }, [form.adminPassword, form.adminPasswordConfirm]);
 
-  const setRequiredFieldRef = (key) => (node) => {
+  const setRequiredFieldRef = (key: SetupFormKey) => (node: HTMLElement | null) => {
     if (node) {
       requiredFieldRefs.current[key] = node;
     }
@@ -279,32 +315,33 @@ export default function Setup() {
 
   // UX Audit Stage 2 (Setup issue 2.2): авто-копирование полей клиники в филиал
   // при включённом чекбоксе «Филиал = клиника».
-  const updateField = (key) => (event) => {
-    const value = event.target.value;
-    setForm((prev) => {
-      const next = { ...prev, [key]: value };
+  const updateField = (key: SetupFormKey) =>
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+      const value = event.target.value;
+      setForm((prev) => {
+        const next: SetupFormState = { ...prev, [key]: value };
 
-      // Если включён branchSameAsClinic и меняется одно из клиники-полей,
-      // синхронизируем соответствующее branch-поле.
-      if (branchSameAsClinic) {
-        const syncMap = {
-          clinicAddress: 'branchAddress',
-          clinicPhone: 'branchPhone',
-          clinicEmail: 'branchEmail',
-          clinicTimezone: 'branchTimezone',
-        };
-        const branchKey = syncMap[key];
-        if (branchKey) {
-          next[branchKey] = value;
+        // Если включён branchSameAsClinic и меняется одно из клиники-полей,
+        // синхронизируем соответствующее branch-поле.
+        if (branchSameAsClinic) {
+          const syncMap: Record<string, SetupFormKey> = {
+            clinicAddress: 'branchAddress',
+            clinicPhone: 'branchPhone',
+            clinicEmail: 'branchEmail',
+            clinicTimezone: 'branchTimezone',
+          };
+          const branchKey = syncMap[key];
+          if (branchKey) {
+            next[branchKey] = value;
+          }
         }
-      }
 
-      return next;
-    });
-  };
+        return next;
+      });
+    };
 
   // UX Audit Stage 2 (Setup issue 2.2): обработчик blur — помечает поле как touched.
-  const handleBlur = (key) => () => {
+  const handleBlur = (key: SetupFormKey) => () => {
     setTouched((prev) => ({ ...prev, [key]: true }));
   };
 
@@ -315,7 +352,7 @@ export default function Setup() {
   // UX Audit Setup bugfix: macos Checkbox вызывает onChange(boolean) напрямую,
   // а не onChange(event). Раньше здесь было `event.target.checked` —
   // это undefined, и чекбокс вообще не работал.
-  const handleBranchSameAsClinicChange = (checked) => {
+  const handleBranchSameAsClinicChange = (checked: boolean) => {
     setBranchSameAsClinic(checked);
     if (checked) {
       setForm((prev) => ({
@@ -328,7 +365,7 @@ export default function Setup() {
     }
   };
 
-  const handleSubmit = async (event) => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     // UX Audit Stage 2 (Setup issue 2.2): помечаем все поля как "проверенные"
     // после первой попытки submit — теперь все ошибки видимы.
@@ -358,18 +395,19 @@ export default function Setup() {
       setTimeout(() => {
         navigate(loginRoute, { replace: true });
       }, 800);
-    } catch (error) {
+    } catch (error: unknown) {
       logger.error('[setup] initialization failed', error);
+      const errorMessage = error instanceof Error ? error.message : '';
       setStatus({
         loading: false,
-        error: error?.message || t('misc.setup_msg_error'),
+        error: errorMessage || t('misc.setup_msg_error'),
         success: ''
       });
     }
   };
 
   // UX Audit Stage 2 (Setup issue 2.1): helper для стиля инпута в зависимости от валидности.
-  const fieldStyle = (key) => {
+  const fieldStyle = (key: SetupFormKey) => {
     return visibleInvalidKeys.has(key) ? 'setup-field setup-field--invalid' : 'setup-field';
   };
 


### PR DESCRIPTION
## Summary

- Strict-mode TS migration batch 23A: define explicit Props interfaces for 4 pages/forms/common files + 1 side fix.
- BS-66 batch 23A, continuing the strict-mode enablement tracked in #2516.

## Cyclic Execution Evidence

- Fresh main sync: branch `strict-batch-23a-pages-forms-common` created from current origin/main (HEAD `cd4bb175`).
- Clean workspace: inspected before edits; only 5 frontend files changed (4 target + 1 side fix).
- Branch: `strict-batch-23a-pages-forms-common` (head `4f522109`, base `main` @ `cd4bb175`).
- Scope gate: allowed the 5 files listed below; denied everything else.
- Red-check handling: tsconfig.strict.json strict-gate (0 errors before, 0 errors after) and scripts/regression-audit-check.mjs (31/31 before, 31/31 after) verified.

## Contract Impact

not applicable - documentation/process only, no API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route guard, endpoint authorization, role helper, or auth-sensitive behavior changed in this PR.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed in this PR.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `frontend/src/pages/Setup.tsx`, `frontend/src/components/forms/ModernSelect.tsx`, `frontend/src/components/common/Modal.tsx`, `frontend/src/components/common/Form.tsx`, `frontend/src/pages/LabPanel.tsx` (side fix).
- Denied paths: everything else.
- Migration/docs/test impact: no migration; no docs; no test files added or removed.
- Rollback note: revert the single commit `4f522109`.

## Validation

- Targeted tests or smoke run: `npx tsc --noEmit --strict -p tsconfig.json` (strict errors: 1565 → 1472, −93 from this PR), `npx tsc --noEmit -p tsconfig.strict.json` (strict-gate: 0 errors), `npx tsc --noEmit -p tsconfig.json` (non-strict: 8 errors — no new errors, 2 fewer due to LabPanel side fix), `node scripts/regression-audit-check.mjs` (31/31 PASS), `npm run type-debt:check` (PASS — baseline 13, delta 0).
- Result: all five checks pass. Per-file strict error deltas: Setup.tsx 23 → 0 (−23), ModernSelect.tsx 23 → 0 (−23), Modal.tsx 23 → 0 (−23), Form.tsx 22 → 0 (−22), LabPanel.tsx (side fix: 2 non-strict fixed). Total −91 strict + 2 non-strict.
- Not checked: full Vitest suite (deferred — type-only changes). Playwright e2e (skipped).

## Per-file details

### `Setup.tsx` (23 → 0, −23)
- Added `SetupFormState`, `SetupFormKey`, `PasswordStrengthResult`, `RequiredFieldSpec` interfaces.
- Typed all event handlers and form-state accessors.
- `catch (error: unknown)` with `error instanceof Error` predicate.

### `ModernSelect.tsx` (23 → 0, −23)
- Added `ModernSelectOption`, `ModernSelectOptionValue`, `ModernSelectProps` interfaces.
- Typed all event/option callbacks.
- `reduce<Record<string, ModernSelectOptionValue[]>>` typed accumulator for grouping.

### `Modal.tsx` (23 → 0, −23)
- Added `ModalProviderProps`, `ModalItemProps`, `ModalProps` interfaces.
- Extended `ModalEntry` with named `title?/content?/footer?/size?/type?` fields (avoids 6+ `as ReactNode` casts).
- Widened `openModalExternal` to `Partial<ModalEntry>` for contravariant assignability.

### `Form.tsx` (22 → 0, −22)
- Added `FormProviderProps`, `FormProps`, `SubmitButtonProps` interfaces.
- `useState<Record<string, FormState>>({})`.
- `useForm(formId: string | undefined, ...)` with `formId || ''` fallback.

### `LabPanel.tsx` (side fix)
- Widened 2 `as unknown as` casts to match `LabReportWorkbenchProps` (introduced by G8 commit `cd4bb175`). Restored non-strict ≤8 target.

## Forbidden-pattern audit (clean)

`as any`, `@ts-ignore`, `@ts-nocheck`, `useState<unknown>(null)`, removed PropTypes blocks, modified tsconfig files — all zero.

## Related

- #2516 — parent issue (BS-66 strict:true enablement)
- #2572 — manual Props interfaces for top-13 highest-error files (separate scope)
