### PR TITLE
fix(backend): atomic PaymentCancel ↔ PaymentTransaction status sync (FOLLOWUP-8)

### DIFF
--- a/backend/app/repositories/payment_cancel_repository.py
+++ b/backend/app/repositories/payment_cancel_repository.py
@@ -17,6 +17,41 @@ class PaymentCancelRepository:
     def get_payment(self, payment_id: int) -> Payment | None:
         return self.db.query(Payment).filter(Payment.id == payment_id).first()
 
+    def count_transactions_by_payment_id(self, payment_id: int) -> int:
+        """Unlocked ``SELECT COUNT(*)`` of PaymentTransaction rows.
+
+        Used as a **soft pre-check** before the external provider cancel
+        call. If this returns ``> 1``, the 1:1 contract invariant is
+        already violated and we raise ``PaymentCancelDomainError(500)``
+        BEFORE calling ``payment_manager.cancel_payment()`` — so we
+        don't leave the provider cancelled while the local Payment
+        stays unchanged.
+
+        This is intentionally an unlocked count: we don't want to hold
+        row locks across the external HTTP call to the provider. The
+        definitive cardinality check (with ``FOR UPDATE`` locks) still
+        runs inside ``_cancel_payment_and_transaction`` via
+        ``get_transactions_by_payment_id_for_update()``. If the count
+        changes between this pre-check and the locked check (e.g. a
+        webhook inserts a second Tx during the cancel call — itself a
+        producer bug), the locked check catches it and raises 500.
+
+        Known limitation (FOLLOWUP-10): if the count is 0 at pre-check
+        time and a webhook inserts a Tx between the pre-check and the
+        locked check, the cancel path will see 1 Tx and update it to
+        'cancelled'. This is correct behavior — the webhook's insert
+        is serialized by the Payment row lock that
+        ``billing_service.update_payment_status`` acquires. The
+        remaining race (webhook reads Payment unlocked, inserts Tx,
+        then cancel overwrites) is a webhook-side issue tracked as
+        FOLLOWUP-10.
+        """
+        return (
+            self.db.query(PaymentTransaction)
+            .filter(PaymentTransaction.payment_id == payment_id)
+            .count()
+        )
+
     def get_transactions_by_payment_id_for_update(
         self, payment_id: int
     ) -> list[PaymentTransaction]:

--- a/backend/app/repositories/payment_cancel_repository.py
+++ b/backend/app/repositories/payment_cancel_repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from sqlalchemy.orm import Session
 
 from app.models.payment import Payment
+from app.models.payment_webhook import PaymentTransaction
 
 
 class PaymentCancelRepository:
@@ -15,3 +16,50 @@ class PaymentCancelRepository:
 
     def get_payment(self, payment_id: int) -> Payment | None:
         return self.db.query(Payment).filter(Payment.id == payment_id).first()
+
+    def get_transactions_by_payment_id_for_update(
+        self, payment_id: int
+    ) -> list[PaymentTransaction]:
+        """Lock all PaymentTransaction rows linked to ``payment_id`` for update.
+
+        Uses ``SELECT ... FOR UPDATE`` (via ``with_for_update()``) to
+        acquire row-level locks on every PaymentTransaction pointing at
+        this Payment. This is the symmetric counterpart of
+        ``billing_service.update_payment_status``'s own
+        ``with_for_update()`` on the Payment row.
+
+        Why this matters (FOLLOWUP-8 TOCTOU guard):
+
+        Inside ``PaymentCancelService._cancel_payment_and_transaction``,
+        the Payment row is already locked by the
+        ``billing_service.update_payment_status(commit=False)`` call
+        (which does ``SELECT Payment ... FOR UPDATE`` internally —
+        see ``billing_service_pkg/_payments.py:409-414``). That lock
+        serializes concurrent ``cancel_payment()`` calls on the same
+        Payment.
+
+        However, a *concurrent webhook handler* (provider_webhook_service)
+        may write to ``PaymentTransaction.status`` without going through
+        this cancel path. Without ``FOR UPDATE`` on our Tx read, the
+        following race is possible:
+
+            Cancel A: lock Payment → read Tx (no lock, sees 'processing')
+                                                 ↓
+            Webhook B: read Tx (no lock) → write tx.status='completed' → commit
+                                                 ↓
+            Cancel A: write tx.status='cancelled' → commit
+                       ↑ overwrites 'completed' silently
+
+        With ``FOR UPDATE`` on the Tx read, webhook B's write blocks
+        until cancel A commits or rolls back. The status we read is
+        the status we mutate.
+
+        Must be called inside a ``transaction_ctx`` block so the lock
+        is released on commit/rollback.
+        """
+        return (
+            self.db.query(PaymentTransaction)
+            .filter(PaymentTransaction.payment_id == payment_id)
+            .with_for_update()
+            .all()
+        )

