### PR TITLE
fix(backend): lock Payment row in Click/Kaspi/Payme-webhook handlers (FOLLOWUP-10)

### DIFF
--- a/backend/app/repositories/provider_webhook_repository.py
+++ b/backend/app/repositories/provider_webhook_repository.py
@@ -86,6 +86,36 @@ class ProviderWebhookRepository:
             .first()
         )
 
+    def get_payment_by_provider_payment_id_for_update(
+        self, provider_payment_id: str
+    ) -> Payment | None:
+        """Lock the payment row for update (SELECT ... FOR UPDATE).
+
+        Symmetric counterpart of ``get_payment_by_id_for_update``. Used
+        by Kaspi webhook handler (which looks up Payment by
+        ``provider_payment_id`` instead of by ``id``) to prevent TOCTOU
+        races against concurrent cashier cancellations.
+
+        FOLLOWUP-10: before this method existed, the Kaspi handler read
+        Payment without a lock, then mutated ``payment.status`` and
+        inserted a new ``PaymentTransaction`` row. A concurrent
+        ``PaymentCancelService.cancel_payment()`` call (which acquires
+        ``SELECT Payment ... FOR UPDATE`` via
+        ``billing_service.update_payment_status``) could commit a
+        terminal status between the Kaspi handler's unlocked read and
+        its write, leaving Payment and PaymentTransaction in
+        inconsistent states.
+
+        Must be called inside a ``transaction_ctx`` block so the lock
+        is released on commit/rollback.
+        """
+        return (
+            self.db.query(Payment)
+            .filter(Payment.provider_payment_id == provider_payment_id)
+            .with_for_update()
+            .first()
+        )
+
     def create_transaction(
         self,
         *,

--- a/backend/app/services/provider_webhook_service.py
+++ b/backend/app/services/provider_webhook_service.py
@@ -155,7 +155,12 @@ class ProviderWebhookService:
                             result.payment_id
                         )
                         if payment_id_from_order:
-                            payment = self.repository.get_payment_by_id(
+                            # FOLLOWUP-10: lock Payment row before mutation.
+                            # Prevents TOCTOU race against concurrent
+                            # PaymentCancelService.cancel_payment() (which
+                            # acquires SELECT Payment ... FOR UPDATE via
+                            # billing_service.update_payment_status).
+                            payment = self.repository.get_payment_by_id_for_update(
                                 payment_id_from_order
                             )
 
@@ -394,7 +399,12 @@ class ProviderWebhookService:
                             result.payment_id
                         )
                         if payment_id_from_order:
