### PR TITLE
🎨 Palette: Add aria-invalid to macOS form inputs

### DIFF
--- a/frontend/src/components/ui/macos/Checkbox.tsx
+++ b/frontend/src/components/ui/macos/Checkbox.tsx
@@ -130,7 +130,8 @@ const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>(({
         tabIndex={disabled ? -1 : 0}
         role="checkbox"
         aria-checked={checked}
-        aria-disabled={disabled}>
+        aria-disabled={disabled}
+        aria-invalid={!!error}>
 
         <div
           ref={ref}

--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -176,6 +176,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         disabled={disabled}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        aria-invalid={!!error}
         {...props}
       />
       {showClearButton && (

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -255,6 +255,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           style={trigger}
           aria-haspopup="listbox"
           aria-expanded={isOpen}
+          aria-invalid={!!error}
           disabled={disabled}
           {...props}
         >

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -145,6 +145,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}
       rows={minRows}
+      aria-invalid={!!error}
       {...props}
     />
   );


### PR DESCRIPTION
### 💡 What
Added the `aria-invalid={!!error}` attribute to the primary form controls (`Checkbox`, `Input`, `Select`, `Textarea`) within the `macos` UI design system components.

### 🎯 Why
When form validation fails, it's crucial for users relying on assistive technologies (like screen readers) to understand which specific fields require their attention. While the components previously changed their visual borders to red, they did not semantically communicate this error state to screen readers. Adding `aria-invalid` bridges this gap.

### 📸 Before/After
*   **Before:** Form controls only provided visual indicators of error states (e.g., red borders).
*   **After:** Form controls now provide both visual indicators and semantic `aria-invalid` attributes, ensuring accessibility.

### ♿ Accessibility
This change directly improves the accessibility of all forms using these core macOS components by correctly communicating the invalid state of the inputs to screen readers, allowing users to efficiently navigate and correct form errors.

---
*PR created automatically by Jules for task [12799239515188361365](https://jules.google.com/task/12799239515188361365) started by @drsapaev*