### PR TITLE
fix: scrub PII inside diagnostic name field of standard Sentry contexts

### DIFF
--- a/backend/app/core/sentry.py
+++ b/backend/app/core/sentry.py
@@ -87,11 +87,17 @@ def _scrub_context(context_name: str, context_value: Any) -> Any:
     """Scrub a single Sentry context, preserving known diagnostic fields.
 
     For standard contexts (runtime, os, device, etc.), known diagnostic
-    keys (e.g. ``name``) are preserved because they collide with PII field
-    patterns but contain runtime metadata, not patient data. All other
-    keys are scrubbed via ``mask_pii()`` — passed as a single-key dict so
-    that ``mask_pii`` can apply key-based redaction (e.g. ``diagnosis``
-    key → ``[REDACTED]``).
+    keys (e.g. ``name``) are passed through ``mask_pii()`` as raw values
+    (not wrapped in a dict). This applies regex-based scrubbing (phone,
+    email, passport, IIN) to the value without triggering key-based
+    ``mask_name()`` — which would corrupt diagnostic names like
+    ``"CPython"`` to ``"C."``. The result: ``device.name = "CPython"``
+    is preserved, but ``device.name = "+998901234567"`` is scrubbed.
+
+    All other keys within standard contexts are scrubbed via
+    ``mask_pii({k: v})`` — wrapped in a single-key dict so ``mask_pii``
+    can apply key-based redaction (e.g. ``diagnosis`` key →
+    ``[REDACTED]``).
 
     For custom contexts, ``mask_pii()`` is applied to the entire value.
     """
@@ -101,7 +107,10 @@ def _scrub_context(context_name: str, context_value: Any) -> Any:
         result = {}
         for k, v in context_value.items():
             if k in _STANDARD_CONTEXT_DIAGNOSTIC_KEYS:
-                result[k] = v
+                # Apply mask_pii to the raw value — for strings this calls
+                # _mask_string_inplace (regex only, no key-based masking).
+                # Preserves "CPython" but scrubs "+998901234567".
+                result[k] = mask_pii(v)
             else:
                 # Wrap in single-key dict so mask_pii applies key-based
                 # redaction (e.g. {"diagnosis": "Crohn"} → {"diagnosis": "[REDACTED]"})

--- a/backend/tests/unit/test_sentry_sanitization.py
+++ b/backend/tests/unit/test_sentry_sanitization.py
@@ -743,3 +743,85 @@ class TestSanitizeEventPiiInStandardContext:
         assert d["phone"] != "+998901234567"
         assert d["iin"] != "12345678901234"
         assert d["version"] == "1.0.0"
+
+
+class TestSanitizeEventPiiInDiagnosticNameField:
+    """PHI inside the diagnostic ``name`` field of standard contexts must
+    be scrubbed via regex, while non-PII diagnostic names are preserved.
+
+    The ``name`` key is in ``PII_FIELD_PATTERNS``, but for standard
+    contexts it contains diagnostic metadata (e.g. "CPython", "Linux").
+    We apply ``mask_pii(value)`` to the raw value — for strings this
+    calls ``_mask_string_inplace()`` (regex only), NOT ``mask_name()``
+    (which would corrupt "CPython" to "C.").
+
+    Criteria (per maintainer review):
+    - device.name = "CPython" → stays "CPython"
+    - device.name = "+998901234567" → phone masked
+    - device.name = "john@example.com" → email masked
+    - device.name = "AA1234567" → passport masked
+    - device.name = "NVIDIA T4" → stays unchanged
+    """
+
+    def test_diagnostic_name_cpython_preserved(self):
+        """runtime.name = 'CPython' → unchanged (non-PII diagnostic)."""
+        event = {"contexts": {"runtime": {"name": "CPython"}}}
+        sanitize_event(event)
+        assert event["contexts"]["runtime"]["name"] == "CPython"
+
+    def test_diagnostic_name_nvidia_t4_preserved(self):
+        """gpu.name = 'NVIDIA T4' → unchanged (non-PII diagnostic)."""
+        event = {"contexts": {"gpu": {"name": "NVIDIA T4"}}}
+        sanitize_event(event)
+        assert event["contexts"]["gpu"]["name"] == "NVIDIA T4"
+
+    def test_diagnostic_name_linux_preserved(self):
+        """os.name = 'Linux' → unchanged."""
+        event = {"contexts": {"os": {"name": "Linux"}}}
+        sanitize_event(event)
+        assert event["contexts"]["os"]["name"] == "Linux"
+
+    def test_phone_in_diagnostic_name_scrubbed(self):
+        """device.name = '+998901234567' → phone masked via regex."""
+        event = {"contexts": {"device": {"name": "+998901234567"}}}
+        sanitize_event(event)
+        assert "+998901234567" not in event["contexts"]["device"]["name"]
+        assert "+998901•••567" in event["contexts"]["device"]["name"]
+
+    def test_email_in_diagnostic_name_scrubbed(self):
+        """response.name = 'john@example.com' → email masked via regex."""
+        event = {"contexts": {"response": {"name": "john@example.com"}}}
+        sanitize_event(event)
+        assert "john@example.com" not in event["contexts"]["response"]["name"]
+        assert "j•••@example.com" in event["contexts"]["response"]["name"]
+
+    def test_passport_in_diagnostic_name_scrubbed(self):
+        """device.name = 'AA1234567' → passport masked via regex."""
+        event = {"contexts": {"device": {"name": "AA1234567"}}}
+        sanitize_event(event)
+        assert "AA1234567" not in event["contexts"]["device"]["name"]
+
+    def test_iin_in_diagnostic_name_scrubbed(self):
+        """device.name = '12345678901234' → IIN masked via regex."""
+        event = {"contexts": {"device": {"name": "12345678901234"}}}
+        sanitize_event(event)
+        assert "12345678901234" not in event["contexts"]["device"]["name"]
+        assert "1234••••••1234" in event["contexts"]["device"]["name"]
+
+    def test_diagnostic_name_with_pii_and_non_pii_mixed_in_context(self):
+        """A standard context with both a diagnostic name (non-PII) and
+        PII in other fields — name preserved, PII scrubbed."""
+        event = {
+            "contexts": {
+                "device": {
+                    "name": "server-1",           # non-PII → preserved
+                    "phone": "+998901234567",     # PII → scrubbed
+                    "model": "PowerEdge R750",    # non-PII → preserved
+                }
+            }
+        }
+        sanitize_event(event)
+        d = event["contexts"]["device"]
+        assert d["name"] == "server-1"
+        assert d["model"] == "PowerEdge R750"
+        assert d["phone"] != "+998901234567"


