### PR TITLE
feat: redesign ChatSessionState per 6 architectural invariants

### DIFF
--- a/docs/adr/ADR-0013-state-management-boundaries.md
+++ b/docs/adr/ADR-0013-state-management-boundaries.md
@@ -1,18 +1,28 @@
-# Sprint B+ Architecture Decision Record
+# ADR-0013 — State Management Boundaries
 
-## State Management Boundaries
+**Status:** Accepted (revised)
+**Last updated:** 2026-07-31
 
-This document defines the architectural boundary between three state management
-patterns in the codebase. It serves as a project rule to prevent reverse migration
-and ensure consistent state management decisions.
+## Summary
+
+This ADR defines the architectural boundary between four state management
+patterns in the frontend codebase. It serves as a project rule to prevent
+reverse migration and ensure consistent state management decisions.
+
+| Pattern | Use case | Examples |
+|---------|----------|----------|
+| `AsyncState<T>` | Async resources with loading lifecycle | useUsers, useReports, useFinance |
+| `useReducer` | Complex workflows / state machines | useEMR (draft → dirty → saving → conflict) |
+| `useState<T>` | Local UI state | selectedId, search, modalOpen, activeTab, filter |
+| Specialized state | Streaming / real-time transport | useAIChat (`ChatSessionState`) |
 
 ---
 
 ## 1. AsyncState<T> — for async resources with loading lifecycle
 
 ### When to use
-AsyncState applies **only to data obtained asynchronously**. Use it when at least
-**two** of the following conditions are met:
+AsyncState applies **only to data obtained asynchronously**. Use it when at
+least **two** of the following conditions are met:
 
 - There is an HTTP/WebSocket request
 - There is a `loading` state
@@ -31,8 +41,8 @@ AsyncState must NOT be used for:
 - `filter` / `filterType` / `filterStatus` — filter state
 - Any state that does not involve an async lifecycle
 
-These are **not technical debt**. They are normal UI state and should remain as
-`useState<T>`.
+These are **not technical debt**. They are normal UI state and should remain
+as `useState<T>`.
 
 ### Current adoption (40 references in hooks/)
 - `useUsers` — full migration ✅
@@ -60,35 +70,134 @@ These are **not technical debt**. They are normal UI state and should remain as
 This is a **streaming model**, not a request/response model. Forcing it into
 `AsyncState<T>` would constantly work around its limitations.
 
-### Recommended approach
-Create a specialized type:
+### ChatSessionState — architectural invariants
+
+The `ChatSessionState` type models the **transport layer** of the chat. It
+follows six invariants. Violating any of them is a bug.
+
+#### Invariant 1: Transport ≠ content
+`ChatSessionState` MUST NOT carry chat messages. Messages live in a separate
+`ChatData<TMessage>` (or just `useState<TMessage[]>` in the hook).
 
 ```typescript
-type ChatSessionState = {
-  connectionStatus: 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'disconnected';
-  streamStatus: 'idle' | 'streaming' | 'completed' | 'error';
-  messages: AIAssistantMsg[];
-  error: string | null;
-};
+interface ChatSessionState {
+  connectionStatus: ConnectionStatus;
+  streamStatus: StreamStatus;
+  error: ChatError | null;
+  reconnectAttempt: number;
+}
+interface ChatData<TMessage = unknown> {
+  messages: TMessage[];
+  activeSessionId: string | number | null;
+}
 ```
 
-This keeps `AsyncState` simple while giving the chat hook a purpose-built state
-model that accurately represents its lifecycle.
+**Why:** reconnecting the WebSocket must not invalidate the message history.
+Clearing the message history must not tear down the connection. Receiving a
+streaming token must not rewrite the entire state object.
 
-### Current state
-- `useState<ChatSession[]>` — sessions list (could use AsyncState for the list)
-- `useState<ChatSession | null>` — current session (UI state, keep as useState)
-- `useState<AIAssistantMsg[]>` — messages (streaming, needs specialized state)
-- `useState(false)` — loading (part of async lifecycle)
-- `useState(false)` — streaming (NOT part of AsyncState)
-- `useState<string | null>` — error (part of async lifecycle)
-- `useState(false)` — connected (NOT part of AsyncState)
+#### Invariant 2: Two independent dimensions
+`connectionStatus` and `streamStatus` evolve independently. We deliberately
+avoid a single enum with twenty variants like
+`authenticated_streaming_receiving_typing_retrying`. Such a flat enum would:
+- explode combinatorially,
+- force every transition to specify the full cross-product,
+- make "I only changed connection" indistinguishable from "I changed everything".
 
