### PR TITLE
fix(ci): regression-audit fileContains uses in-process RegExp (5 false positives)

### DIFF
--- a/scripts/regression-audit-check.mjs
+++ b/scripts/regression-audit-check.mjs
@@ -20,7 +20,7 @@
 
 import { existsSync, statSync, readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
-import { resolve, dirname } from 'node:path';
+import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -44,21 +44,30 @@ function run(cmd, cwd = REPO) {
 }
 
 /**
- * Check if a pattern exists in a file. Uses rg if available, falls back to grep.
- * Returns true if pattern is found.
+ * Check if a pattern exists in a file.
+ *
+ * Implementation note: reads the file via fs and runs a RegExp in-process to
+ * avoid cross-platform shell-quoting issues (cmd.exe on Windows does not
+ * handle single-quoted multi-word patterns the way POSIX shells do, which
+ * caused BS-9/16/35/36/53 to register as false-positive regressions).
+ *
+ * The pattern is treated as a JavaScript RegExp source. Callers that need
+ * literal matching of regex metacharacters must escape them.
  */
 function fileContains(pattern, filePath, cwd = FRONTEND) {
-  // Try rg first (faster, respects gitignore)
-  const rgResult = run(`rg -c ${pattern} ${filePath} 2>/dev/null || true`, cwd);
-  if (rgResult && rgResult.trim() !== '') {
-    return parseInt(rgResult.trim(), 10) > 0;
+  const fullPath = join(cwd, filePath);
+  let content = '';
+  try {
+    content = readFileSync(fullPath, 'utf-8');
+  } catch {
+    return false;
   }
-  // Fallback to grep with -E for regex support
-  const grepResult = run(`grep -cE ${pattern} ${filePath} 2>/dev/null || true`, cwd);
-  if (grepResult && grepResult.trim() !== '') {
-    return parseInt(grepResult.trim(), 10) > 0;
+  try {
+    return new RegExp(pattern).test(content);
+  } catch {
+    // If the pattern is not a valid regex, fall back to literal substring.
+    return content.includes(pattern);
   }
-  return false;
 }
 
 /**
@@ -164,7 +173,7 @@ const checks = [
     category: 'static',
     name: 'EMRHttpStatus exists in domain/emr.ts',
     check: () => {
-      return fileContains('"export type EMRHttpStatus"', 'src/types/domain/emr.ts');
+      return fileContains('export type EMRHttpStatus', 'src/types/domain/emr.ts');
     },
   },
   {
@@ -181,7 +190,7 @@ const checks = [
     category: 'static',
     name: 'ChatContext value wrapped in useMemo',
     check: () => {
-      return fileContains('"useMemo"', 'src/contexts/ChatContext.tsx');
+      return fileContains('useMemo', 'src/contexts/ChatContext.tsx');
     },
   },
   {
@@ -208,7 +217,7 @@ const checks = [
     category: 'static',
     name: 'CONFLICT_RESOLVED resets history: []',
     check: () => {
-      return fileContains('"history: \\[\\]"', 'src/reducers/emrReducer.ts');
+      return fileContains('history: \\[\\]', 'src/reducers/emrReducer.ts');
     },
   },
   {
@@ -216,7 +225,7 @@ const checks = [
     category: 'static',
     name: 'useFinance.deletedIds has TTL (DELETED_IDS_TTL_MS)',
     check: () => {
-      return fileContains('"DELETED_IDS_TTL_MS"', 'src/hooks/useFinance.ts');
+      return fileContains('DELETED_IDS_TTL_MS', 'src/hooks/useFinance.ts');
     },
   },
   {
@@ -261,7 +270,7 @@ const checks = [
     category: 'static',
     name: 'ChatWindow uses safeMessageURL helper',
     check: () => {
-      return fileContains('"safeMessageURL"', 'src/components/chat/ChatWindow.tsx');
+      return fileContains('safeMessageURL', 'src/components/chat/ChatWindow.tsx');
     },
   },
   {


### PR DESCRIPTION
## Summary

Fixes 5 false-positive regressions in the regression audit gate that surfaced after the G8 strict:true milestone (PR #2598). The audit fixes for BS-9, BS-16, BS-35, BS-36, BS-53 were intact in the code, but the `fileContains` helper reported them as regressed because of a shell-quoting bug on Windows.

Root cause: `fileContains` shelled out to `rg -c <pattern> <file>` via `execSync` without quoting the pattern. On Windows, Node's `execSync` uses `cmd.exe` by default, which splits `export type EMRHttpStatus` into 3 separate arguments — rg then searched for files named `export`, `type`, `EMRHttpStatus'` instead of the pattern, and every check failed.

The previous attempt to fix this by wrapping patterns in `"..."` (commit 0fa2e79f) traded one bug for another: on POSIX shells the double-quoted pattern was matched as a string literal (the quotes were passed through to rg), so `rg` searched for the literal `"DELETED_IDS_TTL_MS"` (with quotes) and failed because the code defines it as an unquoted identifier.

Fix: replace the rg/grep shell call with an in-process `readFileSync` + `RegExp.test`. This is cross-platform, deterministic, and avoids all shell-quoting issues. The pattern is still treated as regex source (callers that need literal matching must escape metacharacters), with a fallback to substring matching if the pattern is not a valid regex.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main HEAD (cc6d9c13)
- Clean workspace: 1 file changed, 26 insertions, 17 deletions
- Branch: fix/regression-audit-false-positives
- Scope gate: 1 CI script; no production code
- Red-check handling: before 26/31 (5 false positives); after 31/31 PASS

## Contract Impact

- Canonical surface: N/A because no API changes
- Request shape: N/A because no request changes
- Response shape: N/A because no response changes
- Status codes: N/A because no status code changes
- Frontend consumer: N/A because CI script only
- Compatibility path or alias: N/A because no alias changes
- Contract proof: N/A because CI infrastructure only

## RBAC / Permissions

- Roles allowed: N/A because no role changes
- Roles denied: N/A because no role changes
- Positive auth proof: N/A because no auth logic changes
- Negative auth proof: N/A because no auth logic changes

## Notification / Realtime

- Event type or websocket channel: N/A because no WS changes
- Payload version / ack behavior: N/A because no payload changes
- Read/unread or delivery semantics: N/A because no notification changes
- Reconnect/resync proof: N/A because no reconnect changes

## Frontend Resilience

- Empty data proof: N/A because no runtime logic changed
- Partial data proof: N/A because no data rendering changed
- Forbidden secondary path behavior: N/A because no navigation changes
- Missing draft/resource behavior: N/A because no draft/resource changes
- Stale route/deep-link behavior: N/A because no routing changes

## Scope Gate

- Allowed paths: scripts/regression-audit-check.mjs
- Denied paths: backend, frontend production code, API routes, DB, routing, RBAC
- Migration/docs/test impact: none
- Rollback note: revert the commit; CI script reverts to rg/grep with quoting bug

## Validation

- Targeted tests or smoke run: `node scripts/regression-audit-check.mjs` — before: 26 passed, 5 failed; after: 31 passed, 0 failed
- Result: All 31 BS invariants now correctly verified
- Not checked: CI environment (Linux uses bash, the bug was Windows-specific, but the in-process fix is correct cross-platform)

## Why this matters

Without this fix, the regression audit gate is unreliable on Windows CI runners — it reports false regressions that don't exist, masking real ones. With strict:true now enabled (#2516 milestone), the audit gate needs to be trustworthy.
