### PR TITLE
🎨 Palette: Add `aria-invalid` to form inputs with errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-12 - Missing aria-busy on Complex Loading States
 **Learning:** While buttons effectively communicated their loading states via `aria-busy`, larger container components in the design system (Tables, Lists, Stat Cards) with custom loading skeletons or empty states completely lacked this attribute. This creates a confusing experience for screen reader users who aren't notified when these regions are processing or waiting for data.
 **Action:** Always add `aria-busy="true"` (or `aria-busy={loading}`) to the root container of complex UI components that handle asynchronous data loading, especially when rendering custom loading skeletons or empty states instead of standard UI elements.
+
+## 2024-05-14 - Missing aria-invalid on Form Components
+**Learning:** Native form components support the 'error' state for styling purposes, but failed to pass the aria-invalid attribute to the underlying input elements. This causes screen readers to remain unaware of the invalid state, leading to a poor experience for visually impaired users.
+**Action:** Always add aria-invalid={!!error} to the native form elements in custom wrappers like Input, Textarea, Select, and Checkbox when implementing a custom error state.

--- a/frontend/src/components/ui/macos/Checkbox.tsx
+++ b/frontend/src/components/ui/macos/Checkbox.tsx
@@ -130,7 +130,8 @@ const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>(({
         tabIndex={disabled ? -1 : 0}
         role="checkbox"
         aria-checked={checked}
-        aria-disabled={disabled}>
+        aria-disabled={disabled}
+        aria-invalid={!!error}>
 
         <div
           ref={ref}

--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -174,6 +174,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         className={className}
         style={inputStyle}
         disabled={disabled}
+        aria-invalid={!!error}
         onFocus={handleFocus}
         onBlur={handleBlur}
         {...props}

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -255,6 +255,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           style={trigger}
           aria-haspopup="listbox"
           aria-expanded={isOpen}
+          aria-invalid={!!error}
           disabled={disabled}
           {...props}
         >

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -141,6 +141,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       className={className}
       style={textareaStyles}
       disabled={disabled}
+      aria-invalid={!!error}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}

--- a/update_pr.py
+++ b/update_pr.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+def main():
+    print("Writing PR body update instructions to stdout")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
💡 What: Added `aria-invalid={!!error}` to `Checkbox`, `Input`, `Select`, and `Textarea` form components.
🎯 Why: To properly communicate the error state of form fields to screen readers and assistive technologies.
📸 Before/After: Before, screen readers were not notified when a form field had a validation error. After, the `aria-invalid` attribute correctly communicates the invalid state.
♿ Accessibility: Major accessibility improvement for visually impaired users relying on screen readers to navigate and fill out forms.

---
*PR created automatically by Jules for task [16111210060200967134](https://jules.google.com/task/16111210060200967134) started by @drsapaev*