### PR DESCRIPTION
## Summary

- Codex review #3698888989 on merged PR #2655 flagged that PII inside the diagnostic `name` field of standard Sentry contexts was preserved verbatim. For example: `device.name = "+998901234567"` leaked because `name` is in `_STANDARD_CONTEXT_DIAGNOSTIC_KEYS` and was copied without scrubbing.
- Fix: for diagnostic keys, apply `mask_pii(value)` to the raw value (not wrapped in a dict). For strings, `mask_pii(str)` calls `_mask_string_inplace()` which applies regex scrubbing (phone/email/passport/IIN) without triggering key-based `mask_name()` that would corrupt `"CPython"` to `"C."`.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `c59b4b83` (origin/main HEAD after PR #2655 merge).
- Clean workspace: `git status` clean before commit.
- Branch: `fix/sentry-diagnostic-name-pii-scrubbing` (1 commit: `7c389be2`).
- Scope gate: only 2 files changed (1 production + 1 test).
- Red-check handling: PR Review Quality Gate will be validated by CI.

## Contract Impact

- Canonical surface: `backend/app/core/sentry.py::_scrub_context` — private helper.
- Request shape: not applicable - Sentry event processing.
- Response shape: not applicable - Sentry event processing.
- Status codes: not applicable - Sentry event processing.
- Frontend consumer: not applicable - Sentry event processing.
- Compatibility path or alias: not applicable - Sentry event processing.
- Contract proof: 51 unit tests pass (43 existing + 8 new).

## RBAC / Permissions

- Roles allowed: not applicable - Sentry event processing.
- Roles denied: not applicable - Sentry event processing.
- Positive auth proof: not applicable - Sentry event processing.
- Negative auth proof: not applicable - Sentry event processing.

## Notification / Realtime

- Event type or websocket channel: not applicable - Sentry event processing.
- Payload version / ack behavior: not applicable - Sentry event processing.
- Read/unread or delivery semantics: not applicable - Sentry event processing.
- Reconnect/resync proof: not applicable - Sentry event processing.

## Frontend Resilience

- Empty data proof: not applicable - Sentry event processing.
- Partial data proof: not applicable - Sentry event processing.
- Forbidden secondary path behavior: not applicable - Sentry event processing.
- Missing draft/resource behavior: not applicable - Sentry event processing.
- Stale route/deep-link behavior: not applicable - Sentry event processing.

## Scope Gate

- Allowed paths: `backend/app/core/sentry.py` (change `_scrub_context` diagnostic key handling), `backend/tests/unit/test_sentry_sanitization.py` (8 new tests).
- Denied paths: no changes to `pii_masker.py`, no new regex, no changes to other `sanitize_event` fields.
- Migration/docs/test impact: 8 new unit tests.
- Rollback note: `git revert 7c389be2`.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: 51 tests in `test_sentry_sanitization.py` (43 existing + 8 new).
- Result: 51/51 PASS locally. ruff lint clean.
- Not checked: mypy (CI must run), full backend suite (CI must run).

**All results above are from local sandbox verification. Final confirmation pending CI.**

## Rollback

```bash
git revert 7c389be2
```