--- a/backend/app/services/payment_cancel_service.py
+++ b/backend/app/services/payment_cancel_service.py
@@ -44,6 +44,33 @@ class PaymentCancelService:
                 detail=f"Платеж со статусом {payment.status} нельзя отменить",
             )
 
+        # PRE-CHECK: validate PaymentTransaction cardinality BEFORE
+        # calling the external provider cancel. If >1 row exists, the
+        # 1:1 contract invariant is already violated — raise now so we
+        # don't leave the provider cancelled while the local Payment
+        # stays unchanged (which would happen if we raised 500 only
+        # after the provider call succeeded).
+        #
+        # This is a soft (unlocked) count. The definitive check with
+        # FOR UPDATE locks still runs inside
+        # _cancel_payment_and_transaction. If the count changes between
+        # this pre-check and the locked check (e.g. a webhook inserts
+        # a second Tx during the cancel call — itself a producer bug),
+        # the locked check catches it and raises 500. At that point the
+        # provider cancel has already succeeded, but the 500 response
+        # signals the invariant violation to the operator.
+        tx_count = self.repository.count_transactions_by_payment_id(payment_id)
+        if tx_count > 1:
+            raise PaymentCancelDomainError(
+                status_code=500,
+                detail=(
+                    f"Payment {payment_id} has {tx_count} "
+                    "PaymentTransaction rows — expected exactly 1 "
+                    "(1:1 contract). Manual data reconciliation required "
+                    "before cancellation can proceed safely."
+                ),
+            )
+
         if payment.provider and payment.provider_payment_id:
             result = self.payment_manager.cancel_payment(
                 payment.provider, payment.provider_payment_id

--- a/backend/app/services/payment_cancel_service.py
+++ b/backend/app/services/payment_cancel_service.py
@@ -6,9 +6,11 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from app.db.transactions import transaction as transaction_ctx
 from app.models.enums import PaymentStatus
 from app.repositories.payment_cancel_repository import PaymentCancelRepository
 from app.services.billing_service import BillingService
+from app.services.payment_state_checks import can_transition_transaction_status
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +28,7 @@ class PaymentCancelService:
         self.repository = PaymentCancelRepository(db)
         self.billing_service = BillingService(db)
         self.payment_manager = payment_manager
+        self.db = db
 
     def cancel_payment(self, *, payment_id: int) -> dict[str, Any]:
         payment = self.repository.get_payment(payment_id)
@@ -46,9 +49,8 @@ class PaymentCancelService:
                 payment.provider, payment.provider_payment_id
             )
             if result.success:
-                self.billing_service.update_payment_status(
+                self._cancel_payment_and_transaction(
                     payment_id=payment.id,
-                    new_status=PaymentStatus.CANCELLED.value,
                     meta={**(payment.provider_data or {}), **result.provider_data},
                 )
             else:
@@ -68,8 +70,8 @@ class PaymentCancelService:
                     ),
                 )
         else:
-            self.billing_service.update_payment_status(
-                payment_id=payment.id, new_status=PaymentStatus.CANCELLED.value
+            self._cancel_payment_and_transaction(
+                payment_id=payment.id,
             )
 
         payment = self.repository.get_payment(payment_id)
@@ -84,3 +86,110 @@ class PaymentCancelService:
             "status": payment.status,
             "message": "Платеж отменен",
         }
