### PR TITLE
fix(parity): include .ts/.tsx in frontend API inventory glob

### DIFF
--- a/ops/scripts/extract_frontend_api_usage.py
+++ b/ops/scripts/extract_frontend_api_usage.py
@@ -266,10 +266,14 @@ def _collect_api_method_calls(
 
 def collect_frontend_calls(frontend_root: Path) -> list[ApiCall]:
     targets: list[Path] = []
-    targets.extend(sorted((frontend_root / "api").glob("*.js")))
-    targets.extend(sorted((frontend_root / "services").glob("*.js")))
-    targets.extend(sorted((frontend_root / "hooks").rglob("*.js")))
-    targets.extend(sorted((frontend_root / "hooks").rglob("*.jsx")))
+    # Frontend fully migrated to TypeScript in commit f2c868a1 (2026-07-20):
+    # .js → .ts, .jsx → .tsx. The original glob only matched *.js/*.jsx
+    # which returned 0 files post-migration, causing parity gate to see
+    # 0 frontend API calls and report 0% coverage for 14 days.
+    for ext in ("*.js", "*.jsx", "*.ts", "*.tsx"):
+        targets.extend(sorted((frontend_root / "api").glob(ext)))
+        targets.extend(sorted((frontend_root / "services").glob(ext)))
+        targets.extend(sorted((frontend_root / "hooks").rglob(ext)))
 
     seen: set[str] = set()
     calls: list[ApiCall] = []


### PR DESCRIPTION
## Summary

- Fixes the pre-existing `🔄 Frontend-Backend Parity` gate failure that has been silently breaking main for 14 days.
- Root cause: `ops/scripts/extract_frontend_api_usage.py` glob only matched `*.js`/`*.jsx`, but frontend was fully migrated to TypeScript (`.ts`/`.tsx`) in commit `f2c868a1` (PR #2433, 2026-07-20).
- Single-file fix: extend the glob loop to include `*.ts` and `*.tsx`. 1 file changed, +8/-4 lines.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` @ `120bb372`; no rebase needed.
- Clean workspace: `git status` shows only `ops/scripts/extract_frontend_api_usage.py`.
- Branch: `fix/parity-extract-ts-tsx-glob`.
- Scope gate: only `ops/scripts/extract_frontend_api_usage.py` — no production code, no test code, no docs/reports (generated in CI).
- Red-check handling: this PR eliminates the pre-existing `🔄 Frontend-Backend Parity` red check on `main`. Combined with PR #2671 (which fixes `🐍 Backend тесты`), this fully restores green main.

## Contract Impact

- Canonical surface: no route, no endpoint, no API — infra-script-only change.
- Request shape: not applicable, no API surface touched.
- Response shape: not applicable, no API response shape touched; the parity gate still asserts the same `coverage_pct`, `failed_flows`, `avg_correctness`, `avg_usability` thresholds.
- Status codes: not applicable, no HTTP status code changed.
- Frontend consumer: not applicable, no frontend file or API consumer touched.
- Compatibility path or alias: not applicable, no API contract change.
- Contract proof: diff inspection — only `ops/scripts/extract_frontend_api_usage.py` modified; zero production, test, or report files changed.

## RBAC / Permissions

- Roles allowed: not applicable, no route or guard change; RBAC alignment check (`rbac_status`) still passes (unchanged).
- Roles denied: not applicable, no route or guard change.
- Positive auth proof: not applicable, the fix is in the inventory extractor, not in the auth code path.
- Negative auth proof: not applicable, no denial behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no user-facing panel or frontend data flow changed.
- Partial data proof: not applicable, the extractor now finds 167 calls across 35 files (was 0/0); partial endpoints (12 with unresolved dynamic expressions in `mcpClient.ts`) are informational, not blocking.
- Forbidden secondary path behavior: not applicable, no secondary path introduced.
- Missing draft/resource behavior: not applicable, no draft or resource lifecycle touched.
- Stale route/deep-link behavior: not applicable, no route change.

## Scope Gate

- Allowed paths: `ops/scripts/extract_frontend_api_usage.py`.
- Denied paths: no production code (`app/`), no test code (`backend/tests/`, `frontend/src/__tests__/`), no `docs/reports/` (generated artifacts), no gate threshold changes, no OpenAPI regeneration.
- Migration/docs/test impact: no DB migration; no docs change; no new tests. The parity gate now passes instead of failing.
- Rollback note: revert commit `56fb1279` — the only effect is that the parity gate returns to reporting `total_calls=0` and failing with `avg_correctness 3.75 < required 4.00`. No data migration to undo. Safe to revert at any time.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: ran all 4 parity scripts in sequence locally on clean main HEAD `120bb372` (before and after the fix).
- Result: extract `total_calls=0→167, unique_files=0→35`; build `coverage_pct=0.00→12.78, failed_flows=4→0`; scorecard `avg_correctness=3.75→5.00, avg_usability=5.00→5.00`; gate `EXIT=1→0 (PASS)`. All 4 critical flows: `fail 0/5` (or `0/8`) → `pass 5/5` (or `8/8`).
- Not checked: full backend test suite (sandbox cannot load `grpcio`). CI must run the complete parity pipeline.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.