-### Migration plan
-1. Create `ChatSessionState` type in `src/types/async-state.ts` (or separate file)
-2. Replace `loading` + `streaming` + `error` + `connected` with `ChatSessionState`
-3. Keep `sessions` as `AsyncState<ChatSession[]>` (it's a simple fetch)
-4. Keep `currentSession` and `messages` as separate state (they have different update patterns)
+#### Invariant 3: Explicit transition tables
+The allowed edges are encoded in `isValidConnectionTransition` /
+`isValidStreamTransition` and enforced at runtime by `applyConnectionTransition`
+/ `applyStreamTransition` (dev-only `console.warn` on forbidden edges).
+
+**Connection status transitions:**
+
+| From \ To      | idle | connecting | connected | reconnecting | disconnected |
+|----------------|------|------------|-----------|--------------|--------------|
+| idle           |  ✓   |     ✓      |           |              |      ✓       |
+| connecting     |      |     ✓      |     ✓     |       ✓      |      ✓       |
+| connected      |      |     ✓      |     ✓     |       ✓      |      ✓       |
+| reconnecting   |      |     ✓      |     ✓     |       ✓      |      ✓       |
+| disconnected   |      |     ✓      |           |              |      ✓       |
+
+Forbidden (will be logged in dev):
+- `idle → connected` (must go through `connecting`)
+- `idle → reconnecting` (nothing to reconnect to)
+- `disconnected → connected` (must explicitly re-connect via `connecting`)
+- `disconnected → reconnecting` (`disconnected` is terminal)
+
+**Stream status transitions:**
+
+| From \ To    | idle | streaming | completed |
+|--------------|------|-----------|-----------|
+| idle         |  ✓   |     ✓     |           |
+| streaming    |  ✓   |     ✓     |     ✓     |
+| completed    |  ✓   |     ✓     |     ✓     |
+
+Forbidden:
+- `idle → completed` (must stream first)
+
+#### Invariant 4: Error is a structured object, not a status value
+`streamStatus` does NOT have an `'error'` value. Errors live in a separate
+`error: ChatError | null` field with shape `{ code, message, retryable }`.
+
+```typescript
+type ChatErrorCode =
+  | 'network_error'      // WebSocket close, transport failure
+  | 'auth_error'         // JWT invalid / expired / rejected
+  | 'model_error'        // backend model failed to produce a response
+  | 'rate_limit'         // 429 / quota exceeded
+  | 'cancelled'          // user-initiated cancel
+  | 'contract_mismatch'  // protocol version mismatch with backend
+  | 'unknown';
+
+interface ChatError {
+  code: ChatErrorCode;
+  message: string;
+  retryable: boolean;
+}
+```
+
+**Why:** the UI needs to differentiate between "network blip — retry in 2s",
+"model overload — switch model", "rate limit — show upgrade prompt", and
+"user cancelled — do nothing". A bare `streamStatus: 'error'` cannot express
+this; the UI would have to re-derive the cause from string matching on the
+error message.
+
+#### Invariant 5: No reducer coupling
+`ChatSessionState` is a value object. The hook may use `useState<ChatSessionState>`
+or `useReducer`; either way:
+- WebSocket callbacks (`onopen`, `onclose`, `onmessage`) remain separate functions,
+- REST API calls (`loadSessions`, `sendMessage`) remain separate functions,
+- the state type does not prescribe how transitions are dispatched.
+
+The reducer (if any) MUST NOT know how to open a socket, parse a token, or
+construct an HTTP request. Its only job is to apply the next state.
+
+#### Invariant 6: No premature unification with AsyncState
+`AsyncState` and `ChatSessionState` intentionally share no inheritance or
+generic parameter. They model different lifecycles. Attempts to unify them
+(e.g. `AsyncState<T>` with extra `streaming` status, or `ChatSessionState`
+extending `AsyncState<TMessage[]>`) are explicitly forbidden — they collapse
+the conceptual boundary and force callers to handle states that cannot occur.
+
+### Migration plan for useAIChat
+1. ✅ Create `ChatSessionState` type with the six invariants above
+2. Replace four `useState` calls (`loading`, `streaming`, `error`, `connected`)
+   with a single `useState<ChatSessionState>` initialized to `idleChatSessionState()`
+3. Keep `messages` as a separate `useState<AIAssistantMsg[]>` (Invariant 1)
+4. Keep `currentSession` as a separate `useState<ChatSession | null>` (UI state)
+5. Keep `sessions` as a separate `useState<ChatSession[]>` (it could later become
+   `AsyncState<ChatSession[]>`, but that is out of scope for this PR)
+6. WebSocket callbacks call `applyConnectionTransition` / `applyStreamTransition`
+   / `setChatError` — they never mutate `state` directly
+7. REST API methods (`loadSessions`, `sendMessage`, etc.) are unchanged in shape;
+   they update `messages` and `currentSession` directly, not the session state
+
+### Backward compatibility
+The hook's public return shape is preserved. The legacy boolean fields
+(`loading`, `streaming`, `connected`, `error: string | null`) are derived from
+`ChatSessionState` via accessors (`isChatConnecting`, `isChatStreaming`,
+`isChatConnected`, `getChatErrorMessage`). Consumers do not need to change.
 
 ---
 
@@ -133,29 +242,52 @@ This separates concerns:
 
 ### Migration plan
 1. Do NOT replace `useReducer` with `AsyncState`
-2. Optionally add `AsyncState<void>` for save/sign/amend operations (if there's value in tracking their individual loading/error states separately from the reducer)
-3. This is low priority — the current `useReducer` approach is architecturally correct
+2. Optionally add `AsyncState<void>` for save/sign/amend operations (if there's
+   value in tracking their individual loading/error states separately from the
+   reducer)
+3. This is low priority — the current `useReducer` approach is architecturally
+   correct
 
 ---
 
-## 4. Summary
+## 4. Summary table
 
-| Pattern | Use case | Examples |
-|---------|----------|----------|
-| `AsyncState<T>` | Async resources with loading lifecycle | useUsers, useReports, useFinance |
-| `useReducer` | Complex workflows / state machines | useEMR (draft → dirty → saving → conflict) |
-| `useState<T>` | Local UI state | selectedId, search, modalOpen, activeTab, filter |
-| Specialized state | Streaming / real-time | useAIChat (ChatSessionState) |
+| Pattern | Use case | Examples | What it is NOT |
+|---------|----------|----------|----------------|
+| `AsyncState<T>` | Async resources with loading lifecycle | useUsers, useReports, useFinance | Not for UI state, not for streaming |
+| `useReducer` | Complex workflows / state machines | useEMR (draft → dirty → saving → conflict) | Not for simple async fetches, not for transport |
+| `useState<T>` | Local UI state | selectedId, search, modalOpen, activeTab, filter | Not technical debt — do NOT migrate to AsyncState |
+| `ChatSessionState` | Streaming / real-time transport | useAIChat | Not a generic AsyncState variant, NOT for messages |
 
 ### Migration rules
 1. **Do** migrate to `AsyncState` when: HTTP request + loading + error + success + retry
 2. **Do not** migrate to `AsyncState` when: no async lifecycle (UI state)
 3. **Do not** migrate `useReducer` to `AsyncState` (different pattern)
-4. **Do** create specialized types for streaming/real-time state
-5. **Do not** create abstractions "for the future" — only when there's actual repetition
+4. **Do** create specialized types for streaming/real-time state — but only when
+   the lifecycle genuinely diverges from `AsyncState`
+5. **Do not** create abstractions "for the future" — only when there's actual
+   repetition
+6. **Do not** mix transport / workflow / UI state inside a single state object.
+   Each layer gets its own state slot.
 
-### Next steps
-- P1: Create `ChatSessionState` for useAIChat
-- P2: Leave useEMR as-is (useReducer is correct)
-- P3: Do not touch simple `useState<string | null>` (UI state)
-- P4: After 40+ AsyncState usages, evaluate if `useAsyncResource` / `createAsyncState` helpers would reduce boilerplate
+---
+
+## 5. Next sprint — architectural review
+
+After `ChatSessionState` is integrated into `useAIChat`, the next sprint is
+**NOT** further state migration. Instead, it is an architectural review that
+answers three questions:
+
+1. **Is there duplication** between `AsyncState`, `ChatSessionState`, and
+   `useEMR`'s workflow state? (Suspected answer: no — they model genuinely
+   different lifecycles.)
+2. **Can the common principles be described** without unifying the types?
+   (Suspected answer: yes — see §4 above.)
+3. **Have any hooks started mixing transport / workflow / UI state** inside a
+   single state object? (Suspected answer: needs audit.)
+
+The deliverable is **not** a new state type. It is a short architectural
+invariants document that consolidates the rules in this ADR with concrete
+examples from the codebase. This locks in the boundary and reduces the
+likelihood that, six months from now, new hooks start using different patterns
+for the same problem.

--- a/frontend/src/hooks/useAIChat.ts
+++ b/frontend/src/hooks/useAIChat.ts
@@ -1,10 +1,26 @@
 /**
  * useAIChat - React hook для AI чата
- * 
+ *
  * Функции:
  * - REST API для сессий и сообщений
  * - WebSocket для streaming
  * - Управление состоянием
+ *
+ * Architecture (ADR-0013 §2):
+ * - `sessionState: ChatSessionState` models the WebSocket TRANSPORT layer:
+ *   connectionStatus + streamStatus + structured error. It NEVER carries
+ *   messages (Invariant 1: transport ≠ content).
+ * - `messages`, `currentSession`, `sessions` are separate useState slots —
+ *   they have different update patterns and must not be bundled into the
+ *   transport state.
+ * - `restLoading` / `restError` track REST API operations. They are separate
+ *   from `sessionState` because REST is request/response, not streaming.
+ * - WebSocket callbacks (`onopen`, `onclose`, `onmessage`) call
+ *   `applyConnectionTransition` / `applyStreamTransition` / `setChatError`.
+ *   They never mutate `sessionState` directly (Invariant 3: explicit
+ *   transitions; Invariant 5: no reducer coupling).
+ * - The public return shape is preserved: `loading`, `streaming`, `error`,
+ *   `connected` are derived accessors for backward compatibility.
  */
 
 import { useState, useCallback, useEffect, useRef } from 'react';
@@ -18,7 +34,23 @@ import {
     MESSAGING_CONTRACT_VERSION,
     isSupportedMessagingContractVersion,
 } from '../constants/messagingContract';
-import type { AsyncState } from '../types/async-state';
+import type {
+    ChatSessionState,
+    ChatError,
+    ChatErrorCode,
+} from '../types/chat-session-state';
+import {
+    idleChatSessionState,
+    applyConnectionTransition,
+    applyStreamTransition,
+    setChatError,
+    incrementReconnectAttempt,
+    isChatConnecting,
+    isChatConnected,
+    isChatStreaming,
+    getChatErrorMessage,
+    chatError,
+} from '../types/chat-session-state';
 
 /** AI chat session shape. */
 interface ChatSession {
@@ -46,9 +78,12 @@ interface AIAssistantMsg {
 /** WebSocket message handler shape. */
 type WsMessageHandler = ((data: unknown) => void) | null;
 
+/** Maximum WebSocket reconnect attempts before giving up. */
+const MAX_RECONNECT_ATTEMPTS = 5;
+
 /**
  * Хук для AI чата
- * 
+ *
  * @param {Object} options
  * @param {boolean} options.useWebSocket - Использовать WebSocket для streaming
  * @param {string} options.contextType - Тип контекста (emr, lab, general)
@@ -61,23 +96,30 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
         specialty = null as unknown
     } = options;
 
+    // ======================================================================
     // State
+    //
+    // Three independent slots per ADR-0013 §2:
+    //   1. sessionState  — WebSocket transport (connection + stream + WS error)
+    //   2. messages      — chat content (separate from transport, Invariant 1)
+    //   3. restLoading / restError — REST API request/response state
+    //
+    // Plus session/bookkeeping UI state that has no async lifecycle.
+    // ======================================================================
+
+    const [sessionState, setSessionState] = useState<ChatSessionState>(idleChatSessionState);
     const [sessions, setSessions] = useState<ChatSession[]>([]);
     const [currentSession, setCurrentSession] = useState<ChatSession | null>(null);
     const [messages, setMessages] = useState<AIAssistantMsg[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [streaming, setStreaming] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [connected, setConnected] = useState(false);
+    const [restLoading, setRestLoading] = useState(false);
+    const [restError, setRestError] = useState<string | null>(null);
 
-    // Refs
+    // Refs (mirror of state used inside async / WS callbacks)
     const wsRef = useRef<WebSocket | null>(null);
     const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const handleWebSocketMessageRef = useRef<WsMessageHandler>(null);
     // audit/phase-final, BS-15: shouldReconnect ref + reconnect attempt counter.
     const shouldReconnectRef = useRef(true);
-    const reconnectAttemptRef = useRef(0);
-    const MAX_RECONNECT_ATTEMPTS = 5;
     const currentSessionRef = useRef<ChatSession | null>(null);
     const loadSessionRequestRef = useRef(0);
     const contractVersionMismatchRef = useRef(false);
@@ -86,25 +128,30 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
         currentSessionRef.current = currentSession;
     }, [currentSession]);
 
-    // ==========================================================================
+    // ======================================================================
     // REST API Methods
-    // ==========================================================================
+    //
+    // REST calls update `messages`, `currentSession`, `restLoading`,
+    // `restError`. They DO NOT touch `sessionState` — REST is request/response,
+    // not streaming. (The only exception: a REST load may cancel an in-flight
+    // stream by transitioning streamStatus → idle.)
+    // ======================================================================
 
     /**
      * Загрузить список сессий
      */
     const loadSessions = useCallback(async (limit = 20) => {
         try {
-            setLoading(true);
+            setRestLoading(true);
             const response = await api.get('/ai/chat/sessions', { params: { limit } });
             setSessions(response.data);
             return response.data;
         } catch (err) {
             logger.error('Failed to load chat sessions:', err);
-            setError(getErrorMessage(err) || 'Failed to load sessions');
+            setRestError(getErrorMessage(err) || 'Failed to load sessions');
             return [];
         } finally {
-            setLoading(false);
+            setRestLoading(false);
         }
     }, []);
 
@@ -113,7 +160,7 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
      */
     const createSession = useCallback(async (customContextType: unknown = null, customSpecialty: unknown = null) => {
         try {
-            setLoading(true);
+            setRestLoading(true);
             const response = await api.post('/ai/chat/sessions', {
                 context_type: customContextType || contextType,
                 specialty: customSpecialty || specialty
@@ -124,16 +171,18 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
             setCurrentSession(session);
             currentSessionRef.current = session;
             setMessages([]);
-            setStreaming(false);
-            setError(null);
+            // Cancel any in-flight stream from a previous session.
+            // (completed → idle is allowed; streaming → idle is allowed; idle → idle is idempotent.)
+            setSessionState(prev => applyStreamTransition(prev, 'idle', { clearError: true }));
+            setRestError(null);
 
             return session;
         } catch (err) {
             logger.error('Failed to create chat session:', err);
-            setError(getErrorMessage(err) || 'Failed to create session');
+            setRestError(getErrorMessage(err) || 'Failed to create session');
             return null;
         } finally {
-            setLoading(false);
+            setRestLoading(false);
         }
     }, [contextType, specialty]);
 
@@ -143,9 +192,10 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
     const loadSession = useCallback(async (sessionId: string | number) => {
         const requestId = ++loadSessionRequestRef.current;
         try {
-            setLoading(true);
-            setError(null);
-            setStreaming(false);
+            setRestLoading(true);
+            setRestError(null);
+            // Cancel any in-flight stream when loading a different session.
+            setSessionState(prev => applyStreamTransition(prev, 'idle'));
 
             // Загружаем сессию
             const sessionResponse = await api.get(`/ai/chat/sessions/${sessionId}`);
@@ -162,16 +212,16 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
             setCurrentSession(sessionResponse.data);
             currentSessionRef.current = sessionResponse.data;
             setMessages(messagesResponse.data);
-            setStreaming(false);
-            setError(null);
+            setSessionState(prev => applyStreamTransition(prev, 'idle'));
+            setRestError(null);
 
             return sessionResponse.data;
         } catch (err) {
             logger.error('Failed to load chat session:', err);
-            setError(getErrorMessage(err) || 'Failed to load session');
+            setRestError(getErrorMessage(err) || 'Failed to load session');
             return null;
         } finally {
-            setLoading(false);
+            setRestLoading(false);
         }
     }, []);
 
@@ -180,13 +230,13 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
      */
     const sendMessage = useCallback(async (content: string, includeHistory: boolean = true) => {
         if (!content?.trim()) {
-            setError('Message cannot be empty');
+            setRestError('Message cannot be empty');
             return null;
         }
 
         // Prompt injection check
         if (detectPromptInjection(content)) {
-            setError('Обнаружена попытка prompt injection. Сообщение отклонено.');
+            setRestError('Обнаружена попытка prompt injection. Сообщение отклонено.');
             logger.warn('AI chat: prompt injection detected and blocked');
             return null;
         }
@@ -200,8 +250,8 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
         }
 
         try {
-            setLoading(true);
-            setError(null);
+            setRestLoading(true);
+            setRestError(null);
 
             // Оптимистично добавляем user message
             const userMessage = {
@@ -232,13 +282,13 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
             return response.data;
         } catch (err) {
             logger.error('Failed to send message:', err);
-            setError(getErrorMessage(err) || 'Failed to send message');
+            setRestError(getErrorMessage(err) || 'Failed to send message');
 
             // Откатываем оптимистичное обновление
             setMessages(prev => prev.filter(m => !m._pending));
             return null;
         } finally {
-            setLoading(false);
+            setRestLoading(false);
         }
     }, [createSession]);
 
@@ -255,14 +305,14 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
                 setCurrentSession(null);
                 currentSessionRef.current = null;
                 setMessages([]);
-                setStreaming(false);
-                setError(null);
+                setSessionState(prev => applyStreamTransition(prev, 'idle', { clearError: true }));
+                setRestError(null);
             }
 
             return true;
         } catch (err) {
             logger.error('Failed to delete session:', err);
-            setError(getErrorMessage(err) || 'Failed to delete session');
+            setRestError(getErrorMessage(err) || 'Failed to delete session');
             return false;
         }
     }, []);
@@ -283,9 +333,12 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
         }
     }, []);
 
