### PR TITLE
🎨 Palette: Add aria-invalid to form controls for accessibility

### DIFF
--- a/frontend/src/components/ui/macos/Checkbox.tsx
+++ b/frontend/src/components/ui/macos/Checkbox.tsx
@@ -130,6 +130,7 @@ const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>(({
         tabIndex={disabled ? -1 : 0}
         role="checkbox"
         aria-checked={checked}
+        aria-invalid={!!error}
         aria-disabled={disabled}>
 
         <div

--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -174,6 +174,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         className={className}
         style={inputStyle}
         disabled={disabled}
+        aria-invalid={!!error}
         onFocus={handleFocus}
         onBlur={handleBlur}
         {...props}

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -255,6 +255,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           style={trigger}
           aria-haspopup="listbox"
           aria-expanded={isOpen}
+          aria-invalid={!!error}
           disabled={disabled}
           {...props}
         >

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -141,6 +141,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       className={className}
       style={textareaStyles}
       disabled={disabled}
+      aria-invalid={!!error}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}


### PR DESCRIPTION
💡 **What**: Added the `aria-invalid` attribute to core form controls (`Input`, `Textarea`, `Select`, `Checkbox`) in the macOS UI component library.

🎯 **Why**: When forms have validation errors, assistive technologies (like screen readers) need to be programmatically informed that a specific field is invalid. The `error` prop was already being visually displayed, but was not communicating the error state semantically to screen readers.

📸 **Before/After**: Visually identical, but semantically improved.

♿ **Accessibility**: 
- `Input` and `Textarea` now have `aria-invalid={!!error}` on the underlying native elements.
- `Select` has `aria-invalid={!!error}` on its `<button>` trigger element.
- `Checkbox` has `aria-invalid={!!error}` on its custom `role="checkbox"` wrapper `<div>`.

---
*PR created automatically by Jules for task [15188818454160491003](https://jules.google.com/task/15188818454160491003) started by @drsapaev*