+
+    def _cancel_payment_and_transaction(
+        self,
+        *,
+        payment_id: int,
+        meta: dict[str, Any] | None = None,
+    ) -> None:
+        """Atomically cancel Payment and linked PaymentTransaction.
+
+        Both updates happen inside a single ``transaction_ctx`` so that
+        if either fails, both are rolled back. The Payment status is
+        updated via ``billing_service.update_payment_status(commit=False)``
+        — this internally acquires ``SELECT Payment ... FOR UPDATE``
+        (see ``billing_service_pkg/_payments.py:409-414``) and flushes
+        the change without committing. The PaymentTransaction rows are
+        then read via ``get_transactions_by_payment_id_for_update()``
+        which acquires ``SELECT PaymentTransaction ... FOR UPDATE`` on
+        every linked row, closing the TOCTOU window against concurrent
+        webhook writes.
+
+        FOLLOWUP-8: this fixes the root cause of the Payment ↔
+        PaymentTransaction inconsistency that PR #2657's defensive
+        guard was compensating for.
+
+        Branching on the number of linked transactions follows an
+        explicit 0 / 1 / >1 structure:
+          - 0 rows: cash payment path — Payment has no online
+            transaction; ``transaction_ctx`` commits Payment.status
+            alone.
+          - 1 row: validate transition via shared
+            ``can_transition_transaction_status``; update
+            ``tx.status = 'cancelled'`` if allowed, otherwise log
+            warning and skip (terminal transactions like 'refunded'
+            must not be overwritten).
+          - >1 rows: 1:1 contract invariant violation — raise
+            ``PaymentCancelDomainError(500)``. Do NOT silently pick
+            first. Matches existing project pattern for invariant
+            violations (cf. ``payment_read_service.py:195``,
+            ``payment_create_service.py:117``).
+        """
+        with transaction_ctx(self.db):
+            # 1. Update Payment status (no commit yet).
+            #    billing_service.update_payment_status(commit=False)
+            #    acquires SELECT Payment ... FOR UPDATE internally
+            #    and flushes the UPDATE without committing.
+            self.billing_service.update_payment_status(
+                payment_id=payment_id,
+                new_status=PaymentStatus.CANCELLED.value,
+                meta=meta,
+                commit=False,
+            )
+
+            # 2. Find linked PaymentTransaction by payment_id FK with
+            #    row-level lock (SELECT ... FOR UPDATE).
+            #    Zero rows = cash payment (no online transaction exists)
+            #    — nothing to sync.
+            #    >1 row = data-integrity invariant violation. Payment ↔
+            #    PaymentTransaction is 1:1 by contract; multiple rows
+            #    indicate a producer bug or manual DB modification that
+            #    must be reconciled manually, not silently papered over.
+            transactions = (
+                self.repository.get_transactions_by_payment_id_for_update(
+                    payment_id
+                )
+            )
+
+            if len(transactions) == 0:
+                # Cash payment path — Payment has no linked transaction.
+                # transaction_ctx commits Payment.status alone.
+                return
+
+            if len(transactions) == 1:
+                tx = transactions[0]
+                current_tx_status = tx.status or ""
+
+                if not can_transition_transaction_status(
+                    current_tx_status, "cancelled"
+                ):
+                    # Transaction already in terminal state (refunded /
+                    # already cancelled). Payment.status update still
+                    # commits — the inconsistency this introduces is
+                    # benign because the transaction is terminal and
+                    # cannot transition further.
+                    logger.warning(
+                        "PaymentCancelService: skipping transaction status "
+                        "update — transition not allowed "
+                        "current=%s target=cancelled transaction_id=%s "
+                        "payment_id=%s",
+                        current_tx_status,
+                        getattr(tx, "id", None),
+                        payment_id,
+                    )
+                    return
+
+                tx.status = "cancelled"
+                return
+
+            # len(transactions) > 1 — invariant violation.
+            raise PaymentCancelDomainError(
+                status_code=500,
+                detail=(
+                    f"Payment {payment_id} has {len(transactions)} "
+                    "PaymentTransaction rows — expected exactly 1 "
+                    "(1:1 contract). Manual data reconciliation required "
+                    "before cancellation can proceed safely."
+                ),
+            )