-    // ==========================================================================
+    // ======================================================================
     // WebSocket Methods
-    // ==========================================================================
+    //
+    // WS callbacks update `sessionState` via the transition helpers. They
+    // never assign to `sessionState` directly. (Invariant 3 + Invariant 5.)
+    // ======================================================================
 
     /**
      * Подключиться к WebSocket
@@ -295,13 +348,20 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
 
         const token = tokenManager.getAccessToken();
         if (!token) {
-            setError('Not authenticated');
+            setSessionState(prev =>
+                setChatError(prev, chatError('auth_error', 'Not authenticated', false))
+            );
             return;
         }
 
         // audit/phase-final, BS-15: reset reconnect state on explicit connect.
         shouldReconnectRef.current = true;
-        reconnectAttemptRef.current = 0;
+
+        // Transition idle/disconnected/reconnecting → connecting.
+        // (connected → connecting is also allowed: explicit reconnect.)
+        setSessionState(prev =>
+            applyConnectionTransition(prev, 'connecting', { resetReconnectAttempt: true })
+        );
 
         // P0 security fix: JWT sent via Sec-WebSocket-Protocol subprotocol (bearer.<token>)
         // instead of URL query (?token=...). The URL query form leaked the JWT into nginx
@@ -314,36 +374,76 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
 
             wsRef.current.onopen = () => {
                 logger.info('AI Chat WebSocket connected');
-                setConnected(true);
-                setError(null);
+                // connecting → connected (clears any prior error, resets reconnect attempt).
+                setSessionState(prev =>
+                    applyConnectionTransition(prev, 'connected', {
+                        clearError: true,
+                        resetReconnectAttempt: true,
+                    })
+                );
             };
 
             wsRef.current.onclose = (event) => {
                 logger.info('AI Chat WebSocket closed:', event.code, event.reason);
-                setConnected(false);
 
-                // audit/phase-final, BS-15: exponential backoff + max retries.
-                if (event.code !== 1000 && event.code !== 4001 && shouldReconnectRef.current) {
-                    reconnectAttemptRef.current += 1;
-                    if (reconnectAttemptRef.current <= MAX_RECONNECT_ATTEMPTS) {
-                        const baseDelay = Math.min(1000 * Math.pow(2, reconnectAttemptRef.current - 1), 16000);
-                        const jitter = Math.random() * 500;
-                        const delay = baseDelay + jitter;
-                        logger.info(`Attempting to reconnect WebSocket (${reconnectAttemptRef.current}/${MAX_RECONNECT_ATTEMPTS}) in ${Math.round(delay)}ms...`);
-                        reconnectTimeoutRef.current = setTimeout(() => {
-                            if (shouldReconnectRef.current) {
-                                connectWebSocket();
-                            }
-                        }, delay);
-                    } else {
-                        logger.warn(`WebSocket reconnect giving up after ${MAX_RECONNECT_ATTEMPTS} attempts`);
-                    }
+                // Decide next connection state based on close code + shouldReconnect flag.
+                // Code 1000 (normal) and 4001 (policy) are treated as terminal → disconnected.
+                // Anything else with shouldReconnect=true → reconnecting (will retry).
+                const isNormalClose = event.code === 1000 || event.code === 4001;
+                if (isNormalClose || !shouldReconnectRef.current) {
+                    setSessionState(prev =>
+                        applyConnectionTransition(prev, 'disconnected')
+                    );
+                    return;
                 }
+
+                // Schedule reconnect with exponential backoff + jitter.
+                setSessionState(prev => {
+                    const next = incrementReconnectAttempt(prev);
+                    if (next.reconnectAttempt > MAX_RECONNECT_ATTEMPTS) {
+                        logger.warn(
+                            `WebSocket reconnect giving up after ${MAX_RECONNECT_ATTEMPTS} attempts`
+                        );
+                        return applyConnectionTransition(
+                            setChatError(
+                                prev,
+                                chatError(
+                                    'network_error',
+                                    `Connection lost after ${MAX_RECONNECT_ATTEMPTS} reconnect attempts`,
+                                    false
+                                )
+                            ),
+                            'disconnected'
+                        );
+                    }
+                    const baseDelay = Math.min(
+                        1000 * Math.pow(2, next.reconnectAttempt - 1),
+                        16000
+                    );
+                    const jitter = Math.random() * 500;
+                    const delay = baseDelay + jitter;
+                    logger.info(
+                        `Attempting to reconnect WebSocket (${next.reconnectAttempt}/${MAX_RECONNECT_ATTEMPTS}) in ${Math.round(delay)}ms...`
+                    );
+                    reconnectTimeoutRef.current = setTimeout(() => {
+                        if (shouldReconnectRef.current) {
+                            connectWebSocket();
+                        }
+                    }, delay);
+                    return applyConnectionTransition(next, 'reconnecting');
+                });
             };
 
             wsRef.current.onerror = (error) => {
                 logger.error('AI Chat WebSocket error:', error);
-                setError('WebSocket connection failed');
+                // Note: onerror is usually followed by onclose, which handles
+                // reconnect logic. We only surface the structured error here.
+                setSessionState(prev =>
+                    setChatError(
+                        prev,
+                        chatError('network_error', 'WebSocket connection failed', true)
+                    )
+                );
             };
 
             wsRef.current.onmessage = (event) => {
@@ -368,12 +468,21 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
             };
         } catch (err) {
             logger.error('Failed to create WebSocket:', err);
-            setError('Failed to connect to chat');
+            setSessionState(prev =>
+                setChatError(
+                    prev,
+                    chatError('network_error', 'Failed to connect to chat', true)
+                )
+            );
         }
     }, [useWebSocket]);
 
     /**
-     * Обработка WebSocket сообщений
+     * Обработка WebSocket сообщений.
+     *
+     * This callback updates `sessionState.streamStatus` and `messages`.
+     * It does NOT touch `connectionStatus` — that is owned by the WS
+     * connection handlers above. (Invariant 4: two independent dimensions.)
      */
     const handleWebSocketMessage = useCallback((data: Record<string, unknown>) => {
         if (
@@ -385,6 +494,18 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
             return;
         }
 
+        // Map backend error `type` field to a structured ChatErrorCode.
+        // The backend currently sends only a free-form `message`; we infer
+        // the code from common substrings. This is intentionally conservative.
+        const inferErrorCode = (raw: unknown): { code: ChatErrorCode; retryable: boolean } => {
+            const msg = String(raw ?? '').toLowerCase();
+            if (msg.includes('rate') && msg.includes('limit')) return { code: 'rate_limit', retryable: true };
+            if (msg.includes('auth') || msg.includes('token')) return { code: 'auth_error', retryable: false };
+            if (msg.includes('cancel')) return { code: 'cancelled', retryable: false };
+            if (msg.includes('quota')) return { code: 'rate_limit', retryable: true };
+            return { code: 'model_error', retryable: true };
+        };
+
         switch (data.type) {
             case 'session':
                 // Новая сессия создана
@@ -393,8 +514,10 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
                 break;
 
             case 'chunk':
-                // Streaming chunk
-                setStreaming(true);
+                // Streaming chunk — transition streamStatus → streaming (idempotent).
+                setSessionState(prev =>
+                    applyStreamTransition(prev, 'streaming', { clearError: true })
+                );
                 setMessages(prev => {
                     const last = prev[prev.length - 1];
                     if (last?.role === 'assistant' && last._streaming) {
@@ -419,8 +542,8 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
                 break;
 
             case 'done':
-                // Streaming завершен
-                setStreaming(false);
+                // Streaming завершен — transition streaming → completed.
+                setSessionState(prev => applyStreamTransition(prev, 'completed'));
                 setMessages(prev => {
                     const last = prev[prev.length - 1];
                     if (last?._streaming) {
@@ -444,17 +567,26 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
                 });
                 break;
 
-            case 'error':
-                setStreaming(false);
-                setError(String(data.message ?? 'Unknown error'));
+            case 'error': {
+                // Backend reported an error during streaming.
+                const message = String(data.message ?? 'Unknown error');
+                const { code, retryable } = inferErrorCode(data.message);
+                const chatErr: ChatError = chatError(code, message, retryable);
+                setSessionState(prev => {
+                    // streaming → idle (cancel any in-flight stream), then attach error.
+                    const transitioned = applyStreamTransition(prev, 'idle');
+                    return setChatError(transitioned, chatErr);
+                });
                 break;
+            }
 
             case 'session_closed':
                 if (currentSessionRef.current?.id === data.session_id) {
                     setCurrentSession(null);
                     currentSessionRef.current = null;
                     setMessages([]);
-                    setStreaming(false);
+                    // completed/streaming → idle is allowed; idle → idle is idempotent.
+                    setSessionState(prev => applyStreamTransition(prev, 'idle'));
                 }
                 break;
 
@@ -476,13 +608,17 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
      */
     const sendMessageWS = useCallback((content: string) => {
         if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
-            setError('WebSocket not connected');
+            setSessionState(prev =>
+                setChatError(prev, chatError('network_error', 'WebSocket not connected', true))
+            );
             return false;
         }
 
         // Prompt injection check
         if (detectPromptInjection(content)) {
-            setError('Обнаружена попытка prompt injection.');
+            setSessionState(prev =>
+                setChatError(prev, chatError('cancelled', 'Обнаружена попытка prompt injection.', false))
+            );
             logger.warn('AI chat WS: prompt injection detected and blocked');
             return false;
         }
@@ -532,12 +668,13 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
             wsRef.current = null;
         }
 
-        setConnected(false);
+        // connected/reconnecting/connecting → disconnected (terminal).
+        setSessionState(prev => applyConnectionTransition(prev, 'disconnected'));
     }, []);
 
-    // ==========================================================================
+    // ======================================================================
     // Effects
-    // ==========================================================================
+    // ======================================================================
 
     // Подключаемся к WebSocket при монтировании (если включено)
     useEffect(() => {
@@ -552,7 +689,7 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
 
     // Ping каждые 30 секунд для keepalive
     useEffect(() => {
-        if (!useWebSocket || !connected) return;
+        if (!useWebSocket || !isChatConnected(sessionState)) return;
 
         const interval = setInterval(() => {
             if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -565,21 +702,36 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
         }, 30000);
 
         return () => clearInterval(interval);
-    }, [useWebSocket, connected]);
+    }, [useWebSocket, sessionState]);
 
-    // ==========================================================================
-    // Return
-    // ==========================================================================
+    // ======================================================================
+    // Return — backward-compatible public API
+    //
+    // Legacy boolean fields are derived from `sessionState`:
+    //   loading   ← restLoading (REST API only)
+    //   streaming ← isChatStreaming(sessionState)
+    //   connected ← isChatConnected(sessionState)
+    //   error     ← restError ?? getChatErrorMessage(sessionState)
+    // ======================================================================
+
+    const clearError = useCallback(() => {
+        setRestError(null);
+        setSessionState(prev => setChatError(prev, null));
+    }, []);
 
     return {
-        // State
+        // State (legacy field names preserved for backward compatibility)
         sessions,
         currentSession,
         messages,
-        loading,
-        streaming,
-        error,
-        connected,
+        loading: restLoading,
+        streaming: isChatStreaming(sessionState),
+        error: restError ?? getChatErrorMessage(sessionState),
+        connected: isChatConnected(sessionState),
+
+        // Expose the structured transport state for advanced consumers
+        // (e.g. UI that wants to distinguish 'reconnecting' from 'connecting').
+        sessionState,
 
         // REST methods
         loadSessions,
@@ -595,7 +747,7 @@ export const useAIChat = (options: Record<string, unknown> = {}) => {
         sendMessageWS: useWebSocket ? sendMessageWS : sendMessage,
 
         // Utilities
-        clearError: () => setError(null),
+        clearError,
         clearMessages: () => setMessages([]),
         setCurrentSession,
     };

--- a/frontend/src/types/chat-session-state.ts
+++ b/frontend/src/types/chat-session-state.ts
@@ -1,20 +1,86 @@
 /**
- * ChatSessionState — specialized state model for real-time chat with WebSocket streaming.
+ * ChatSessionState — transport-layer state model for real-time chat with
+ * WebSocket streaming.
  *
- * Unlike AsyncState<T> (which models request/response: idle → loading → success → error),
- * ChatSessionState models a streaming lifecycle:
+ * Design constraints (see ADR-0013 §2 for full rationale):
  *
- *   idle → connecting → connected → streaming → completed
- *                                   ↘ reconnecting ↗
- *                                   ↘ disconnected
+ * 1. **Transport only.** This state describes the WebSocket connection and the
+ *    active streaming operation. It MUST NOT carry chat messages — those live
+ *    in a separate `ChatData<TMessage>` (or just `useState<TMessage[]>` in the
+ *    hook) so that reconnecting or clearing history does not invalidate the
+ *    other dimension.
  *
- * This separation keeps AsyncState simple for request/response patterns while
- * giving the chat hook a purpose-built state that accurately represents its
- * WebSocket-based lifecycle.
+ * 2. **Two independent dimensions.** `connectionStatus` and `streamStatus`
+ *    evolve independently. We deliberately avoid a single enum with twenty
+ *    variants like `authenticated_streaming_receiving_typing_retrying` —
+ *    that becomes unreadable and prevents independent state transitions.
  *
- * See ADR-0013 for the full rationale.
+ * 3. **Explicit transitions.** `isValidConnectionTransition` and
+ *    `isValidStreamTransition` encode the allowed state machine edges.
+ *    `applyConnectionTransition` / `applyStreamTransition` enforce them at
+ *    runtime (dev-only `console.warn` on forbidden edges).
+ *
+ * 4. **Structured error.** Errors are NOT encoded as `streamStatus === 'error'`.
+ *    Instead, `error: ChatError | null` carries the full picture: code,
+ *    human-readable message, and whether the user can retry. The UI can then
+ *    distinguish network failure / model failure / rate limit / user-cancel.
+ *
+ * 5. **No reducer coupling.** This type is a value object. The hook may use
+ *    `useState<ChatSessionState>` or `useReducer`; either way, WebSocket
+ *    callbacks and REST API calls remain separate functions. The state type
+ *    does not prescribe how transitions are dispatched.
+ *
+ * See ADR-0013 for the allowed transition tables and invariants.
  */
 
+// ===========================================================================
+// Error — structured, separate from status (constraint #5)
+// ===========================================================================
+
+export type ChatErrorCode =
+  | 'network_error'        // WebSocket close, transport failure
+  | 'auth_error'           // JWT invalid / expired / rejected
+  | 'model_error'          // backend model failed to produce a response
+  | 'rate_limit'           // 429 / quota exceeded
+  | 'cancelled'            // user-initiated cancel
+  | 'contract_mismatch'    // protocol version mismatch with backend
+  | 'unknown';
+
+export interface ChatError {
+  code: ChatErrorCode;
+  message: string;
+  /** When false, the UI should not show a "Retry" button. */
+  retryable: boolean;
+}
+
+export function chatError(
+  code: ChatErrorCode,
+  message: string,
+  retryable: boolean = true
+): ChatError {
+  return { code, message, retryable };
+}
+
+// ===========================================================================
+// Two independent status dimensions (constraints #1, #4)
+// ===========================================================================
+
+/**
+ * WebSocket transport dimension.
+ *
+ * Allowed transitions (see `isValidConnectionTransition`):
+ *
+ *   idle ──▶ connecting ──▶ connected ──▶ reconnecting ──▶ connected
+ *                │              │              │
+ *                ▼              ▼              ▼
+ *           disconnected   disconnected    disconnected
+ *
+ * Forbidden:
+ *   - idle → connected (must go through connecting)
+ *   - idle → reconnecting (nothing to reconnect to)
+ *   - disconnected → connected (must explicitly re-connect via connecting)
+ *   - disconnected → reconnecting (disconnected is terminal)
+ */
 export type ConnectionStatus =
   | 'idle'
   | 'connecting'
@@ -22,75 +88,204 @@ export type ConnectionStatus =
   | 'reconnecting'
   | 'disconnected';
 
+/**
+ * Streaming operation dimension. Independent of connection status.
+ *
+ * Allowed transitions:
+ *
+ *   idle ──▶ streaming ──▶ completed ──▶ idle      (normal cycle)
+ *                       └──▶ idle                  (cancelled / session_closed)
+ *
+ * Forbidden:
+ *   - idle → completed (must stream first)
+ *
+ * Note: there is NO `error` value here. Errors are carried in `ChatError`
+ * (constraint #5). When an error occurs, streamStatus typically returns to
+ * `idle` and `error` is populated.
+ */
 export type StreamStatus =
   | 'idle'
   | 'streaming'
-  | 'completed'
-  | 'error';
+  | 'completed';
 
-export interface ChatSessionState<TMessage = unknown> {
-  /** WebSocket connection state */
+// ===========================================================================
+// ChatSessionState — transport + stream + error (NO messages — constraints #1, #2)
+// ===========================================================================
+
+export interface ChatSessionState {
   connectionStatus: ConnectionStatus;
-  /** Current streaming operation state */
   streamStatus: StreamStatus;
-  /** Chat messages (accumulated during session) */
+  error: ChatError | null;
+  /** Number of reconnect attempts since the last successful connection. */
+  reconnectAttempt: number;
+}
+
+// ===========================================================================
+// ChatData — messages and active session, SEPARATE from session state
+// (constraints #1, #2)
+// ===========================================================================
+
+export interface ChatData<TMessage = unknown> {
   messages: TMessage[];
-  /** Error message (from connection or streaming) */
-  error: string | null;
+  activeSessionId: string | number | null;
 }
 
-// === Helper constructors ===
+// ===========================================================================
+// Initial state + helper constructors
+// ===========================================================================
 
-export function idleChatState<T>(): ChatSessionState<T> {
-  return { connectionStatus: 'idle', streamStatus: 'idle', messages: [], error: null };
+export function idleChatSessionState(): ChatSessionState {
+  return {
+    connectionStatus: 'idle',
+    streamStatus: 'idle',
+    error: null,
+    reconnectAttempt: 0,
+  };
 }
 
-export function connectingChatState<T>(messages: T[] = []): ChatSessionState<T> {
-  return { connectionStatus: 'connecting', streamStatus: 'idle', messages, error: null };
+// ===========================================================================
+// Transition validation (constraint #3)
+// ===========================================================================
+
+const ALLOWED_CONNECTION_TRANSITIONS: Record<ConnectionStatus, readonly ConnectionStatus[]> = {
+  idle: ['connecting', 'disconnected'],
+  connecting: ['connected', 'disconnected', 'reconnecting'],
+  connected: ['reconnecting', 'disconnected', 'connecting'],
+  reconnecting: ['connected', 'disconnected', 'connecting'],
+  disconnected: ['connecting'],
+};
+
+const ALLOWED_STREAM_TRANSITIONS: Record<StreamStatus, readonly StreamStatus[]> = {
+  idle: ['streaming'],
+  streaming: ['completed', 'idle'],
+  completed: ['idle', 'streaming'],
+};
+
+export function isValidConnectionTransition(
+  from: ConnectionStatus,
+  to: ConnectionStatus
+): boolean {
+  if (from === to) return true; // idempotent
+  return ALLOWED_CONNECTION_TRANSITIONS[from].includes(to);
 }
 
-export function connectedChatState<T>(messages: T[] = []): ChatSessionState<T> {
-  return { connectionStatus: 'connected', streamStatus: 'idle', messages, error: null };
+export function isValidStreamTransition(
+  from: StreamStatus,
+  to: StreamStatus
+): boolean {
+  if (from === to) return true; // idempotent
+  return ALLOWED_STREAM_TRANSITIONS[from].includes(to);
 }
 
-export function streamingChatState<T>(messages: T[]): ChatSessionState<T> {
-  return { connectionStatus: 'connected', streamStatus: 'streaming', messages, error: null };
+// ===========================================================================
+// Transition applicators — enforce invariants at runtime (dev-only warn)
+// ===========================================================================
+
+/**
+ * Apply a connection-status transition. Returns the (possibly updated) state.
+ *
+ * On a forbidden transition, logs a warning and returns the state unchanged
+ * (or with `error` populated if requested). This is intentional: a forbidden
+ * transition indicates a logic bug in the caller; we surface it loudly in dev
+ * but never crash production.
+ */
+export function applyConnectionTransition(
+  state: ChatSessionState,
+  next: ConnectionStatus,
+  options: { resetReconnectAttempt?: boolean; clearError?: boolean } = {}
+): ChatSessionState {
+  if (!isValidConnectionTransition(state.connectionStatus, next)) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[ChatSessionState] forbidden connection transition: ${state.connectionStatus} → ${next}`
+      );
+    }
+    return state;
+  }
+  return {
+    ...state,
+    connectionStatus: next,
+    reconnectAttempt: options.resetReconnectAttempt ? 0 : state.reconnectAttempt,
+    error: options.clearError ? null : state.error,
+  };
 }
 
-export function completedChatState<T>(messages: T[]): ChatSessionState<T> {
-  return { connectionStatus: 'connected', streamStatus: 'completed', messages, error: null };
+/**
+ * Apply a stream-status transition. Returns the (possibly updated) state.
+ *
+ * On a forbidden transition, logs a warning and returns the state unchanged.
+ */
+export function applyStreamTransition(
+  state: ChatSessionState,
+  next: StreamStatus,
+  options: { clearError?: boolean } = {}
+): ChatSessionState {
+  if (!isValidStreamTransition(state.streamStatus, next)) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[ChatSessionState] forbidden stream transition: ${state.streamStatus} → ${next}`
+      );
+    }
+    return state;
+  }
+  return {
+    ...state,
+    streamStatus: next,
+    error: options.clearError ? null : state.error,
+  };
 }
 
-export function reconnectingChatState<T>(messages: T[]): ChatSessionState<T> {
-  return { connectionStatus: 'reconnecting', streamStatus: 'idle', messages, error: null };
+/**
+ * Set the structured error on the state. Does NOT change connection/stream
+ * status — the caller decides whether to also transition (e.g. to `idle`).
+ */
+export function setChatError(
+  state: ChatSessionState,
+  error: ChatError | null
+): ChatSessionState {
+  return { ...state, error };
 }
 
-export function disconnectedChatState<T>(messages: T[] = []): ChatSessionState<T> {
-  return { connectionStatus: 'disconnected', streamStatus: 'idle', messages, error: null };
+/**
+ * Increment the reconnect attempt counter. Used by the WebSocket onclose
+ * handler when scheduling the next reconnect.
+ */
+export function incrementReconnectAttempt(
+  state: ChatSessionState
+): ChatSessionState {
+  return { ...state, reconnectAttempt: state.reconnectAttempt + 1 };
 }
 
-export function errorChatState<T>(error: string, messages: T[] = []): ChatSessionState<T> {
-  return { connectionStatus: 'disconnected', streamStatus: 'error', messages, error };
+// ===========================================================================
+// Convenience accessors — derive the legacy boolean fields from the new state
+// ===========================================================================
+
+export function isChatConnecting(state: ChatSessionState): boolean {
+  return (
+    state.connectionStatus === 'connecting' ||
+    state.connectionStatus === 'reconnecting'
+  );
 }
 
-// === Convenience accessors ===
-
-export function isChatLoading<T>(state: ChatSessionState<T>): boolean {
-  return state.connectionStatus === 'connecting' || state.connectionStatus === 'reconnecting';
-}
-
-export function isChatStreaming<T>(state: ChatSessionState<T>): boolean {
-  return state.streamStatus === 'streaming';
-}
-
-export function isChatConnected<T>(state: ChatSessionState<T>): boolean {
+export function isChatConnected(state: ChatSessionState): boolean {
   return state.connectionStatus === 'connected';
 }
 
-export function getChatError<T>(state: ChatSessionState<T>): string | null {
+export function isChatStreaming(state: ChatSessionState): boolean {
+  return state.streamStatus === 'streaming';
+}
+
+export function getChatError(state: ChatSessionState): ChatError | null {
   return state.error;
 }
 
-export function getChatMessages<T>(state: ChatSessionState<T>): T[] {
-  return state.messages;
+/**
+ * Returns a human-readable error message suitable for the UI, or null if
+ * there is no error. Kept for backward-compat with the legacy `error: string`
+ * API of useAIChat.
+ */
+export function getChatErrorMessage(state: ChatSessionState): string | null {
+  return state.error?.message ?? null;
 }


### PR DESCRIPTION
## Summary

- Redesign `ChatSessionState` (introduced in PR #2619) to enforce 6 architectural invariants: transport ≠ content, no messages inside session state, explicit transition tables, two independent dimensions, structured error, no reducer coupling.
- Remove `messages: TMessage[]` from `ChatSessionState`; messages live in a separate `useState<AIAssistantMsg[]>` in `useAIChat`. Reconnecting the WebSocket no longer invalidates history; clearing history no longer tears down the connection.
- Introduce structured `ChatError { code, message, retryable }` with 7 codes (`network_error`, `auth_error`, `model_error`, `rate_limit`, `cancelled`, `contract_mismatch`, `unknown`). Remove `'error'` value from `StreamStatus`. UI can now differentiate network blip vs model overload vs rate limit vs user cancel vs auth failure.
- Add `isValidConnectionTransition` / `isValidStreamTransition` validators with allowed-edge tables; `applyConnectionTransition` / `applyStreamTransition` enforce at runtime (dev-only `console.warn` on forbidden edges, prod no-op).
- Migrate `useAIChat`: 4 `useState` (loading/streaming/error/connected) replaced by single `useState<ChatSessionState>`. WS callbacks call transition helpers; never assign directly. REST API loading + errors remain separate `useState` (REST is request/response, not streaming). Public return shape preserved (18 fields); 1 new additive field `sessionState` for advanced consumers. `AIChatWidget` (only consumer) needs no code changes.

## Cyclic Execution Evidence

- Fresh main sync: yes — branch `sprint-b-plus-redesign` created from `origin/main` (commit `30b9ece6`); redesign files checked out from `sprint-b-plus/architecture-decisions` and committed on top of clean main.
- Clean workspace: yes — `git status` clean before commit; only 3 files in diff (`docs/adr/ADR-0013-state-management-boundaries.md`, `frontend/src/types/chat-session-state.ts`, `frontend/src/hooks/useAIChat.ts`).
- Branch: `sprint-b-plus/architecture-decisions` (force-pushed to clean commit `a140677c`).
- Scope gate: 3 files only — no other modules touched. ADR-0013 revised in place; `chat-session-state.ts` full rewrite; `useAIChat.ts` migrated to new type.
- Red-check handling: ran all 4 CI gates locally before pushing — tsc 0 errors, eslint 0 errors, type-debt PASS (20/20, delta 0), regression 31/31 PASS, vitest useAIChat 1/1 PASS, vitest hooks 17/17 PASS, vite build success.

See `docs/runbooks/AGENT_CYCLIC_WORKFLOW.md` for the Evidence-Based Small PR Protocol.

## Contract Impact

- Canonical surface: `frontend/src/types/chat-session-state.ts` (exported type `ChatSessionState`); `frontend/src/hooks/useAIChat.ts` (hook return shape).
- Request shape: not applicable - no REST or WebSocket request payload changed.
- Response shape: not applicable - no REST or WebSocket response shape changed. Backend protocol unchanged.
- Status codes: not applicable - no HTTP status handling changed.
- Frontend consumer: `useAIChat` return value preserved (18 existing fields with identical names and types). 1 new additive field: `sessionState: ChatSessionState` for advanced consumers (e.g. UI distinguishing 'reconnecting' from 'connecting'). `AIChatWidget` (only consumer — verified via grep) needs no code changes.
- Compatibility path or alias: legacy boolean accessors (`loading`, `streaming`, `error`, `connected`) are derived from `sessionState` via `isChatStreaming` / `isChatConnected` / `getChatErrorMessage`. Existing consumer code continues to work.
- Contract proof: diff of return statement pre/post (commits `476e639b` vs `a140677c`) shows 18/18 fields preserved. vitest `useAIChat.test.tsx` race-condition test still passes — confirms `currentSession.id`, `messages`, and message content shape unchanged.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed. The hook consumes the existing `tokenManager.getAccessToken()` only inside `connectWebSocket` (unchanged).

## Notification / Realtime

- Event type or websocket channel: not applicable - WebSocket URL `/api/v1/ai/chat/ws` unchanged; backend message types (`session`, `chunk`, `done`, `error`, `session_closed`, `pong`) unchanged. Only the client-side state representation changed.
- Payload version / ack behavior: not applicable - `MESSAGING_CONTRACT_VERSION` constant unchanged; `contract_version` field still sent in every WS message.
- Read/unread or delivery semantics: not applicable - AI chat has no read/unread concept; messages accumulate in `useState<AIAssistantMsg[]>` and are not marked as read/unread.
- Reconnect/resync proof: reconnect logic preserved — exponential backoff + jitter + max 5 attempts. Now modeled via `reconnecting` connection state instead of a separate `reconnectAttemptRef`. `incrementReconnectAttempt` helper added; transition `reconnecting → connected` clears error and resets counter. On giving up after 5 attempts, transitions to `disconnected` with structured `network_error` (retryable=false).

## Frontend Resilience

- Empty data proof: `messages: []` initial state preserved; `ChatSessionState` no longer carries messages so empty state is `idleChatSessionState()` returning `{ connectionStatus: 'idle', streamStatus: 'idle', error: null, reconnectAttempt: 0 }`. Empty-data rendering in `AIChatWidget` is unaffected.
- Partial data proof: streaming `chunk` messages still accumulate via `setMessages(prev => [...])`; the streaming message is created on first chunk and appended-to on subsequent chunks. Behavior unchanged from PR #2619. Partial streaming still works because messages are decoupled from `sessionState`.
- Forbidden secondary path behavior: prompt-injection detection still blocks forbidden content. Now structured as `ChatError { code: 'cancelled', retryable: false }` instead of bare string. UI behavior unchanged (error message displayed, message not sent).
- Missing draft/resource behavior: `sendMessage` and `sendMessageWS` still handle missing session (auto-create via `createSession`) and missing WebSocket (`setError` / structured `network_error`). Behavior preserved.
- Stale route/deep-link behavior: `loadSession` race-condition protection (`loadSessionRequestRef` counter) preserved. Stale response ignored if a newer `loadSession` call started. Verified by `useAIChat.test.tsx` (race condition test — second session wins, no messages requested for stale session).

## Scope Gate

- Allowed paths: `docs/adr/ADR-0013-state-management-boundaries.md`, `frontend/src/types/chat-session-state.ts`, `frontend/src/hooks/useAIChat.ts`.
- Denied paths: no other files touched. No backend changes. No test file changes. No migration scripts.
- Migration/docs/test impact: ADR-0013 revised (now contains 6 invariants + transition matrices + migration plan + next-sprint preview). No test changes — existing `useAIChat.test.tsx` still passes against the new implementation.
- Rollback note: revert commit `a140677c`. Since `ChatSessionState` is only consumed by `useAIChat`, and `useAIChat` is only consumed by `AIChatWidget` (which uses only the legacy boolean fields), rollback restores PR #2619's original `ChatSessionState` shape with no consumer breakage.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: `tsc --noEmit` (strict:true); `eslint src/**/*.{ts,tsx} --quiet`; `node scripts/type-debt-check.mjs`; `node scripts/regression-audit-check.mjs`; `npx vitest run src/hooks/__tests__/useAIChat.test.tsx`; `npx vitest run src/hooks/__tests__/`; `npx vite build`.
- Result: tsc 0 errors. eslint 0 errors. type-debt PASS (20/20, delta 0). regression 31/31 PASS. vitest useAIChat 1/1 PASS. vitest hooks 17/17 PASS (6 files). vite build success.
- Not checked: e2e (CI runs it, skipped locally). Backend tests (no backend changes). Frontend visual regression (no UI changes — `AIChatWidget` consumes only legacy boolean fields).
