### PR TITLE
feat(wireup): integrate invariants + state machines into hooks/reducers

### DIFF
--- a/frontend/src/hooks/__tests__/wireup/emr-reducer-wireup.test.ts
+++ b/frontend/src/hooks/__tests__/wireup/emr-reducer-wireup.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Wire-up integration tests — verify invariants + state machines are
+ * actually called in hooks/reducers.
+ *
+ * These are NOT unit tests of the invariants themselves (those exist in
+ * types/domain/invariants/__tests__/). These tests verify that the hooks
+ * and reducers CALL the invariant validators at the right points.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { emrReducer, EMR_ACTIONS, initialState } from '../../../reducers/emrReducer';
+import type { EmrState } from '../../../types/features/emr';
+
+describe('EMR reducer wire-up — state machine transitions', () => {
+  it('SAVE_START transitions idle → saving', () => {
+    const state: EmrState = { ...initialState, status: 'idle' };
+    const next = emrReducer(state, { type: EMR_ACTIONS.SAVE_START, payload: {} });
+    expect(next.status).toBe('saving');
+  });
+
+  it('SAVE_SUCCESS transitions saving → idle', () => {
+    const state: EmrState = { ...initialState, status: 'saving' };
+    const next = emrReducer(state, {
+      type: EMR_ACTIONS.SAVE_SUCCESS,
+      payload: { emr: { data: {}, version: 1 } },
+    });
+    expect(next.status).toBe('idle');
+  });
+
+  it('SAVE_ERROR transitions saving → error', () => {
+    const state: EmrState = { ...initialState, status: 'saving' };
+    const next = emrReducer(state, {
+      type: EMR_ACTIONS.SAVE_ERROR,
+      payload: { error: 'Network error' },
+    });
+    expect(next.status).toBe('error');
+  });
+
+  it('CONFLICT_DETECTED transitions saving → conflict', () => {
+    const state: EmrState = { ...initialState, status: 'saving' };
+    const next = emrReducer(state, {
+      type: EMR_ACTIONS.CONFLICT_DETECTED,
+      payload: {
+        current_version: { data: 'server' },
+        your_version: { data: 'client' },
+        last_edited_by: 'other_user',
+        last_edited_at: '2024-01-01T00:00:00Z',
+      },
+    });
+    expect(next.status).toBe('conflict');
+  });
+
+  it('CONFLICT_RESOLVED transitions conflict → idle', () => {
+    const state: EmrState = { ...initialState, status: 'conflict' };
+    const next = emrReducer(state, {
+      type: EMR_ACTIONS.CONFLICT_RESOLVED,
+      payload: { data: { resolved: true }, rowVersion: 2 },
+    });
+    expect(next.status).toBe('idle');
+  });
+
+  it('forbidden transition (idle → error) is no-op', () => {
+    // SAVE_ERROR from idle is forbidden — state machine should block it
+    const state: EmrState = { ...initialState, status: 'idle' };
+    const next = emrReducer(state, {
+      type: EMR_ACTIONS.SAVE_ERROR,
+      payload: { error: 'should not happen' },
+    });
+    // applyEmrTransition returns original state on forbidden transition
+    expect(next.status).toBe('idle');
+  });
+
+  it('forbidden transition (idle → conflict) is no-op', () => {
+    const state: EmrState = { ...initialState, status: 'idle' };
+    const next = emrReducer(state, {
+      type: EMR_ACTIONS.CONFLICT_DETECTED,
+      payload: {
+        current_version: {},
+        your_version: {},
+        last_edited_by: '',
+        last_edited_at: '',
+      },
+    });
+    expect(next.status).toBe('idle');
+  });
+
+  it('LOAD resets to idle regardless of current status', () => {
+    const state: EmrState = { ...initialState, status: 'error' };
+    const next = emrReducer(state, {
+      type: EMR_ACTIONS.LOAD,
+      payload: { emr: { data: { loaded: true }, version: 1 } },
+    });
+    expect(next.status).toBe('idle');
+  });
+});

