### PR TITLE
🎨 Palette: Add aria-invalid to macOS inputs

### DIFF
--- a/frontend/src/components/ui/macos/Checkbox.tsx
+++ b/frontend/src/components/ui/macos/Checkbox.tsx
@@ -130,6 +130,7 @@ const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>(({
         tabIndex={disabled ? -1 : 0}
         role="checkbox"
         aria-checked={checked}
+        aria-invalid={!!error}
         aria-disabled={disabled}>
 
         <div

--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -174,6 +174,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         className={className}
         style={inputStyle}
         disabled={disabled}
+        aria-invalid={!!error}
         onFocus={handleFocus}
         onBlur={handleBlur}
         {...props}

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -255,6 +255,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           style={trigger}
           aria-haspopup="listbox"
           aria-expanded={isOpen}
+          aria-invalid={!!error}
           disabled={disabled}
           {...props}
         >

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -141,6 +141,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       className={className}
       style={textareaStyles}
       disabled={disabled}
+      aria-invalid={!!error}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}


### PR DESCRIPTION
### 💡 What
Added `aria-invalid={!!error}` to the `Input`, `Textarea`, `Checkbox`, and `Select` components within the `macOS` UI system.

### 🎯 Why
When form fields enter an error state, visually impaired users relying on screen readers need an explicit programmatic cue that the field requires their attention. Binding `aria-invalid` to the component's internal `error` prop explicitly communicates this invalid state to assistive technologies in a standard and compliant way. 

### ♿ Accessibility
* Screen readers will now announce "invalid data" or similar cues when focusing on an input, textarea, checkbox, or select that is in an error state.
* The `aria-invalid` attribute was correctly applied to the outermost semantic interactive element (e.g., `role="checkbox"` for the custom Checkbox and `<button>` for the Select trigger).

---
*PR created automatically by Jules for task [6704178260290064972](https://jules.google.com/task/6704178260290064972) started by @drsapaev*