### PR TITLE
fix(tests): use SimpleNamespace instead of dict for get_current_user override

### DIFF
--- a/backend/tests/integration/test_visit_payments_router_order.py
+++ b/backend/tests/integration/test_visit_payments_router_order.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -16,11 +18,17 @@ def test_visit_payments_summary_route_dispatches_before_visit_id(monkeypatch):
     app = FastAPI()
     app.include_router(visit_payments.router)
     app.dependency_overrides[get_db] = lambda: object()
-    app.dependency_overrides[get_current_user] = lambda: {
-        "role": "Admin",
-        "is_superuser": False,
-        "id": 1,
-    }
+    # Use SimpleNamespace (not a dict) so attribute access in
+    # app.core.security.require_roles (current_user.role,
+    # current_user.is_superuser, current_user.id) works correctly.
+    # This matches the production contract of get_current_user -> User
+    # and the established override pattern in
+    # tests/unit/test_messages_router_service_wiring.py.
+    app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id=1,
+        role="Admin",
+        is_superuser=False,
+    )
 
     monkeypatch.setattr(
         visit_payments,


### PR DESCRIPTION
## Summary

- Fixes the pre-existing backend-test failure on `main` that blocks `PR Required Gate` for every subsequent PR.
- Replaces the dict-typed `get_current_user` override in `test_visit_payments_router_order.py` with a `SimpleNamespace` that matches the production contract (`User` object with attribute access).
- No production code changed — the bug was in the test, not in `app/core/security.py:229`.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` @ `120bb372`; no rebase needed.
- Clean workspace: `git status` shows only the one test file in this PR.
- Branch: `fix/security-py-229-visit-payments-test-user-object`.
- Scope gate: only `backend/tests/integration/test_visit_payments_router_order.py`.
- Red-check handling: this PR eliminates the only red backend check on `main`. The pre-existing failure was: `tests/integration/test_visit_payments_router_order.py::test_visit_payments_summary_route_dispatches_before_visit_id` with `AttributeError: 'dict' object has no attribute 'id'` at `app/core/security.py:229` in `require_roles._dep`.

## Contract Impact

- Canonical surface: no route, no endpoint, no service — test-only change.
- Request shape: not applicable, no API surface touched.
- Response shape: not applicable, no API response shape touched; the test still asserts the same `{total, paid}` JSON response from the visit-payments summary endpoint.
- Status codes: not applicable, no status code changed; the test still asserts HTTP 200 on the visit-payments summary route.
- Frontend consumer: not applicable, no frontend file or API consumer touched.
- Compatibility path or alias: not applicable, no API contract change.
- Contract proof: diff inspection — only `backend/tests/integration/test_visit_payments_router_order.py` modified; zero production files changed.

## RBAC / Permissions

- Roles allowed: not applicable, no route or guard change; the test still asserts `Admin` role access via the same `require_roles("Admin", "Registrar")` guard.
- Roles denied: not applicable, no route or guard change.
- Positive auth proof: not applicable, the fix is in the test fixture, not in the auth code path.
- Negative auth proof: not applicable, no denial behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no user-facing panel or frontend data flow changed.
- Partial data proof: not applicable, no frontend data flow touched.
- Forbidden secondary path behavior: not applicable, no secondary path introduced.
- Missing draft/resource behavior: not applicable, no draft or resource lifecycle touched.
- Stale route/deep-link behavior: not applicable, no route change.

## Scope Gate

- Allowed paths: `backend/tests/integration/test_visit_payments_router_order.py`.
- Denied paths: no production code (no `app/` files), no `security.py`, no `deps.py`, no migration, no docs, no OpenAPI regeneration.
- Migration/docs/test impact: no DB migration; no docs change; the existing test now passes (was failing).
- Rollback note: revert commit `d32a91b3` — the only effect is that the pre-existing failure returns. No data migration to undo. Safe to revert at any time.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: `pytest tests/integration/test_visit_payments_router_order.py tests/unit/test_messages_router_service_wiring.py tests/integration/test_messages_upload_limits.py`.
- Result: 7 passed, 0 failed (1.85s) locally. Confirms the fix resolves the failure without breaking the other two tests that also override `get_current_user` (one uses `SimpleNamespace`, the other uses a `User` fixture — both unchanged and still green).
- Not checked: full backend test suite — sandbox cannot load `grpcio` (binary incompatible with Python 3.12). CI must run the complete backend suite. Expected delta: `1 failed, 1971 passed` → `0 failed, 1972 passed`.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.