### PR TITLE
ci: upload Playwright failure artifacts (test-results/) for debugging

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -812,6 +812,15 @@ jobs:
         npx playwright test e2e/load/ e2e/chaos/ --project=chromium
       continue-on-error: true  # Non-blocking — load/chaos tests are informational in CI
 
+    - name: рџ“¤ Upload Playwright failure artifacts
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: playwright-failure-artifacts
+        path: frontend/test-results/
+        retention-days: 14
+        if-no-files-found: ignore
+
   # --- Backend тесты ---
   backend-tests:
     name: 🐍 Backend тесты
@@ -2112,6 +2121,7 @@ jobs:
         path: |
           docs/release_gates/telegram_mini_app_release_gate_score.json
           output/playwright/telegram-miniapp-release-gate/
+          frontend/test-results/
         retention-days: 14
         if-no-files-found: warn
 


### PR DESCRIPTION
## Summary

- Adds `frontend/test-results/` to Playwright artifact uploads in two CI jobs, so failed test screenshots, videos, traces, and error-context files are downloadable for debugging.
- **No production code, no test code, no behavior change. Only workflow config — 10 lines added to 1 file.**

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main at `c18566fa`
- Clean workspace: only `.github/workflows/ci-cd-unified.yml` changed
- Branch: `ci/upload-playwright-test-results`
- Scope gate: allowed only the workflow YAML file; denied all code, tests, docs, migrations
- Red-check handling: fix any failed CI check in this same PR before merge

## Contract Impact

not applicable - CI workflow config only. No backend endpoint, websocket event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, or realtime behavior changed.

## Frontend Resilience

not applicable - no frontend code changed. The PR only changes which files are uploaded as CI artifacts after test runs.

## Scope Gate

- Allowed paths: `.github/workflows/ci-cd-unified.yml` (workflow config only)
- Denied paths: all production code, all test code, all docs, migrations, frontend source
- Migration/docs/test impact: no migration; no docs; no test changes
- Rollback note: revert the 1 file; no DB state, no API contract to restore

## Validation

- Targeted tests or smoke run: none — workflow config only, no runtime code to test
- Result: passed — YAML syntax verified locally; artifact paths verified against Playwright config (default outputDir = `test-results/`, not overridden)
- Not checked: full CI run (deferred to CI — this PR IS the CI change)

---

## What changed

### 1. Telegram Mini App Release Gate job (line 2115)

Added `frontend/test-results/` to the existing artifact upload path list:

```yaml
path: |
  docs/release_gates/telegram_mini_app_release_gate_score.json
  output/playwright/telegram-miniapp-release-gate/
  frontend/test-results/          # ← NEW
```

`if-no-files-found: warn` (existing setting) — artifact still uploads the score JSON even if test-results/ is empty on green runs.

### 2. Frontend e2e job (new step, after Load+Chaos E2E)

New step:

```yaml
- name: 📤 Upload Playwright failure artifacts
  if: always()
  uses: actions/upload-artifact@v7
  with:
    name: playwright-failure-artifacts
    path: frontend/test-results/
    retention-days: 14
    if-no-files-found: ignore
```

`if-no-files-found: ignore` — this job runs many e2e suites; if all pass, test-results/ is empty and we don't want a warning.

## Why this matters

When Playwright e2e tests fail, they create diagnostic artifacts:
- `test-failed-1.png` — screenshot at failure point
- `video.webm` — recording of the test run
- `error-context.md` — error summary with page state
- `trace.zip` — Playwright trace (DOM snapshot, network log, console log)

Previously, these were created on the CI runner but **not uploaded** as workflow artifacts. The evidence existed in CI logs (paths were logged) but was discarded when the runner was cleaned up — requiring log archaeology instead of direct artifact inspection.

This was discovered during investigation of the Telegram Mini App Release Gate failure (PR #2687). The failed test artifacts existed in CI logs but were not downloadable.

## Verification: Playwright outputDir

Playwright config (`frontend/playwright.config.js`) does NOT override `outputDir`. Default is `test-results/` relative to the config file location = `frontend/test-results/`.

Config also sets:
- `trace: 'on-first-retry'` — trace.zip created on retry
- `screenshot: 'only-on-failure'` — test-failed-1.png created on failure
- `video: 'retain-on-failure'` — video.webm created on failure

All artifacts land in `frontend/test-results/` — the path added in this PR.

## What is NOT changed (intentionally)

- **No production code** — only workflow YAML
- **No test code** — no spec files modified
- **No Playwright config** — `playwright.config.js` unchanged
- **No timeout changes** — `timeout-minutes: 15` for frontend-e2e remains (separate task to investigate e2e timeout)
- **No concurrency changes** — `cancel-in-progress` settings unchanged

## Scope

1 file changed, 10 insertions(+).

## References

- PR #2687 (merged): Telegram Mini App Release Gate fix — investigation discovered missing artifacts
- Playwright docs: https://playwright.dev/docs/test-reporters#artifact-upload
- GitHub Actions upload-artifact: https://github.com/actions/upload-artifact
