### PR TITLE
sprint-b+: ADR-0013 state boundaries + ChatSessionState for useAIChat (P1)

### DIFF
--- a/docs/adr/ADR-0013-state-management-boundaries.md
+++ b/docs/adr/ADR-0013-state-management-boundaries.md
@@ -1,0 +1,161 @@
+# Sprint B+ Architecture Decision Record
+
+## State Management Boundaries
+
+This document defines the architectural boundary between three state management
+patterns in the codebase. It serves as a project rule to prevent reverse migration
+and ensure consistent state management decisions.
+
+---
+
+## 1. AsyncState<T> — for async resources with loading lifecycle
+
+### When to use
+AsyncState applies **only to data obtained asynchronously**. Use it when at least
+**two** of the following conditions are met:
+
+- There is an HTTP/WebSocket request
+- There is a `loading` state
+- There is an `error` state
+- There is a `success` state with data
+- There is retry/refresh functionality
+- The state is used by multiple callbacks
+
+### When NOT to use
+AsyncState must NOT be used for:
+
+- `selectedId` / `selectedItem` — local UI selection state
+- `search` / `searchTerm` — search input state
+- `modalId` / `dialogOpen` — modal visibility state
+- `activeTab` — tab selection state
+- `filter` / `filterType` / `filterStatus` — filter state
+- Any state that does not involve an async lifecycle
+
+These are **not technical debt**. They are normal UI state and should remain as
+`useState<T>`.
+
+### Current adoption (40 references in hooks/)
+- `useUsers` — full migration ✅
+- `useReports` — full migration ✅
+- `useFinance` — full migration with cache-fallback ✅
+- `useDoctors`, `useRoles`, `useSecurity`, `useDoctorPhrases`, `usePaymentMethods`,
+  `usePayments`, `useAppointments`, `useSettings`, `useAdminData`, `useUserPreferences`
+  — partial (loading+error merged into AsyncState, data separate) ✅
+- `useAIChat` — NOT migrated (see §2 below)
+- `useEMR` — NOT migrated (see §3 below)
+
+---
+
+## 2. useAIChat — specialized streaming state (NOT AsyncState)
+
+### Why not AsyncState
+`useAIChat` has a WebSocket-based streaming lifecycle that goes beyond the simple
+`idle → loading → success → error` model:
+
+- `connecting` — WebSocket connecting
+- `streaming` — receiving partial messages
+- `reconnecting` — connection lost, attempting reconnect
+- `connected` — connection established, idle
+
+This is a **streaming model**, not a request/response model. Forcing it into
+`AsyncState<T>` would constantly work around its limitations.
+
+### Recommended approach
+Create a specialized type:
+
+```typescript
+type ChatSessionState = {
+  connectionStatus: 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'disconnected';
+  streamStatus: 'idle' | 'streaming' | 'completed' | 'error';
+  messages: AIAssistantMsg[];
+  error: string | null;
+};
+```
+
+This keeps `AsyncState` simple while giving the chat hook a purpose-built state
+model that accurately represents its lifecycle.
+
+### Current state
+- `useState<ChatSession[]>` — sessions list (could use AsyncState for the list)
+- `useState<ChatSession | null>` — current session (UI state, keep as useState)
+- `useState<AIAssistantMsg[]>` — messages (streaming, needs specialized state)
+- `useState(false)` — loading (part of async lifecycle)
+- `useState(false)` — streaming (NOT part of AsyncState)
+- `useState<string | null>` — error (part of async lifecycle)
+- `useState(false)` — connected (NOT part of AsyncState)
+
+### Migration plan
+1. Create `ChatSessionState` type in `src/types/async-state.ts` (or separate file)
+2. Replace `loading` + `streaming` + `error` + `connected` with `ChatSessionState`
+3. Keep `sessions` as `AsyncState<ChatSession[]>` (it's a simple fetch)
+4. Keep `currentSession` and `messages` as separate state (they have different update patterns)
+
+---
+
+## 3. useEMR — useReducer + AsyncState for operations (NOT full migration)
+
+### Why not migrate
+`useEMR` already uses `useReducer` — this is correct because EMR has a complex
+state machine:
+
+- `draft` — unsaved changes
+- `dirty` — modified since last save
+- `saving` — save in progress
+- `saved` — save completed
+- `conflict` — concurrent edit detected
+- `readonly` — signed/amended, no edits allowed
+- `autosaving` — background autosave
+
+This is a **workflow state machine**, not a simple async resource. `useReducer`
+is the right tool.
+
+### Recommended approach
+Keep `useReducer` for the document state machine. Use `AsyncState` **only inside
+specific operations**:
+
+```typescript
+// Inside useEMR:
+const [state, dispatch] = useReducer(emrReducer, initialState);
+
+// AsyncState for individual operations:
+const [saveState, setSaveState] = useState<AsyncState<void>>(idleState());
+const [loadState, setLoadState] = useState<AsyncState<EMRData>>(idleState());
+```
+
+This separates concerns:
+- `useReducer` manages the document workflow (draft → dirty → saving → saved → conflict)
+- `AsyncState` manages individual async operations (load, save, sign, amend)
+
+### Current state
+- `useReducer(emrReducer, initialState)` — document state machine ✅ (keep)
+- `useState(false)` — writeAccessDenied (UI gate, keep as useState)
+- No `useState<string | null>` — error is part of the reducer state
+
+### Migration plan
+1. Do NOT replace `useReducer` with `AsyncState`
+2. Optionally add `AsyncState<void>` for save/sign/amend operations (if there's value in tracking their individual loading/error states separately from the reducer)
+3. This is low priority — the current `useReducer` approach is architecturally correct
+
+---
+
+## 4. Summary
+
+| Pattern | Use case | Examples |
+|---------|----------|----------|
+| `AsyncState<T>` | Async resources with loading lifecycle | useUsers, useReports, useFinance |
+| `useReducer` | Complex workflows / state machines | useEMR (draft → dirty → saving → conflict) |
+| `useState<T>` | Local UI state | selectedId, search, modalOpen, activeTab, filter |
+| Specialized state | Streaming / real-time | useAIChat (ChatSessionState) |
+
+### Migration rules
+1. **Do** migrate to `AsyncState` when: HTTP request + loading + error + success + retry
+2. **Do not** migrate to `AsyncState` when: no async lifecycle (UI state)
+3. **Do not** migrate `useReducer` to `AsyncState` (different pattern)
+4. **Do** create specialized types for streaming/real-time state
+5. **Do not** create abstractions "for the future" — only when there's actual repetition
+
+### Next steps
+- P1: Create `ChatSessionState` for useAIChat
+- P2: Leave useEMR as-is (useReducer is correct)
+- P3: Do not touch simple `useState<string | null>` (UI state)
+- P4: After 40+ AsyncState usages, evaluate if `useAsyncResource` / `createAsyncState` helpers would reduce boilerplate

--- a/frontend/src/types/chat-session-state.ts
+++ b/frontend/src/types/chat-session-state.ts
@@ -1,0 +1,96 @@
+/**
+ * ChatSessionState — specialized state model for real-time chat with WebSocket streaming.
+ *
+ * Unlike AsyncState<T> (which models request/response: idle → loading → success → error),
+ * ChatSessionState models a streaming lifecycle:
+ *
+ *   idle → connecting → connected → streaming → completed
+ *                                   ↘ reconnecting ↗
+ *                                   ↘ disconnected
+ *
+ * This separation keeps AsyncState simple for request/response patterns while
+ * giving the chat hook a purpose-built state that accurately represents its
+ * WebSocket-based lifecycle.
+ *
+ * See ADR-0013 for the full rationale.
+ */
+
+export type ConnectionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'disconnected';
+
+export type StreamStatus =
+  | 'idle'
+  | 'streaming'
+  | 'completed'
+  | 'error';
+
+export interface ChatSessionState<TMessage = unknown> {
+  /** WebSocket connection state */
+  connectionStatus: ConnectionStatus;
+  /** Current streaming operation state */
+  streamStatus: StreamStatus;
+  /** Chat messages (accumulated during session) */
+  messages: TMessage[];
+  /** Error message (from connection or streaming) */
+  error: string | null;
+}
+
+// === Helper constructors ===
+
+export function idleChatState<T>(): ChatSessionState<T> {
+  return { connectionStatus: 'idle', streamStatus: 'idle', messages: [], error: null };
+}
+
+export function connectingChatState<T>(messages: T[] = []): ChatSessionState<T> {
+  return { connectionStatus: 'connecting', streamStatus: 'idle', messages, error: null };
+}
+
+export function connectedChatState<T>(messages: T[] = []): ChatSessionState<T> {
+  return { connectionStatus: 'connected', streamStatus: 'idle', messages, error: null };
+}
+
+export function streamingChatState<T>(messages: T[]): ChatSessionState<T> {
+  return { connectionStatus: 'connected', streamStatus: 'streaming', messages, error: null };
+}
+
+export function completedChatState<T>(messages: T[]): ChatSessionState<T> {
+  return { connectionStatus: 'connected', streamStatus: 'completed', messages, error: null };
+}
+
+export function reconnectingChatState<T>(messages: T[]): ChatSessionState<T> {
+  return { connectionStatus: 'reconnecting', streamStatus: 'idle', messages, error: null };
+}
+
+export function disconnectedChatState<T>(messages: T[] = []): ChatSessionState<T> {
+  return { connectionStatus: 'disconnected', streamStatus: 'idle', messages, error: null };
+}
+
+export function errorChatState<T>(error: string, messages: T[] = []): ChatSessionState<T> {
+  return { connectionStatus: 'disconnected', streamStatus: 'error', messages, error };
+}
+
+// === Convenience accessors ===
+
+export function isChatLoading<T>(state: ChatSessionState<T>): boolean {
+  return state.connectionStatus === 'connecting' || state.connectionStatus === 'reconnecting';
+}
+
+export function isChatStreaming<T>(state: ChatSessionState<T>): boolean {
+  return state.streamStatus === 'streaming';
+}
+
+export function isChatConnected<T>(state: ChatSessionState<T>): boolean {
+  return state.connectionStatus === 'connected';
+}
+
+export function getChatError<T>(state: ChatSessionState<T>): string | null {
+  return state.error;
+}
+
+export function getChatMessages<T>(state: ChatSessionState<T>): T[] {
+  return state.messages;
+}


### PR DESCRIPTION
## Summary

- ADR-0013: State management boundaries (AsyncState vs useReducer vs useState vs specialized state)
- ChatSessionState: purpose-built streaming state for useAIChat (P1)
- Documents architectural decisions to prevent reverse migration

## Cyclic Execution Evidence

- Fresh main sync: branch `sprint-b-plus/architecture-decisions` created from current origin/main.
- Clean workspace: 2 files added (ADR + ChatSessionState type).
- Branch: `sprint-b-plus/architecture-decisions` (head latest, base `main`).
- Scope gate: allowed `docs/adr/` and `frontend/src/types/`.
- Red-check handling: tsc 0, strict-gate 0, lint 0, type-debt PASS (20/20), regression 31/31.

## Contract Impact

not applicable - documentation/process only, no API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route guard, endpoint authorization, role helper, or auth-sensitive behavior changed because this PR only adds documentation and type definitions.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed because this PR only adds documentation and type definitions.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed because this PR only adds documentation and type definitions.

## Scope Gate

- Allowed paths: `docs/adr/ADR-0013-state-management-boundaries.md`, `frontend/src/types/chat-session-state.ts`.
- Denied paths: everything else.
- Migration/docs/test impact: 1 ADR document, 1 type file. No test files modified.
- Rollback note: revert all commits on the branch.

## Validation

- Targeted tests or smoke run: `npx tsc --noEmit -p tsconfig.json` (0 errors), `npm run lint:check` (0 errors), `npm run type-debt:check` (PASS — baseline 20), `node scripts/regression-audit-check.mjs` (31/31 PASS).
- Result: all four checks pass.
- Not checked: full Vitest suite.

## Per-file details

### `docs/adr/ADR-0013-state-management-boundaries.md`
Architectural decision record defining:
- AsyncState<T>: async resources with loading lifecycle (HTTP + loading + error + success + retry)
- useReducer: complex workflows / state machines (EMR: draft → dirty → saving → conflict)
- useState<T>: local UI state (selectedId, search, modalOpen, activeTab, filter)
- Specialized state: streaming / real-time (useAIChat: ChatSessionState)

Rules:
1. Migrate to AsyncState when: HTTP request + loading + error + success + retry
2. Do NOT migrate to AsyncState when: no async lifecycle (UI state)
3. Do NOT migrate useReducer to AsyncState (different pattern)
4. DO create specialized types for streaming/real-time state
5. Do NOT create abstractions "for the future"

### `frontend/src/types/chat-session-state.ts`
Purpose-built state for WebSocket-based chat:
- ConnectionStatus: idle | connecting | connected | reconnecting | disconnected
- StreamStatus: idle | streaming | completed | error
- Messages: TMessage[]
- Error: string | null

8 helper constructors + 5 convenience accessors.

## Related

- #2516 — parent issue (BS-66 strict:true enablement) — COMPLETED
- Sprint B+ of the "value-driven architecture" plan
