### PR TITLE
🎨 Palette: Add aria-invalid to custom form controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-12 - Missing aria-busy on Complex Loading States
 **Learning:** While buttons effectively communicated their loading states via `aria-busy`, larger container components in the design system (Tables, Lists, Stat Cards) with custom loading skeletons or empty states completely lacked this attribute. This creates a confusing experience for screen reader users who aren't notified when these regions are processing or waiting for data.
 **Action:** Always add `aria-busy="true"` (or `aria-busy={loading}`) to the root container of complex UI components that handle asynchronous data loading, especially when rendering custom loading skeletons or empty states instead of standard UI elements.
+
+## 2024-08-09 - Missing aria-invalid on Custom Form Controls
+**Learning:** The custom form components (Input, Textarea, Select, Checkbox) visually indicated their error states (e.g., using red borders via a custom `error` prop), but failed to programmatically communicate this invalid state to assistive technologies. Users relying on screen readers wouldn't know a field was invalid.
+**Action:** When creating custom form controls that accept an `error` prop for visual feedback, always ensure `aria-invalid={!!error}` is passed down to the underlying interactive element (`<input>`, `<textarea>`, `<button>`, or the element with `role="checkbox"`).

--- a/frontend/src/components/ui/macos/Checkbox.tsx
+++ b/frontend/src/components/ui/macos/Checkbox.tsx
@@ -130,7 +130,8 @@ const Checkbox = React.forwardRef<HTMLDivElement, CheckboxProps>(({
         tabIndex={disabled ? -1 : 0}
         role="checkbox"
         aria-checked={checked}
-        aria-disabled={disabled}>
+        aria-disabled={disabled}
+        aria-invalid={!!error}>
 
         <div
           ref={ref}

--- a/frontend/src/components/ui/macos/Input.tsx
+++ b/frontend/src/components/ui/macos/Input.tsx
@@ -174,6 +174,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         className={className}
         style={inputStyle}
         disabled={disabled}
+        aria-invalid={!!error}
         onFocus={handleFocus}
         onBlur={handleBlur}
         {...props}

--- a/frontend/src/components/ui/macos/Select.tsx
+++ b/frontend/src/components/ui/macos/Select.tsx
@@ -256,6 +256,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(({
           aria-haspopup="listbox"
           aria-expanded={isOpen}
           disabled={disabled}
+          aria-invalid={!!error}
           {...props}
         >
           <span>{selected ? (selected.label ?? String(selected.value)) : <span style={{ color: 'var(--mac-text-secondary)' }}>{placeholder}</span>}</span>

--- a/frontend/src/components/ui/macos/Textarea.tsx
+++ b/frontend/src/components/ui/macos/Textarea.tsx
@@ -141,6 +141,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({
       className={className}
       style={textareaStyles}
       disabled={disabled}
+      aria-invalid={!!error}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onInput={(e: FormEvent<HTMLTextAreaElement>) => adjustHeight()}


### PR DESCRIPTION
💡 What: Added `aria-invalid={!!error}` to custom form controls (`Input`, `Textarea`, `Select`, `Checkbox`).
🎯 Why: While the components visually indicated errors via red borders, they did not programmatically announce their invalid state to assistive technologies, leaving screen reader users unaware of form validation failures.
📸 Before/After: No visual changes; purely accessibility improvements.
♿ Accessibility: Screen readers will now correctly announce when a field is invalid based on the component's error state.

---
*PR created automatically by Jules for task [1851628878936087342](https://jules.google.com/task/1851628878936087342) started by @drsapaev*