### PR TITLE
🎨 Palette: Add aria-invalid to form components to expose error states

### DIFF
--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -174,6 +174,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         className={className}
         style={inputStyle}
         disabled={disabled}
+        aria-invalid={!!error}
         onFocus={handleFocus}
         onBlur={handleBlur}
         {...props}

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -255,6 +255,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           style={trigger}
           aria-haspopup="listbox"
           aria-expanded={isOpen}
+          aria-invalid={!!error}
           disabled={disabled}
           {...props}
         >

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -141,6 +141,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       className={className}
       style={textareaStyles}
       disabled={disabled}
+      aria-invalid={!!error}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}


### PR DESCRIPTION
💡 **What:** Added the `aria-invalid={!!error}` attribute to the native `<input>`, `<textarea>`, and trigger `<button>` (for Select) elements in our custom macOS UI form components.

🎯 **Why:** Previously, these components accepted an `error` prop to display visual validation errors, but did not programmatically link this error state to the underlying input controls. Screen reader users would navigate to an invalid field and have no context that the field had failed validation. 

📸 **Before/After:** No visual changes. This is a semantic markup change under the hood.

♿ **Accessibility:** Screen readers will now automatically announce "invalid data" (or similar localized phrasing) when focusing on an `Input`, `Textarea`, or `Select` field that has a truthy `error` prop.

---
*PR created automatically by Jules for task [17327548594577157434](https://jules.google.com/task/17327548594577157434) started by @drsapaev*