### PR TITLE
🎨 Palette: [a11y] Add aria-invalid to form components in error state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-12 - Missing aria-busy on Complex Loading States
 **Learning:** While buttons effectively communicated their loading states via `aria-busy`, larger container components in the design system (Tables, Lists, Stat Cards) with custom loading skeletons or empty states completely lacked this attribute. This creates a confusing experience for screen reader users who aren't notified when these regions are processing or waiting for data.
 **Action:** Always add `aria-busy="true"` (or `aria-busy={loading}`) to the root container of complex UI components that handle asynchronous data loading, especially when rendering custom loading skeletons or empty states instead of standard UI elements.
+
+## 2024-05-14 - Missing aria-invalid on Form Controls with Errors
+**Learning:** While form controls accurately represented error states visually (via red borders), they lacked the `aria-invalid` attribute. Screen reader users would hear the label and value, but not the critical context that the current value is invalid or in an error state.
+**Action:** For form inputs, textareas, custom checkboxes, and select triggers, always ensure `aria-invalid={!!error}` is passed to the underlying native element or custom element (e.g., `role="checkbox"`) to properly communicate error states to assistive technologies.

--- a/frontend/src/components/ui/macos/Checkbox.tsx
+++ b/frontend/src/components/ui/macos/Checkbox.tsx
@@ -130,7 +130,8 @@ const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>(({
         tabIndex={disabled ? -1 : 0}
         role="checkbox"
         aria-checked={checked}
-        aria-disabled={disabled}>
+        aria-disabled={disabled}
+        aria-invalid={!!error}>
 
         <div
           ref={ref}

--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -176,6 +176,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         disabled={disabled}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        aria-invalid={!!error}
         {...props}
       />
       {showClearButton && (

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -256,6 +256,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           aria-haspopup="listbox"
           aria-expanded={isOpen}
           disabled={disabled}
+          aria-invalid={!!error}
           {...props}
         >
           <span>{selected ? (selected.label ?? String(selected.value)) : <span style={{ color: 'var(--mac-text-secondary)' }}>{placeholder}</span>}</span>

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -145,6 +145,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}
       rows={minRows}
+      aria-invalid={!!error}
       {...props}
     />
   );


### PR DESCRIPTION
💡 **What**: Added the `aria-invalid={!!error}` attribute to the native HTML elements within the `Input`, `Textarea`, `Checkbox`, and `Select` components.

🎯 **Why**: When a form control enters an error state, visual users can see the red border, but screen reader users rely on `aria-invalid` to know that the value they entered (or the field itself) is in an error state.

📸 **Before/After**: Visually identical (no UI changes).

♿ **Accessibility**: 
- Greatly improves the experience for users on screen readers.
- Screen readers will now announce "invalid" when focusing on an input, textarea, checkbox, or select that has an active error state.

---
*PR created automatically by Jules for task [16489815522843632143](https://jules.google.com/task/16489815522843632143) started by @drsapaev*