--- a/backend/app/services/payment_state_checks.py
+++ b/backend/app/services/payment_state_checks.py
@@ -1,0 +1,63 @@
+"""Shared payment status transition checks.
+
+Single source of truth for Payment and PaymentTransaction state-machine
+rules. Used by:
+- ProviderWebhookService (provider_webhook_service.py)
+- PaymentCancelService (payment_cancel_service.py)
+
+FOLLOWUP-6 will extend this into a full state-machine module with
+ALLOWED_TRANSITIONS tables. For now, these functions encapsulate the
+rules that were previously inlined in ProviderWebhookService.
+
+This module is intentionally pure: it imports only
+``from __future__ import annotations`` and has no knowledge of any
+service, repository, model, or API layer. This keeps it reusable and
+free of circular-import risk.
+"""
+from __future__ import annotations
+
+# Terminal payment states: no outgoing transitions allowed.
+# A duplicate webhook or cancellation must not reopen these.
+TERMINAL_PAYMENT_STATUSES = frozenset({"refunded", "cancelled", "void"})
+
+# Terminal transaction states: no outgoing transitions allowed.
+TERMINAL_TRANSACTION_STATUSES = frozenset({"cancelled", "refunded"})
+
+
+def is_terminal_payment(status: str) -> bool:
+    """Return True if a Payment status is terminal (no outgoing transitions)."""
+    return status in TERMINAL_PAYMENT_STATUSES
+
+
+def is_terminal_transaction(status: str) -> bool:
+    """Return True if a PaymentTransaction status is terminal."""
+    return status in TERMINAL_TRANSACTION_STATUSES
+
+
+def can_transition_payment_status(current_status: str, target_status: str) -> bool:
+    """Check if a Payment status transition is allowed.
+
+    Same-status transitions (e.g. ``paid → paid`` from a duplicate
+    webhook) are allowed as idempotent no-ops.
+    """
+    if current_status == target_status:
+        return True
+    if is_terminal_payment(current_status):
+        return False
+    # failed → paid is not a valid direct transition per project
+    # state-machine (failed must return to pending first).
+    if current_status == "failed" and target_status == "paid":
+        return False
+    return True
+
+
+def can_transition_transaction_status(current_status: str, target_status: str) -> bool:
+    """Check if a PaymentTransaction status transition is allowed.
+
+    Same-status transitions are allowed as idempotent no-ops.
+    """
+    if current_status == target_status:
+        return True
+    if is_terminal_transaction(current_status):
+        return False
+    return True

--- a/backend/app/services/provider_webhook_service.py
+++ b/backend/app/services/provider_webhook_service.py
@@ -13,6 +13,10 @@ from sqlalchemy.orm import Session
 from app.db.transactions import transaction as transaction_ctx
 from app.repositories.provider_webhook_repository import ProviderWebhookRepository
 from app.services.payment_provider_manager_factory import get_payment_manager
+from app.services.payment_state_checks import (
+    can_transition_payment_status,
+    can_transition_transaction_status,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -519,12 +523,10 @@ class ProviderWebhookService:
                 "id": request_id,
             }
 
-    # Mirrors business rules from billing_service_pkg/_payments.py:423-446.
-    # See FOLLOWUP-6 for shared state-machine extraction.
-    # Terminal payment states: no outgoing transitions allowed. A duplicate
-    # webhook must not reopen a refunded/cancelled/void payment. The
-    # failed → paid direct transition is also blocked — per project
-    # state-machine, failed must return to pending before a new paid attempt.
+    # State-machine rules are now in app.services.payment_state_checks
+    # (shared with PaymentCancelService). These class attributes and
+    # classmethods are retained as thin delegates for backward
+    # compatibility with existing tests and any external callers.
     _TERMINAL_PAYMENT_STATUSES = frozenset({"refunded", "cancelled", "void"})
     _TERMINAL_TRANSACTION_STATUSES = frozenset({"cancelled", "refunded"})
 
@@ -532,31 +534,21 @@ class ProviderWebhookService:
     def _can_transition_payment_status(
         cls, current_status: str, target_status: str
     ) -> bool:
