### PR TITLE
fix(payme): terminal-status guard — don't persist terminal status as pre_cancel_status (Codex P2 on FOLLOWUP-12)

### DIFF
--- a/backend/app/services/provider_webhook_service.py
+++ b/backend/app/services/provider_webhook_service.py
@@ -26,6 +26,13 @@ logger = logging.getLogger(__name__)
 # (CancelTransaction response state must be idempotent per ADR-0019).
 PAYME_TX_PRE_CANCEL_STATE_ACTION = "PAYME_TX_PRE_CANCEL_STATE"
 
+# FOLLOWUP-12: terminal PaymentTransaction statuses. If current_tx_status
+# is in this set AND no AuditLog pre_cancel_status record exists, the first
+# cancel already committed but its AuditLog INSERT failed — we cannot
+# recover the true pre-cancel state and must not persist the terminal
+# status (Codex P2 review on PR #2684).
+_TERMINAL_TX_STATUSES = frozenset({"refunded", "cancelled", "void"})
+
 
 class ProviderWebhookService:
     """Handles provider webhook processing formerly implemented in controller."""
@@ -803,6 +810,18 @@ class ProviderWebhookService:
         structured warning.
 
         Constraint: at most 1 SELECT + 1 INSERT per call.
+
+        Terminal-status guard (Codex P2 review on PR #2684): if
+        `current_tx_status` is already terminal (refunded/cancelled/void)
+        AND no AuditLog record exists, this means the first cancel
+        already committed but its AuditLog INSERT failed. In this case
+        we CANNOT recover the true pre-cancel state — it is lost. We
+        return False (conservative — response state=-1) and DO NOT
+        persist the terminal status, because doing so would record an
+        immutable-but-wrong `pre_cancel_status` that blocks all future
+        recovery. This is the unavoidable degradation of Strategy 2:
+        when the first AuditLog write fails, idempotency for that Tx
+        is lost, but we do not make it worse by persisting wrong data.
         """
         tx_id = getattr(transaction, "id", None)
 
@@ -812,17 +831,38 @@ class ProviderWebhookService:
             # Retry: AuditLog record exists from a prior CancelTransaction.
             return recovered_pre_cancel == "completed"
 
-        # Step 2: first call (or prior AuditLog write failed). Derive from
-        # current mutable state and persist for future retries.
+        # Step 2: first call (or prior AuditLog write failed).
+        #
+        # Terminal-status guard: if current_tx_status is already terminal,
+        # the first cancel already committed but its AuditLog INSERT
+        # failed. We cannot recover the true pre-cancel state — persist
+        # the terminal status would record wrong data that blocks future
+        # recovery. Return False (conservative) and do not persist.
+        if current_tx_status in _TERMINAL_TX_STATUSES:
+            logger.warning(
+                "Payme webhook: Tx is already in terminal state %s but no "
+                "AuditLog pre_cancel_status record exists — first cancel's "
+                "AuditLog INSERT must have failed. Cannot recover true "
+                "pre-cancel state; returning was_completed=False (state=-1). "
+                "Idempotency for this Tx is degraded (Strategy 2). "
+                "transaction_id=%s",
+                current_tx_status,
+                tx_id,
+            )
+            return False
+
+        # Step 3: genuine first call — current_tx_status is a non-terminal
+        # state (processing/completed). Derive was_completed and persist
+        # for future retries.
         was_completed = current_tx_status == "completed"
 
         # Persist pre_cancel_status. On failure, fall back to mutable-state
         # derivation (Strategy 2). The webhook response is still sent;
         # idempotency degrades silently for this Tx if a retry arrives.
         # The try/except here is a safety net: _persist_pre_cancel_state
-        # already catches exceptions internally (via SAVEPOINT), but this
-        # outer catch ensures that any unexpected error from the helper
-        # does not abort the webhook.
+        # already catches exceptions internally, but this outer catch
+        # ensures that any unexpected error from the helper does not
+        # abort the webhook.
         try:
             self._persist_pre_cancel_state(tx_id, current_tx_status)
         except Exception as exc:

--- a/backend/tests/unit/test_provider_webhook_service.py
+++ b/backend/tests/unit/test_provider_webhook_service.py
@@ -912,3 +912,97 @@ class TestPaymeTerminalStatePreservation:
             f"got {_locked.provider_data.get('method')!r}. Phase 2 provider_data "
             "mutation was lost."
         )
+
+    def test_cancel_retry_after_failed_audit_log_does_not_persist_terminal_status(
+        self, db_session, caplog
+    ):
+        """REGRESSION TEST for Codex P2 review on PR #2684.
+
+        Scenario (the terminal-status guard):
+          Step 1: Tx.status='completed' (Payme state 2)
+            → first CancelTransaction
+            → _persist_pre_cancel_state called with pre_cancel_status='completed'
+            → AuditLog INSERT succeeds
+            → response state=-2 ✅
+            → Tx.status mutates to 'refunded'
+
+          Step 2: simulate AuditLog INSERT failed on step 1 (rollback
+            removed the AuditLog row, but Tx.status mutation committed
+            in a fresh transaction). Now Tx.status='refunded' and no
+            AuditLog record exists.
+
+          Step 3: retry CancelTransaction
+            → _get_pre_cancel_state_from_audit_log returns None (no record)
+            → current_tx_status='refunded' (terminal)
+            → terminal-status guard kicks in: return was_completed=False
+              WITHOUT persisting 'refunded' as pre_cancel_status
+            → response state=-1 (degraded, but not worse)
+
+          Step 4: another retry
+            → same as step 3 — no AuditLog record, terminal guard,
+              state=-1
+
+        Without the terminal-status guard, step 3 would persist
+        pre_cancel_status='refunded' (wrong), and step 4 would recover
+        it and return state=-1 (also wrong, but now permanently wrong
+        because the AuditLog record is immutable). The guard prevents
+        persisting wrong data.
+
+        This test verifies:
+          1. No AuditLog record is created when current_tx_status is terminal
+          2. Response state=-1 (conservative, degraded idempotency)
+          3. Structured warning is emitted
+        """
+        import logging
+        from app.models.audit import AuditLog
+        from app.services.provider_webhook_service import (
+            PAYME_TX_PRE_CANCEL_STATE_ACTION,
+        )
+
+        # Setup: Tx is already in 'refunded' (terminal) state, no AuditLog
+        # record exists (simulating failed INSERT on first cancel).
+        service, tx, payment, _locked = self._make_service(
+            db_session,
+            transaction_status="refunded",  # terminal — first cancel already happened
+            payment_status="refunded",
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = self._call_cancel(service, reason=2)
+
+        # Response: state=-1 (degraded, but not persisting wrong data)
+        assert result["result"]["state"] == -1, (
+            f"Expected -1 (terminal-status guard, degraded), "
+            f"got {result['result']['state']}"
+        )
+
+        # KEY ASSERTION: no AuditLog record was created.
+        # The terminal-status guard must NOT persist 'refunded' as
+        # pre_cancel_status — that would be immutable-but-wrong data.
+        audit_entry = (
+            db_session.query(AuditLog)
+            .filter(
+                AuditLog.action == PAYME_TX_PRE_CANCEL_STATE_ACTION,
+                AuditLog.entity_type == "payment_transaction",
+                AuditLog.entity_id == tx.id,
+            )
+            .first()
+        )
+        assert audit_entry is None, (
+            f"Terminal-status guard failed: AuditLog record was created with "
+            f"pre_cancel_status={audit_entry.payload.get('pre_cancel_status')!r}. "
+            "Persisting a terminal status as pre_cancel_status would block "
+            "future recovery — the guard should have skipped the INSERT."
+        )
+
+        # Structured warning was emitted
+        warning_messages = [
+            rec.getMessage()
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING
+            and "terminal state" in rec.getMessage()
+        ]
+        assert any("transaction_id=77" in msg for msg in warning_messages), (
+            f"Expected warning about terminal state with transaction_id=77, "
+            f"got: {warning_messages}"
+        )


### PR DESCRIPTION
## Summary

- Fixes a real idempotency defect identified by Codex P2 review on PR #2684 (post-merge, on commit `263cfaac`).
- Adds a terminal-status guard in `_resolve_was_completed`: if `current_tx_status` is already terminal (refunded/cancelled/void) AND no AuditLog record exists, do NOT persist the terminal status as `pre_cancel_status` — it would be immutable-but-wrong data that blocks all future recovery.
- **No schema changes, no migrations, no AuditService modifications, Payme-only scope.**

## Cyclic Execution Evidence

- Fresh main sync: branch created from current origin/main at commit `91d9e4d2` (PR #2684, FOLLOWUP-12 merge)
- Clean workspace: inspected before edits; only `provider_webhook_service.py` (production code) and `test_provider_webhook_service.py` (tests) changed
- Branch: `fix/followup-12-terminal-status-guard`
- Scope gate: allowed `backend/app/services/provider_webhook_service.py` and `backend/tests/unit/test_provider_webhook_service.py`; denied Click/Kaspi handlers, AuditService, transaction_ctx, SessionLocal, repositories, migrations, frontend, generated output
- Red-check handling: fix any failed test or CI check in this same PR before merge

## Contract Impact

not applicable - no backend endpoint, websocket event, scheduled job, or frontend consumer contract changed. The Payme CancelTransaction JSON-RPC response shape is unchanged. This PR only changes the internal logic of `_resolve_was_completed` to avoid persisting wrong data in a specific failure-recovery scenario.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/app/services/provider_webhook_service.py` (terminal-status guard in `_resolve_was_completed`), `backend/tests/unit/test_provider_webhook_service.py` (1 new regression test)
- Denied paths: Click/Kaspi webhook handlers, AuditService, transaction_ctx, SessionLocal, repositories, migrations, frontend, generated output, any other backend runtime path
- Migration/docs/test impact: no migration; no docs changes; 1 new test added
- Rollback note: revert the 2 files in this PR; no DB state to roll back

## Validation

- Targeted tests or smoke run: standalone test runner ran 5 tests (4 from FOLLOWUP-12 + 1 new terminal-guard test)
- Result: passed (5/5)
- Not checked: full backend integration tests with PostgreSQL (deferred to CI — that is the authoritative check)

---

## The defect (Codex P2 review on PR #2684)

Codex identified that after FOLLOWUP-12 merged, there is still an idempotency defect in the failure-recovery path:

```
Step 1: Tx.status='completed' → first CancelTransaction
        → AuditLog INSERT FAILS (Strategy 2 fallback)
        → response state=-2 (correct, derived from current_tx_status)
        → Tx.status mutates to 'refunded'

Step 2: retry CancelTransaction
        → _get_pre_cancel_state_from_audit_log returns None (no record
          from step 1 — INSERT failed)
        → current_tx_status='refunded' (terminal)
        → OLD CODE: persists pre_cancel_status='refunded' (WRONG)
        → returns was_completed=False → state=-1 (wrong, should be -2)

Step 3: another retry
        → _get_pre_cancel_state_from_audit_log returns 'refunded'
          (immutable AuditLog record from step 2)
        → returns was_completed=False → state=-1 (permanently wrong)
```

The old code made the problem worse: not only did step 2 return the wrong state, but it persisted that wrong value in an **immutable** AuditLog record, blocking all future recovery.

## The fix

Terminal-status guard in `_resolve_was_completed`:

```python
if current_tx_status in _TERMINAL_TX_STATUSES:
    logger.warning(...)
    return False  # do NOT persist terminal status
```

If `current_tx_status` is already terminal AND no AuditLog record exists, this means the first cancel committed but its AuditLog INSERT failed. The true pre-cancel state is **lost** — we cannot recover it. Return `was_completed=False` (conservative, `state=-1`) and **do not persist** the terminal status.

This is the unavoidable degradation of Strategy 2 (ADR-0019 lines 152-154): when the first AuditLog write fails, idempotency for that Tx is lost. The guard ensures we do not make it worse by persisting wrong data.

## Implementation assumptions (per maintainer directive in Issue #2679)

Same constraints as FOLLOWUP-12:

1. **Only Payme CancelTransaction is modified.** Click and Kaspi handlers do not appear in the diff.
2. **Click/Kaspi handlers are not touched.**
3. **AuditService is not modified.**
4. **DB schema is not changed.** No new columns, tables, triggers, or enums.
5. **Public API is not changed.** No changes to endpoint signatures or response schemas.
6. **Defensive guard from FOLLOWUP-10 is preserved.**
7. **No refactoring or cleanup outside scope.** The change is a 50-line addition to `_resolve_was_completed` plus a 94-line regression test.

## Invariants verified

1. `ALLOWED_PAYMENT_TRANSITIONS` (FOLLOWUP-6) — unchanged.
2. Lock ordering (FOLLOWUP-8, FOLLOWUP-10) — unchanged.
3. Defensive webhook guard (FOLLOWUP-10) — preserved.
4. External provider response idempotency — improved (was still broken in the failure-recovery path).
5. No mutable state as source of historical truth — AuditLog remains immutable; the guard prevents persisting wrong data.

## Regression test

New test `test_cancel_retry_after_failed_audit_log_does_not_persist_terminal_status`:
- Setup: Tx.status='refunded' (terminal), no AuditLog record
- Verify: response state=-1 (degraded)
- Verify: NO AuditLog record created (terminal-status guard prevents wrong persist)
- Verify: structured warning emitted

## Risk assessment

- **Runtime behaviour change:** Yes — in the specific failure-recovery scenario (first cancel's AuditLog INSERT failed, retry arrives), the response is now `state=-1` (was `-1` before too, but now we don't persist wrong data). The change is in what we DO NOT do (no wrong persist), not in what we return.
- **Test regression:** None expected — 4 existing FOLLOWUP-12 tests still pass; 1 new test added.
- **Atomicity:** Unchanged — AuditLog INSERT and Tx.status mutation still in the same `transaction_ctx`.
- **Failure mode:** Strategy 2 still applies — AuditLog failure falls back to mutable-state derivation. The terminal-status guard is an additional protection on top of Strategy 2.

## Scope

2 files changed, 139 insertions(+), 5 deletions(-).

## References

- Codex P2 review on PR #2684 (comment_id: 3719709108)
- ADR-0019: `docs/adr/ADR-0019-idempotent-webhook-responses-require-immutable-pre-transition-state.md`
- PR #2684 (merged): FOLLOWUP-12 implementation
- Issue #2679: RFC — architecture decision
