### PR TITLE
fix(parity): handle TypeScript generic args in api.<method>(...) calls

### DIFF
--- a/backend/tests/unit/test_extract_frontend_api_usage.py
+++ b/backend/tests/unit/test_extract_frontend_api_usage.py
@@ -1,0 +1,148 @@
+"""Unit tests for extract_frontend_api_usage.py.
+
+Covers the TypeScript generic-argument fix (PR follow-up to #2672):
+`api.get<UserDto>(...)` must be matched the same as `api.get(...)`.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    root = Path(__file__).resolve().parents[3]
+    script_path = root / "ops" / "scripts" / "extract_frontend_api_usage.py"
+    spec = importlib.util.spec_from_file_location("extract_frontend_api_usage", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load extract_frontend_api_usage.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def extractor():
+    return _load_module()
+
+
+@pytest.mark.unit
+class TestAxiosMethodCallPattern:
+    """Verify AXIOS_METHOD_CALL_PATTERN handles TypeScript generics."""
+
+    def test_plain_call_without_generic(self, extractor):
+        """`api.get('/url')` must still match (no regression)."""
+        content = "api.get('/patients/1')"
+        matches = list(extractor.AXIOS_METHOD_CALL_PATTERN.finditer(content))
+        assert len(matches) == 1
+        assert matches[0].group("method").lower() == "get"
+
+    def test_typed_call_with_generic(self, extractor):
+        """`api.get<UserDto>('/url')` must match — the bug fixed in this PR."""
+        content = "api.get<UserDto>('/auth/me')"
+        matches = list(extractor.AXIOS_METHOD_CALL_PATTERN.finditer(content))
+        assert len(matches) == 1
+        assert matches[0].group("method").lower() == "get"
+
+    def test_typed_post_with_generic(self, extractor):
+        """`api.post<VisitDto>(...)` must match."""
+        content = "api.post<VisitDto>('/visits', payload)"
+        matches = list(extractor.AXIOS_METHOD_CALL_PATTERN.finditer(content))
+        assert len(matches) == 1
+        assert matches[0].group("method").lower() == "post"
+
+    def test_typed_put_with_generic(self, extractor):
+        """`api.put<PatientDto>(...)` must match."""
+        content = "api.put<PatientDto>(`/patients/${id}`, body)"
+        matches = list(extractor.AXIOS_METHOD_CALL_PATTERN.finditer(content))
+        assert len(matches) == 1
+        assert matches[0].group("method").lower() == "put"
+
+    def test_typed_delete_with_generic(self, extractor):
+        """`api.delete<void>(...)` must match."""
+        content = "api.delete<void>('/items/1')"
+        matches = list(extractor.AXIOS_METHOD_CALL_PATTERN.finditer(content))
+        assert len(matches) == 1
+        assert matches[0].group("method").lower() == "delete"
+
+    def test_typed_call_with_whitespace_before_generic(self, extractor):
+        """`api.get <UserDto>(...)` (rare but legal TS) must match."""
+        content = "api.get <UserDto>('/url')"
+        matches = list(extractor.AXIOS_METHOD_CALL_PATTERN.finditer(content))
+        assert len(matches) == 1
+        assert matches[0].group("method").lower() == "get"
+
+    def test_typed_call_with_whitespace_after_generic(self, extractor):
+        """`api.get<UserDto> ('/url')` must match."""
+        content = "api.get<UserDto> ('/url')"
+        matches = list(extractor.AXIOS_METHOD_CALL_PATTERN.finditer(content))
+        assert len(matches) == 1
+        assert matches[0].group("method").lower() == "get"
+
+    def test_all_six_methods_match_with_generic(self, extractor):
+        """Every method in the alternation must match with a generic arg."""
+        for method in ("get", "post", "put", "patch", "delete", "options", "head"):
+            content = f"api.{method}<T>('/url')"
+            matches = list(extractor.AXIOS_METHOD_CALL_PATTERN.finditer(content))
+            assert len(matches) == 1, f"method={method!r} did not match"
+            assert matches[0].group("method").lower() == method
+
+    def test_non_api_method_not_matched(self, extractor):
+        """`myapi.get(...)`, `apiget(...)` must not match (word boundary)."""
+        for content in ("myapi.get('/url')", "apiget('/url')", "api.getx('/url')"):
+            matches = list(extractor.AXIOS_METHOD_CALL_PATTERN.finditer(content))
+            assert matches == [], f"unexpected match in {content!r}"
+
+
+@pytest.mark.unit
+class TestCollectFrontendCallsIntegration:
+    """End-to-end test: collect_frontend_calls on a fake frontend tree."""
+
+    def test_typed_and_untyped_calls_collected_equally(self, extractor, tmp_path):
+        """A mixed file with both `api.get(...)` and `api.get<T>(...)` must
+        produce 2 ApiCall entries, one per call, both with method='GET'.
+        """
+        frontend_root = tmp_path / "frontend" / "src"
+        (frontend_root / "api").mkdir(parents=True)
+        (frontend_root / "api" / "mixed.ts").write_text(
+            "export const fetchPlain = () => api.get('/plain');\n"
+            "export const fetchTyped = () => api.get<UserDto>('/typed');\n"
+            "export const createTyped = () => api.post<VisitDto>('/visits', body);\n",
+            encoding="utf-8",
+        )
+
+        calls = extractor.collect_frontend_calls(frontend_root)
+
+        # 3 calls total: 1 plain + 2 typed
+        assert len(calls) == 3, f"expected 3 calls, got {len(calls)}: {calls}"
+        methods = sorted(c.method for c in calls)
+        assert methods == ["GET", "GET", "POST"], methods
+        # Verify the typed calls' endpoint literals are extracted correctly
+        endpoints = sorted(c.endpoint_literal for c in calls if c.endpoint_literal)
+        assert endpoints == ["/plain", "/typed", "/visits"], endpoints
+
+    def test_visits_ts_pattern_matched(self, extractor, tmp_path):
+        """Reproduces the exact pattern from frontend/src/api/visits.ts that
+        was silently skipped before the fix.
+        """
+        frontend_root = tmp_path / "frontend" / "src"
+        (frontend_root / "api").mkdir(parents=True)
+        (frontend_root / "api" / "visits.ts").write_text(
+            "import { api } from './client';\n"
+            "import type { VisitDto, VisitWithServicesDto } from '../types';\n\n"
+            "export const getVisit = (id: string) =>\n"
+            "  api.get<VisitWithServicesDto>(`/visits/visits/${encodeURIComponent(id)}`);\n\n"
+            "export const createVisit = (data: unknown) =>\n"
+            "  api.post<VisitDto>('/visits', data);\n",
+            encoding="utf-8",
+        )
+
+        calls = extractor.collect_frontend_calls(frontend_root)
+
+        assert len(calls) == 2, f"expected 2 calls, got {len(calls)}"
+        # Both should be matched (was 0 before the fix)
+        methods = sorted(c.method for c in calls)
+        assert methods == ["GET", "POST"], methods

--- a/ops/scripts/extract_frontend_api_usage.py
+++ b/ops/scripts/extract_frontend_api_usage.py
@@ -15,8 +15,14 @@ from pathlib import Path
 LOGGER = logging.getLogger("frontend_api_inventory")
 
 API_REQUEST_CALL_PATTERN = re.compile(r"\bapiRequest\s*\(", re.IGNORECASE)
+# Optional TypeScript generic type argument after the method name, e.g.
+# `api.get<UserDto>(...)`. Without this group, typed calls are silently
+# skipped because the regex requires `(` immediately after the method.
+# `(?:<[^>]*>)?` matches one optional `<...>` clause; nested generics
+# like `api.get<Page<T>>(...)` are not currently present in the codebase
+# (verified) and would require a non-regex parser to balance correctly.
 AXIOS_METHOD_CALL_PATTERN = re.compile(
-    r"\bapi\.(?P<method>get|post|put|patch|delete|options|head)\s*\(",
+    r"\bapi\.(?P<method>get|post|put|patch|delete|options|head)\s*(?:<[^>]*>)?\s*\(",
     re.IGNORECASE,
 )
 SINGLE_QUOTE_LITERAL = re.compile(r"^'([^'\\]|\\.)*'$")


### PR DESCRIPTION
## Summary

- Review follow-up to merged PR #2672. The original fix added `*.ts`/`*.tsx` to the glob, but `AXIOS_METHOD_CALL_PATTERN` still required `(` immediately after the method name — silently skipping TypeScript generic calls like `api.get<UserDto>(...)`.
- 9 production calls were missing from the parity inventory, including every call in `frontend/src/api/visits.ts` and most calls in `patients.ts` and `client.ts`. The parity report treated these real frontend consumers as missing.
- Fix: 1-line regex extension (add optional `(?:<[^>]*>)?` group) + 11-test extractor suite.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` @ `964bc210`; no rebase needed.
- Clean workspace: `git status` shows only `ops/scripts/extract_frontend_api_usage.py` and the new test file.
- Branch: `fix/parity-extract-ts-generic-args`.
- Scope gate: only `ops/scripts/extract_frontend_api_usage.py` (1-line regex change + comment) and `backend/tests/unit/test_extract_frontend_api_usage.py` (new, 11 tests).
- Red-check handling: this PR does not touch any red check. Main is currently green; this PR makes the parity inventory more accurate by capturing 9 previously-missed TypeScript generic calls.

## Contract Impact

- Canonical surface: no route, no endpoint, no API — infra-script-only change.
- Request shape: not applicable, no API surface touched.
- Response shape: not applicable, no API response shape touched; the parity gate still asserts the same `coverage_pct`, `failed_flows`, `avg_correctness`, `avg_usability` thresholds.
- Status codes: not applicable, no HTTP status code changed.
- Frontend consumer: not applicable, no frontend file changed.
- Compatibility path or alias: not applicable, no API contract change.
- Contract proof: diff inspection — only `ops/scripts/extract_frontend_api_usage.py` modified (1-line regex + 6-line comment); new test file added. Zero production `app/` files changed.

## RBAC / Permissions

- Roles allowed: not applicable, no route or guard change; RBAC alignment check (`rbac_status`) still passes (unchanged).
- Roles denied: not applicable, no route or guard change.
- Positive auth proof: not applicable, the fix is in the inventory extractor, not in the auth code path.
- Negative auth proof: not applicable, no denial behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable, no user-facing panel or frontend data flow changed.
- Partial data proof: not applicable, the extractor now finds 176 calls across 36 files (was 167/35); 9 previously-missed TypeScript generic calls are now correctly inventoried.
- Forbidden secondary path behavior: not applicable, no secondary path introduced.
- Missing draft/resource behavior: not applicable, no draft or resource lifecycle touched.
- Stale route/deep-link behavior: not applicable, no route change.

## Scope Gate

- Allowed paths: `ops/scripts/extract_frontend_api_usage.py`, `backend/tests/unit/test_extract_frontend_api_usage.py`.
- Denied paths: no production code (`app/`), no frontend code (`frontend/src/`), no `docs/reports/` (generated artifacts), no gate threshold changes, no OpenAPI regeneration.
- Migration/docs/test impact: no DB migration; no docs change; new test file with 11 unit tests.
- Rollback note: revert commit `ca337376` — the only effect is that the 9 TypeScript generic calls return to being silently skipped. `coverage_pct` drops from 13.57 to 12.78. Gate still passes (avg_correctness 5.00 ≥ 4.0). Safe to revert at any time.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: `pytest tests/unit/test_extract_frontend_api_usage.py tests/unit/test_frontend_backend_parity_gate.py` + ran all 4 parity scripts on real `frontend/src/`.
- Result: 13/13 tests PASS (11 new extractor tests + 2 existing parity gate tests, no regression). Inventory delta on real frontend: `total_calls=167→176 (+9)`, `unique_files=35→36 (+1)`, `coverage_pct=12.78→13.57 (+0.79)`. All 4 critical flows still pass. Gate exit 0 (PASS) — unchanged.
- Not checked: full backend test suite (sandbox cannot load `grpcio`). CI must run the complete pipeline.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.