-        """Check if a payment status transition is allowed.
+        """Delegate to shared payment_state_checks module.
 
         Same-status duplicates (e.g. ``paid → paid`` from a retry webhook)
         are allowed as idempotent no-ops — ``payment.status`` is not
         mutated, but ``provider_data`` is still updated to preserve the
         audit trail.
         """
-        if current_status == target_status:
-            return True
-        if current_status in cls._TERMINAL_PAYMENT_STATUSES:
-            return False
-        if current_status == "failed" and target_status == "paid":
-            return False
-        return True
+        return can_transition_payment_status(current_status, target_status)
 
     @classmethod
     def _can_transition_transaction_status(
         cls, current_status: str, target_status: str
     ) -> bool:
-        """Check if a PaymentTransaction status transition is allowed."""
-        if current_status == target_status:
-            return True
-        if current_status in cls._TERMINAL_TRANSACTION_STATUSES:
-            return False
-        return True
+        """Delegate to shared payment_state_checks module."""
+        return can_transition_transaction_status(current_status, target_status)
 
     def _apply_existing_payme_transaction_state(
         self,

--- a/backend/tests/unit/test_payment_cancel_transaction_atomicity.py
+++ b/backend/tests/unit/test_payment_cancel_transaction_atomicity.py
@@ -257,6 +257,70 @@ class TestPaymentCancelTransactionAtomicity:
         db_session.refresh(payment)
         assert payment.status == "processing"
 
+    def test_cancel_multiple_transactions_raises_before_provider_call(
+        self, db_session, test_visit
+    ):
+        """Codex P1 #1 regression guard: the cardinality pre-check must
+        fire BEFORE the external provider cancel is called.
+
+        Without the pre-check, the provider cancel would succeed first,
+        then the locked cardinality check inside
+        _cancel_payment_and_transaction would raise 500 — leaving the
+        provider cancelled while the local Payment stays unchanged.
+
+        With the pre-check, payment_manager.cancel_payment() is NEVER
+        called when the invariant is already violated.
+        """
+        payment, _ = self._create_payment_with_transaction(
+            db_session, test_visit, payment_status="processing", tx_status="processing"
+        )
+
+        duplicate_tx = PaymentTransaction(
+            transaction_id="tx-DUPLICATE",
+            provider="click",
+            amount=1_000_000,
+            currency="UZS",
+            status="processing",
+            payment_id=payment.id,
+            webhook_id=None,
+            visit_id=test_visit.id,
+            provider_data={"method": "CreateTransaction"},
+        )
+        db_session.add(duplicate_tx)
+        db_session.commit()
+        db_session.refresh(payment)
+
+        # Use a fake manager that would FAIL the cancel call — if the
+        # pre-check works, the manager is never called at all, so the
+        # failure never happens. If the pre-check is missing, the
+        # manager is called, returns failure, and we'd see a 502
+        # instead of the expected 500.
+        fake_manager = _FakePaymentManager(
+            PaymentResult(success=False, error_message="SHOULD_NOT_BE_CALLED")
+        )
+        service = PaymentCancelService(db_session, fake_manager)
+
+        # Track whether cancel_payment was invoked on the manager.
+        original_cancel = fake_manager.cancel_payment
+        call_count = {"n": 0}
+
+        def tracking_cancel(provider_name, provider_payment_id):
+            call_count["n"] += 1
+            return original_cancel(provider_name, provider_payment_id)
+
+        fake_manager.cancel_payment = tracking_cancel
+
+        with pytest.raises(PaymentCancelDomainError) as exc_info:
+            service.cancel_payment(payment_id=payment.id)
+
+        assert exc_info.value.status_code == 500
+        assert "expected exactly 1" in exc_info.value.detail
+        assert call_count["n"] == 0, (
+            "payment_manager.cancel_payment() must NOT be called when "
+            "the cardinality pre-check detects >1 PaymentTransaction. "
+            f"Was called {call_count['n']} time(s)."
+        )
+
 
 @pytest.mark.unit
 class TestPaymentCancelRepositoryLocking:

--- a/backend/tests/unit/test_payment_cancel_transaction_atomicity.py
+++ b/backend/tests/unit/test_payment_cancel_transaction_atomicity.py
@@ -1,0 +1,302 @@
+"""Tests for PaymentCancelService atomic transaction update (FOLLOWUP-8).
+
+Validates that cancel_payment() atomically updates both Payment.status
+and PaymentTransaction.status in a single DB transaction, with
+row-level locking on both tables.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.models.payment import Payment
+from app.models.payment_webhook import PaymentTransaction
+from app.services.payment_cancel_service import (
+    PaymentCancelDomainError,
+    PaymentCancelService,
+)
+from app.services.payment_providers.base import PaymentResult
+
+
+class _FakePaymentManager:
+    def __init__(self, result: PaymentResult):
+        self.result = result
+
+    def cancel_payment(self, provider_name: str, provider_payment_id: str) -> PaymentResult:
+        return self.result
+
+
+@pytest.mark.unit
+class TestPaymentCancelTransactionAtomicity:
+    """Verify atomic cancellation of Payment + PaymentTransaction."""
+
+    def _create_payment_with_transaction(
+        self, db_session, test_visit, payment_status="processing",
+        tx_status="processing", provider="click"
+    ):
+        payment = Payment(
+            visit_id=test_visit.id,
+            amount=10_000.0,
+            currency="UZS",
+            method="online",
+            status=payment_status,
+            provider=provider,
+            provider_payment_id="provider-123",
+            provider_data={"source": "unit"},
+        )
+        db_session.add(payment)
+        db_session.flush()
+
+        tx = PaymentTransaction(
+            transaction_id="tx-123",
+            provider=provider,
+            amount=1_000_000,
+            currency="UZS",
+            status=tx_status,
+            payment_id=payment.id,
+            webhook_id=None,
+            visit_id=test_visit.id,
+            provider_data={"method": "CreateTransaction"},
+        )
+        db_session.add(tx)
+        db_session.commit()
+        db_session.refresh(payment)
+        db_session.refresh(tx)
+        return payment, tx
+
+    def test_cancel_updates_payment_and_transaction_atomically(
+        self, db_session, test_visit
+    ):
+        """Both Payment.status and PaymentTransaction.status are 'cancelled'
+        after cancel."""
+        payment, tx = self._create_payment_with_transaction(
+            db_session, test_visit, payment_status="processing", tx_status="processing"
+        )
+
+        service = PaymentCancelService(
+            db_session, _FakePaymentManager(PaymentResult(success=True))
+        )
+        result = service.cancel_payment(payment_id=payment.id)
+
+        db_session.refresh(payment)
+        db_session.refresh(tx)
+        assert result["success"] is True
+        assert payment.status == "cancelled"
+        assert tx.status == "cancelled"
+
+    def test_cancel_rolls_back_on_transaction_error(
+        self, db_session, test_visit
+    ):
+        """If an exception occurs after Payment is updated but before
+        Transaction is updated, both are rolled back.
+
+        Patches billing_service.update_payment_status to call the
+        original (with commit=False) and then raise RuntimeError —
+        simulating a failure between Payment.status write and the
+        PaymentTransaction lookup. transaction_ctx must roll back
+        BOTH writes.
+        """
+        payment, tx = self._create_payment_with_transaction(
+            db_session, test_visit, payment_status="processing", tx_status="processing"
+        )
+
+        service = PaymentCancelService(
+            db_session, _FakePaymentManager(PaymentResult(success=True))
+        )
+
+        original_update = service.billing_service.update_payment_status
+
+        def update_then_fail(*args, **kwargs):
+            kwargs["commit"] = False
+            original_update(*args, **kwargs)
+            # Simulate failure after Payment is updated but before
+            # the PaymentTransaction query/lock runs.
+            raise RuntimeError("Simulated failure before transaction update")
+
+        with patch.object(
+            service.billing_service, "update_payment_status", side_effect=update_then_fail
+        ):
+            with pytest.raises(RuntimeError):
+                service.cancel_payment(payment_id=payment.id)
+
+        # Both should be unchanged due to transaction_ctx rollback.
+        db_session.refresh(payment)
+        db_session.refresh(tx)
+        assert payment.status == "processing"
+        assert tx.status == "processing"
+
+    def test_cancel_does_not_update_terminal_transaction(
+        self, db_session, test_visit
+    ):
+        """If transaction is already 'refunded' (terminal), it stays
+        'refunded' — not overwritten to 'cancelled'."""
+        payment, tx = self._create_payment_with_transaction(
+            db_session, test_visit, payment_status="processing", tx_status="refunded"
+        )
+
+        service = PaymentCancelService(
+            db_session, _FakePaymentManager(PaymentResult(success=True))
+        )
+        result = service.cancel_payment(payment_id=payment.id)
+
+        db_session.refresh(payment)
+        db_session.refresh(tx)
+        assert payment.status == "cancelled"
+        assert tx.status == "refunded"  # NOT overwritten
+
+    def test_cancel_cash_payment_no_transaction(self, db_session, test_visit):
+        """Cash payment (no PaymentTransaction) still works — no error."""
+        payment = Payment(
+            visit_id=test_visit.id,
+            amount=10_000.0,
+            currency="UZS",
+            method="cash",
+            status="pending",
+        )
+        db_session.add(payment)
+        db_session.commit()
+        db_session.refresh(payment)
+
+        service = PaymentCancelService(
+            db_session, _FakePaymentManager(PaymentResult(success=True))
+        )
+        result = service.cancel_payment(payment_id=payment.id)
+
+        db_session.refresh(payment)
+        assert result["success"] is True
+        assert payment.status == "cancelled"
+
+    def test_cancel_idempotent_does_not_break_consistency(
+        self, db_session, test_visit
+    ):
+        """Calling cancel twice on already-cancelled payment raises error
+        but doesn't corrupt state."""
+        payment, tx = self._create_payment_with_transaction(
+            db_session, test_visit, payment_status="processing", tx_status="processing"
+        )
+
+        service = PaymentCancelService(
+            db_session, _FakePaymentManager(PaymentResult(success=True))
+        )
+        # First cancel succeeds.
+        service.cancel_payment(payment_id=payment.id)
+
+        db_session.refresh(payment)
+        db_session.refresh(tx)
+        assert payment.status == "cancelled"
+        assert tx.status == "cancelled"
+
+        # Second cancel should raise (status not cancellable).
+        with pytest.raises(PaymentCancelDomainError) as exc_info:
+            service.cancel_payment(payment_id=payment.id)
+        assert exc_info.value.status_code == 400
+
+    def test_cancel_online_payment_with_completed_transaction(
+        self, db_session, test_visit
+    ):
+        """Transaction 'completed' → 'cancelled' (valid non-terminal
+        transition) + Payment 'processing' → 'cancelled'."""
+        payment, tx = self._create_payment_with_transaction(
+            db_session, test_visit, payment_status="processing", tx_status="completed"
+        )
+
+        service = PaymentCancelService(
+            db_session, _FakePaymentManager(PaymentResult(success=True))
+        )
+        result = service.cancel_payment(payment_id=payment.id)
+
+        db_session.refresh(payment)
+        db_session.refresh(tx)
+        assert result["success"] is True
+        assert payment.status == "cancelled"
+        assert tx.status == "cancelled"
+
+    def test_cancel_multiple_transactions_raises_invariant_error(
+        self, db_session, test_visit
+    ):
+        """If Payment has >1 linked PaymentTransaction (1:1 contract
+        violation), cancel must raise PaymentCancelDomainError(500)
+        and NOT silently pick the first one.
+
+        Critical: the entire transaction_ctx must roll back —
+        Payment.status must remain unchanged.
+        """
+        payment, _ = self._create_payment_with_transaction(
+            db_session, test_visit, payment_status="processing", tx_status="processing"
+        )
+
+        # Insert a second PaymentTransaction row pointing at the same
+        # payment_id — simulates producer bug or manual DB modification.
+        duplicate_tx = PaymentTransaction(
+            transaction_id="tx-DUPLICATE",
+            provider="click",
+            amount=1_000_000,
+            currency="UZS",
+            status="processing",
+            payment_id=payment.id,
+            webhook_id=None,
+            visit_id=test_visit.id,
+            provider_data={"method": "CreateTransaction"},
+        )
+        db_session.add(duplicate_tx)
+        db_session.commit()
+        db_session.refresh(payment)
+
+        service = PaymentCancelService(
+            db_session, _FakePaymentManager(PaymentResult(success=True))
+        )
+
+        with pytest.raises(PaymentCancelDomainError) as exc_info:
+            service.cancel_payment(payment_id=payment.id)
+
+        assert exc_info.value.status_code == 500
+        assert "expected exactly 1" in exc_info.value.detail
+
+        # Rollback guarantee: Payment.status must NOT be 'cancelled'.
+        db_session.refresh(payment)
+        assert payment.status == "processing"
+
+
+@pytest.mark.unit
+class TestPaymentCancelRepositoryLocking:
+    """Verify that PaymentCancelRepository acquires FOR UPDATE on Tx rows.
+
+    This is the TOCTOU guard against concurrent webhook writes —
+    see payment_cancel_repository.get_transactions_by_payment_id_for_update
+    docstring for the race scenario.
+    """
+
+    def test_get_transactions_by_payment_id_for_update_uses_with_for_update(
+        self, db_session, test_visit
+    ):
+        """The query must call .with_for_update() to acquire row locks."""
+        from app.repositories.payment_cancel_repository import PaymentCancelRepository
+        from unittest.mock import MagicMock
+
+        # Build a fake query chain that records whether with_for_update
+        # was called. We don't hit the real DB — we just verify the
+        # query builder path.
+        fake_db = MagicMock()
+        fake_query = MagicMock()
+        fake_filtered = MagicMock()
+
+        # db.query(PaymentTransaction) -> fake_query
+        fake_db.query.return_value = fake_query
+        # fake_query.filter(...) -> fake_filtered
+        fake_query.filter.return_value = fake_filtered
+        # fake_filtered.with_for_update() -> fake_locked
+        fake_locked = MagicMock()
+        fake_filtered.with_for_update.return_value = fake_locked
+        # fake_locked.all() -> []
+        fake_locked.all.return_value = []
+
+        repo = PaymentCancelRepository(fake_db)
+        result = repo.get_transactions_by_payment_id_for_update(payment_id=42)
+
+        # Verify the chain: query -> filter -> with_for_update -> all
+        fake_db.query.assert_called_once()
+        fake_query.filter.assert_called_once()
+        fake_filtered.with_for_update.assert_called_once_with()
+        fake_locked.all.assert_called_once()
+        assert result == []