--- a/frontend/src/hooks/useAppointments.ts
+++ b/frontend/src/hooks/useAppointments.ts
@@ -4,6 +4,8 @@ import { api } from '../api/client';
 import type { Appointment, Doctor } from '../types/domain/clinic';
 import type { AsyncState } from '../types/async-state';
 import { idleState, loadingState, successState, errorState, getError } from '../types/async-state';
+// Wire-up: domain invariant validators (Track 2 + Wire-up).
+import { checkAppointmentHasPatient, checkAppointmentPaymentAmount } from '../types/domain/invariants/appointment';
 
 /**
  * Normalized appointment shape — extends the domain Appointment with the
@@ -119,6 +121,22 @@ const useAppointments = (doctors: Doctor[] = []) => {
 
   const createAppointment = useCallback(
     async (appointmentData: Record<string, unknown>) => {
+      // Wire-up: validate business invariants before API call.
+      const patientCheck = checkAppointmentHasPatient({
+        patient_id: appointmentData.patient_id as string | number | null,
+      });
+      if (!patientCheck.ok) {
+        setRequestState(errorState<unknown>(patientCheck.message));
+        throw new Error(patientCheck.message);
+      }
+      const amountCheck = checkAppointmentPaymentAmount({
+        payment_amount: appointmentData.payment_amount as number | undefined,
+      });
+      if (!amountCheck.ok) {
+        setRequestState(errorState<unknown>(amountCheck.message));
+        throw new Error(amountCheck.message);
+      }
+
       setRequestState(loadingState<unknown>());
 
       try {

--- a/frontend/src/hooks/useDoctorQueue.ts
+++ b/frontend/src/hooks/useDoctorQueue.ts
@@ -11,6 +11,8 @@ import type {
 } from '../types/domain/queue';
 // ADR-0016: canonical error types from types/errors.ts.
 import type { HttpApiError } from '../types/errors';
+// Wire-up: queue invariant validator (Track 2 + Wire-up).
+import { checkQueueEntryCanBeCalled } from '../types/domain/invariants/queue';
 
 // Doctor-queue-specific payload envelope. The backend returns this shape from
 // /queue/{id} with queue entries + stats + can_call_next metadata. The
@@ -154,9 +156,21 @@ const useDoctorQueue = (specialty: string = 'general'): UseDoctorQueueReturn => 
   const callNext = useCallback(async (): Promise<unknown> => {
     try {
       const currentQueue = await api.get(`/doctor/${encodeURIComponent(normalizedSpecialty)}/queue/today`);
-      const nextCallEntryId = selectNextCallEntryId(currentQueue.data as DoctorQueuePayload);
+      const queueData = currentQueue.data as DoctorQueuePayload;
+      const nextCallEntryId = selectNextCallEntryId(queueData);
       if (!nextCallEntryId) {
         return { success: false, message: 'Нет ожидающих пациентов' };
+      }
+
+      // Wire-up: validate queue invariant before calling.
+      // Find the entry to check its status — don't call a terminal entry.
+      const entry = (queueData?.entries ?? []).find((e) => e.id === nextCallEntryId);
+      if (entry) {
+        const canCallCheck = checkQueueEntryCanBeCalled(entry);
+        if (!canCallCheck.ok) {
+          logger.warn('[useDoctorQueue] Invariant violation in callNext:', canCallCheck);
+          return { success: false, message: canCallCheck.message };
+        }
       }
 
       const response = await api.post(`/doctor/queue/${nextCallEntryId}/call`, {});

--- a/frontend/src/hooks/useFinance.ts
+++ b/frontend/src/hooks/useFinance.ts
@@ -6,6 +6,8 @@ import type { Transaction } from '../types/domain/clinic';
 import type { AsyncState } from '../types/async-state';
 import { successState, loadingState, errorState, getData, getError } from '../types/async-state';
 import { safeJsonParse } from '../utils/safeJsonParse';
+// Wire-up: payment invariant validator (Track 2 + Wire-up).
+import { checkPaymentAmount } from '../types/domain/invariants/billing';
 
 const FINANCE_CACHE_KEY = 'admin_finance_transactions_cache';
 // audit/phase-8, BS-36: TTL for deletedIds. Previously deletedIds grew
@@ -266,6 +268,15 @@ const useFinance = () => {
   }, [persistTransactions]);
 
   const createTransaction = useCallback(async (transactionData: Partial<Transaction>) => {
+    // Wire-up: validate payment invariant before API call.
+    const amountCheck = checkPaymentAmount({
+      amount: transactionData.amount as number | undefined,
+    });
+    if (!amountCheck.ok) {
+      setTransactionsState(errorState<unknown[]>(amountCheck.message));
+      throw new Error(amountCheck.message);
+    }
+
     setTransactionsState(loadingState<unknown[]>());
 
     try {

--- a/frontend/src/reducers/emrReducer.ts
+++ b/frontend/src/reducers/emrReducer.ts
@@ -12,6 +12,8 @@
  */
 import type { EmrAction, EmrRecord, EmrState } from '../types/features/emr';
 import { safeJsonParse } from '../utils/safeJsonParse';