-                            payment = self.repository.get_payment_by_id(
+                            # FOLLOWUP-10: lock Payment row before mutation.
+                            # Prevents TOCTOU race against concurrent
+                            # PaymentCancelService.cancel_payment() (which
+                            # acquires SELECT Payment ... FOR UPDATE via
+                            # billing_service.update_payment_status).
+                            payment = self.repository.get_payment_by_id_for_update(
                                 payment_id_from_order
                             )
 
@@ -779,7 +789,12 @@ class ProviderWebhookService:
                     payment = None
                     mapped_status = None
                     if result.payment_id:
-                        payment = self.repository.get_payment_by_provider_payment_id(
+                        # FOLLOWUP-10: lock Payment row before mutation.
+                        # Prevents TOCTOU race against concurrent
+                        # PaymentCancelService.cancel_payment() (which
+                        # acquires SELECT Payment ... FOR UPDATE via
+                        # billing_service.update_payment_status).
+                        payment = self.repository.get_payment_by_provider_payment_id_for_update(
                             result.payment_id
                         )
 

--- a/backend/tests/unit/test_provider_webhook_service.py
+++ b/backend/tests/unit/test_provider_webhook_service.py
@@ -192,6 +192,125 @@ class TestProviderWebhookService:
         assert payment.paid_at is None
         repository.create_transaction.assert_not_called()
 
+    # --- FOLLOWUP-10: Click/Kaspi/Payme must lock Payment before mutation ---
+
+    def test_click_webhook_locks_payment_before_mutation(self, db_session):
+        """FOLLOWUP-10 regression guard: Click handler must call
+        get_payment_by_id_for_update (not get_payment_by_id) before
+        mutating payment.status. Without the lock, a concurrent cashier
+        cancel could commit a terminal status between our read and
+        write, leaving Payment and PaymentTransaction inconsistent.
+        """
+        webhook = SimpleNamespace(id=33, status="pending", processed_at=None)
+        payment = SimpleNamespace(
+            id=44,
+            amount=Decimal("1000"),
+            status="pending",
+            paid_at=None,
+            provider_data={},
+            visit_id=55,
+        )
+        repository = SimpleNamespace(
+            get_existing_transaction=Mock(return_value=None),
+            create_webhook=Mock(return_value=webhook),
+            get_payment_by_id=Mock(return_value=payment),
+            get_payment_by_id_for_update=Mock(return_value=payment),
+            create_transaction=Mock(),
+        )
+        manager = SimpleNamespace(
+            get_provider=Mock(
+                return_value=SimpleNamespace(
+                    validate_webhook_signature=Mock(return_value=True)
+                )
+            ),
+            process_webhook=Mock(
+                return_value=SimpleNamespace(
+                    success=True,
+                    payment_id="clinic_44_1700000000",
+                    status="completed",
+                    provider_data={"amount": Decimal("1000")},
+                )
+            ),
+        )
+        service = ProviderWebhookService(db_session, repository=repository)
+
+        with patch(
+            "app.services.provider_webhook_service.get_payment_manager",
+            return_value=manager,
+        ):
+            service.process_click_webhook(
+                {
+                    "click_trans_id": "click-1",
+                    "merchant_trans_id": "clinic_44_1700000000",
+                    "amount": 100000,
+                    "sign_string": "valid",
+                }
+            )
+
+        # The locked variant must be called; the unlocked one must NOT.
+        repository.get_payment_by_id_for_update.assert_called_once_with(44)
+        repository.get_payment_by_id.assert_not_called()
+
+    def test_kaspi_webhook_locks_payment_before_mutation(self, db_session):
+        """FOLLOWUP-10 regression guard: Kaspi handler must call
+        get_payment_by_provider_payment_id_for_update (not
+        get_payment_by_provider_payment_id) before mutating payment.status.
+        """
+        webhook = SimpleNamespace(id=33, status="pending", processed_at=None)
+        payment = SimpleNamespace(
+            id=44,
+            amount=Decimal("1000"),
+            status="pending",
+            paid_at=None,
+            provider_data={},
+            visit_id=55,
+        )
+        repository = SimpleNamespace(
+            get_existing_transaction=Mock(return_value=None),
+            create_webhook=Mock(return_value=webhook),
+            get_payment_by_provider_payment_id=Mock(return_value=payment),
+            get_payment_by_provider_payment_id_for_update=Mock(
+                return_value=payment
+            ),
+            create_transaction=Mock(),
+        )
+        manager = SimpleNamespace(
+            get_provider=Mock(
+                return_value=SimpleNamespace(
+                    validate_webhook_signature=Mock(return_value=True)
+                )
+            ),
+            process_webhook=Mock(
+                return_value=SimpleNamespace(
+                    success=True,
+                    payment_id="kaspi-pay-123",
+                    status="completed",
+                    provider_data={"amount": Decimal("1000")},
+                )
+            ),
+        )
+        service = ProviderWebhookService(db_session, repository=repository)
+
+        with patch(
+            "app.services.provider_webhook_service.get_payment_manager",
+            return_value=manager,
+        ):
+            service.process_kaspi_webhook(
+                {
+                    "transaction_id": "kaspi-1",
+                    "merchant_id": "m1",
+                    "amount": 100000,
+                    "currency": "KZT",
+                    "signature": "valid",
+                }
+            )
+
+        # The locked variant must be called; the unlocked one must NOT.
+        repository.get_payment_by_provider_payment_id_for_update.assert_called_once_with(
+            "kaspi-pay-123"
+        )
+        repository.get_payment_by_provider_payment_id.assert_not_called()
+
     def test_extract_payment_id_from_order(self, db_session):
         service = ProviderWebhookService(db_session)
 


### PR DESCRIPTION
## Summary

- Closes the TOCTOU race identified by Codex P1 #2 on PR #2670: Click, Kaspi, and Payme new-flow webhook handlers read and mutated `Payment` without `FOR UPDATE`, allowing a concurrent cashier cancel to commit a terminal status between the webhook's read and write.
- Adds `get_payment_by_provider_payment_id_for_update()` to `ProviderWebhookRepository` (symmetric counterpart of `get_payment_by_id_for_update`).
- All three webhook handlers (Click, Kaspi, Payme new-flow) now acquire `SELECT Payment ... FOR UPDATE` before mutating `payment.status` or inserting a `PaymentTransaction`.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` @ `e77ae872`; no rebase needed.
- Clean workspace: `git status` shows 3 files (1 repository method added, 3 call-site changes, 2 new tests).
- Branch: `fix/followup-10-click-kaspi-webhook-locking`.
- Scope gate: `backend/app/repositories/provider_webhook_repository.py` (+1 method), `backend/app/services/provider_webhook_service.py` (3 call-site changes + comments), `backend/tests/unit/test_provider_webhook_service.py` (2 new tests).
- Red-check handling: no red checks. Main is currently green; this PR keeps it green.

## Contract Impact

- Canonical surface: `POST /api/v1/payment-webhooks/click`, `POST /api/v1/payment-webhooks/payme`, `POST /api/v1/payment-webhooks/kaspi` — no route change, no API change.
- Request shape: not applicable, no change to incoming webhook request parsing.
- Response shape: not applicable, no change to Click `{error, error_note, ...}`, Kaspi `{status, message, ...}`, or Payme `{result, ...}` response shapes.
- Status codes: not applicable, HTTP 200 unchanged for all three webhook endpoints.
- Frontend consumer: not applicable, these endpoints are called by payment providers, not by the frontend.
- Compatibility path or alias: not applicable, no API contract change visible to any consumer.
- Contract proof: diff inspection — only repository method addition + call-site changes from `get_payment_by_id` to `get_payment_by_id_for_update` (and Kaspi equivalent). Zero changes to response construction logic.

## RBAC / Permissions

- Roles allowed: not applicable, no route or guard change; webhook endpoints authenticate via provider-specific auth (Payme Basic Auth, Click/Kaspi signature), unchanged.
- Roles denied: not applicable, no route or guard change.
- Positive auth proof: not applicable, locking change; auth validation still runs before any DB access.
- Negative auth proof: not applicable, no denial behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed. The internal `payment_status` field (which drives `_emit_payment_notification_from_webhook_result`) is computed identically; only the locking around its computation changes.

## Frontend Resilience

- Empty data proof: not applicable, no user-facing panel or frontend data flow changed.
- Partial data proof: not applicable, the response is a single JSON object per provider, no partial data possible.
- Forbidden secondary path behavior: not applicable, no secondary path introduced.
- Missing draft/resource behavior: not applicable, no draft or resource lifecycle touched.
- Stale route/deep-link behavior: not applicable, no route change.

## Scope Gate

- Allowed paths: `backend/app/repositories/provider_webhook_repository.py` (+1 method `get_payment_by_provider_payment_id_for_update`), `backend/app/services/provider_webhook_service.py` (3 call-site changes: Click line 158, Kaspi line 782, Payme new-flow line 397), `backend/tests/unit/test_provider_webhook_service.py` (2 new regression tests).
- Denied paths: no changes to `_apply_existing_payme_transaction_state`, no changes to response construction, no changes to `PaymentCancelService`, no migration, no OpenAPI regeneration, no frontend.
- Migration/docs/test impact: no DB migration; no docs change; 2 new regression tests.
- Rollback note: revert commit `b2aac5a0` — the only effect is that Click/Kaspi/Payme new-flow handlers return to unlocked reads. The TOCTOU race described in Codex P1 #2 returns. Safe to revert at any time.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: `pytest tests/unit/test_provider_webhook_service.py`.
- Result: 30 passed, 0 failed (0.51s). 2 new regression tests added (`test_click_webhook_locks_payment_before_mutation`, `test_kaspi_webhook_locks_payment_before_mutation`). All 28 pre-existing tests pass unchanged.
- Not checked: full backend test suite (sandbox cannot load `grpcio`). CI must run the complete pipeline.

## Invariants verified (per maintainer pre-implementation review)

1. **Consistent locking strategy**: `SELECT ... FOR UPDATE` is now used consistently across all three webhook handlers (Click, Kaspi, Payme new-flow + existing-flow). No mixed locking strategies.

2. **Lock acquired before mutation, after idempotency check**: `get_existing_transaction` (idempotency check) still runs BEFORE the lock — duplicate webhooks return early without acquiring the lock. The lock is only acquired for new-transaction processing, which is the path that mutates `Payment.status`.

3. **No change to external responses**: Click still returns `{error, error_note, ...}`, Kaspi still returns `{status, message, ...}`, Payme still returns `{result, ...}`. Only concurrency guarantees change — no business-logic or response-shape changes.

See `docs/runbooks/PR_REVIEW_QUALITY_GATES.md` for the review checklist behind this template.