### PR DESCRIPTION
## Summary

- Fixes root cause of Payment ↔ PaymentTransaction status drift: `PaymentCancelService.cancel_payment()` previously updated `Payment.status → 'cancelled'` but never touched the linked `PaymentTransaction.status`, leaving it stuck in `processing`/`completed`. The defensive guard added in PR #2657 was compensating for this — now the cancel path itself writes both rows atomically.
- Introduces `payment_state_checks.py` as a pure (no service/repository/model imports) single source of truth for state-machine rules; `ProviderWebhookService` and `PaymentCancelService` both delegate to it (no duplicated state-machine code).
- Adds row-level `SELECT ... FOR UPDATE` lock on `PaymentTransaction` via `PaymentCancelRepository.get_transactions_by_payment_id_for_update()`, symmetric to the existing `get_payment_by_id_for_update()` from PR #2657. Closes the TOCTOU window against concurrent webhook writes.
- Treats `>1` linked transaction as a 1:1 contract invariant violation → `PaymentCancelDomainError(500)` (matches project pattern for invariant violations), not silent "pick first".

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` @ `d70c5290`; no rebase needed.
- Clean workspace: `git status` shows only the 5 files in this PR.
- Branch: `fix/followup-8-payment-cancel-transaction-atomicity`.
- Scope gate: only `payment_cancel_service.py`, `payment_cancel_repository.py`, `payment_state_checks.py` (new), `provider_webhook_service.py` (refactor delegate), and a new test file.
- Red-check handling: no red checks; pre-existing failing test `test_visit_payments_summary_route_dispatches_before_visit_id` is on `main` and not affected by this PR.

## Contract Impact

- Canonical surface: `POST /api/v1/payments/{payment_id}/cancel` route is unchanged; only the service layer (`PaymentCancelService`) is modified.
- Request shape: unchanged (`payment_id` path parameter only).
- Response shape: unchanged — `{success, payment_id, status, message}`.
- Status codes: existing 400/404/502 preserved; new 500 is possible only on the rare `>1` PaymentTransaction invariant violation path (was previously a silent corruption).
- Frontend consumer: no change — frontend already handles 4xx/5xx from this endpoint generically.
- Compatibility path or alias: not applicable, no API contract change, no rename, no alias introduced.
- Contract proof: diff inspection — endpoint signature in `registrar_api.py` unchanged; `PaymentCancelService.cancel_payment()` return shape unchanged.

## RBAC / Permissions

- Roles allowed: cashier, admin (unchanged — route guard in `registrar_api.py`).
- Roles denied: doctor, patient, anonymous (unchanged).
- Positive auth proof: not applicable, no route or guard change; existing cashier/admin access to the cancel endpoint is preserved verbatim.
- Negative auth proof: not applicable, no route or guard change; existing denial of non-cashier/non-admin roles is preserved verbatim.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no user-facing panel or frontend data flow changed; frontend still receives the same response shape.
- Partial data proof: not applicable, service response is atomic (single dict), no partial data possible.
- Forbidden secondary path behavior: not applicable, no new secondary path introduced; 403 handling on the route is unchanged.
- Missing draft/resource behavior: not applicable, no draft or resource lifecycle touched.
- Stale route/deep-link behavior: not applicable, no route change; deep links to `/payments/{id}/cancel` continue to work identically.

## Scope Gate

- Allowed paths: `backend/app/services/payment_cancel_service.py`, `backend/app/repositories/payment_cancel_repository.py`, `backend/app/services/payment_state_checks.py` (new), `backend/app/services/provider_webhook_service.py` (refactor), `backend/tests/unit/test_payment_cancel_transaction_atomicity.py` (new).
- Denied paths: no frontend, no OpenAPI regeneration, no migration, no provider_data changes, no FOLLOWUP-9 (Payme `result.state` spec), no FOLLOWUP-6 (full `ALLOWED_TRANSITIONS` extraction).
- Migration/docs/test impact: no DB migration (no schema change); no docs change; new test file added.
- Rollback note: revert commit `fb191c47` — pure additive/refactor change, no data migration to undo. The defensive guard from PR #2657 remains in place as defense-in-depth, so a revert does not reintroduce the original bug surface.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: `pytest tests/unit/test_payment_cancel_service.py tests/unit/test_payment_cancel_transaction_atomicity.py tests/unit/test_provider_webhook_service.py`.
- Result: 40 passed, 0 failed (1.96s) locally. Includes the rollback test (`test_cancel_rolls_back_on_transaction_error`), the invariant-violation test (`test_cancel_multiple_transactions_raises_invariant_error`), and the new lock-acquisition test (`test_get_transactions_by_payment_id_for_update_uses_with_for_update`).
- Not checked: full backend test suite — sandbox cannot load `grpcio` (binary incompatible with Python 3.12). CI must run the complete backend suite.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.