+// Wire-up: EMR state machine transition validator (Track 3 + Wire-up).
+import { applyEmrTransition } from '../types/state-machines/emr';
 
 // Action types — exported as a const object for runtime use.
 // The EmrAction discriminated union (in types/features/emr.ts) is the
@@ -158,55 +160,51 @@ export function emrReducer(state: EmrState, action: EmrAction): EmrState {
         // SAVE_START - Begin save
         // =========================================================================
         case EMR_ACTIONS.SAVE_START:
-            return {
+            return applyEmrTransition({
                 ...state,
-                status: 'saving',
                 error: null,
-            };
+            }, 'saving');
 
         // =========================================================================
         // SAVE_SUCCESS - Save completed
         // =========================================================================
         case EMR_ACTIONS.SAVE_SUCCESS: {
             const emr: EmrRecord = action.payload.emr;
-            return {
+            return applyEmrTransition({
                 ...state,
                 emr,
                 version: emr.version ?? state.version,
                 rowVersion: emr.row_version ?? state.rowVersion,
-                status: 'idle',
                 isDirty: false,
                 lastSaved: new Date().toISOString(),
                 error: null,
                 conflict: null,
-            };
+            }, 'idle');
         }
 
         // =========================================================================
         // SAVE_ERROR - Save failed
         // =========================================================================
         case EMR_ACTIONS.SAVE_ERROR:
-            return {
+            return applyEmrTransition({
                 ...state,
-                status: 'error',
                 error: action.payload.error,
-            };
+            }, 'error');
 
         // =========================================================================
         // CONFLICT_DETECTED - Optimistic lock failed
         // =========================================================================
         case EMR_ACTIONS.CONFLICT_DETECTED: {
             const p = action.payload;
-            return {
+            return applyEmrTransition({
                 ...state,
-                status: 'conflict',
                 conflict: {
                     serverVersion: p.current_version,
                     yourVersion: p.your_version,
                     lastEditedBy: p.last_edited_by,
                     lastEditedAt: p.last_edited_at,
                 },
-            };
+            }, 'conflict');
         }
 
         // =========================================================================
@@ -228,9 +226,8 @@ export function emrReducer(state: EmrState, action: EmrAction): EmrState {
         // pre-conflict version), and clears `error`.
         case EMR_ACTIONS.CONFLICT_RESOLVED: {
             const payload = action.payload;
-            return {
+            return applyEmrTransition({
                 ...state,
-                status: 'idle',
                 conflict: null,
                 ...(payload?.data ? { data: payload.data } : {}),
                 ...(payload?.rowVersion ? { rowVersion: payload.rowVersion } : {}),
@@ -238,7 +235,7 @@ export function emrReducer(state: EmrState, action: EmrAction): EmrState {
                 future: [],
                 isDirty: true,
                 error: null,
-            };
+            }, 'idle');
         }
 
         // =========================================================================


### PR DESCRIPTION
## Summary

- **Wire-up** — Integrates Track 2 (domain invariants) and Track 3 (state machines) into production code paths. EMR reducer now enforces state machine transitions; useAppointments, useDoctorQueue, useFinance hooks call invariant validators before API calls.

## Cyclic Execution Evidence

- Fresh main sync: yes — branch from origin/main at 6360cfaf.
- Clean workspace: yes — 5 files changed.
- Branch: wireup-integration.
- Scope gate: 1 reducer + 3 hooks + 1 test file. No new modules — only wire-up of existing validators.
- Red-check handling: tsc 0, eslint 0, type-debt PASS (21/21), regression 31/31, vitest 295/295 (8 new wireup + 287 existing).

## Contract Impact

- Canonical surface: reducers/emrReducer.ts (applyEmrTransition calls), hooks/useAppointments.ts (invariant checks), hooks/useDoctorQueue.ts (invariant check), hooks/useFinance.ts (invariant check).
- Request shape: not applicable - no HTTP request payload changed. Invariants run before API calls.
- Response shape: not applicable - no backend response shape changed.
- Status codes: not applicable - no HTTP status handling changed.
- Frontend consumer: behavioral change — hooks now reject invalid inputs BEFORE API calls (previously would send to backend and get 400/422). EMR reducer cannot reach illegal states.
- Compatibility path or alias: all hook public APIs unchanged. Invariant violations throw Error with invariant message (same as existing error handling).
- Contract proof: tsc 0, 295 tests pass (8 wireup tests verify state machine is actually called in reducer).

## RBAC / Permissions

not applicable - no route, endpoint, guard, or auth-sensitive behavior changed. Invariant validators are client-side pre-checks.

## Notification / Realtime

- Event type or websocket channel: not applicable - no WebSocket channel changed.
- Payload version / ack behavior: not applicable - no WS payload versioning touched.
- Read/unread or delivery semantics: not applicable - AI chat has no read/unread concept.
- Reconnect/resync proof: not applicable - reconnect logic unchanged.

## Frontend Resilience

- Empty data proof: not applicable - invariants validate business rules, not data presence.
- Partial data proof: not applicable - invariants check specific fields.
- Forbidden secondary path behavior: not applicable - no auth/route/guard logic touched.
- Missing draft/resource behavior: not applicable - EMR state machine models workflow transitions, doesn't change resource lifecycle.
- Stale route/deep-link behavior: not applicable - no routing changed.

## Scope Gate

- Allowed paths: reducers/emrReducer.ts, hooks/useAppointments.ts, hooks/useDoctorQueue.ts, hooks/useFinance.ts, hooks/__tests__/wireup/emr-reducer-wireup.test.ts.
- Denied paths: no backend changes, no component changes, no new modules.
- Migration/docs/test impact: no migration needed — wire-up uses existing validators. 8 new integration tests.
- Rollback note: revert commit. Hooks revert to direct API calls without pre-validation. EMR reducer reverts to direct status assignment without state machine enforcement.

## DevBrain Memory Impact

- [x] no durable memory update needed
- [ ] PROJECT_MEMORY updated
- [ ] DEVBRAIN_STATUS updated
- [ ] AI Factory dossier/log/patch updated
- [ ] agent_gate routing rule updated
- [ ] indexes/artifacts refreshed locally
- [ ] regression matrix run

## Validation

- Targeted tests or smoke run: tsc --noEmit; eslint src/reducers/emrReducer.ts src/hooks/useAppointments.ts src/hooks/useDoctorQueue.ts src/hooks/useFinance.ts --quiet; node scripts/type-debt-check.mjs; node scripts/regression-audit-check.mjs; npx vitest run src/hooks/__tests__/ src/types/state-machines/__tests__/ src/types/domain/invariants/__tests__/.
- Result: tsc 0. eslint 0. type-debt PASS (21/21). regression 31/31. vitest 295/295 (8 new wireup + 287 existing).
- Not checked: e2e (CI runs it). Backend tests (no backend changes). Visual regression (no UI changes).
