### PR TITLE
🎨 Palette: Add aria-label and title to fullscreen Modal close button

### DIFF
--- a/frontend/src/components/ui/macos/Modal.tsx
+++ b/frontend/src/components/ui/macos/Modal.tsx
@@ -287,6 +287,8 @@ const Modal = ({
           variant="ghost"
           size="small"
           onClick={onClose}
+          aria-label={t('common.close', 'Close')}
+          title={t('common.close', 'Close')}
           style={{
             position: 'absolute',
             top: '12px',

--- a/frontend/src/components/ui/macos/Modal.tsx
+++ b/frontend/src/components/ui/macos/Modal.tsx
@@ -287,8 +287,8 @@ const Modal = ({
           variant="ghost"
           size="small"
           onClick={onClose}
-          aria-label={t('common.close', 'Close')}
-          title={t('common.close', 'Close')}
+          aria-label={t('common.close', { defaultValue: 'Close' })}
+          title={t('common.close', { defaultValue: 'Close' })}
           style={{
             position: 'absolute',
             top: '12px',


### PR DESCRIPTION
**💡 What:** Added `aria-label` and `title` attributes to the icon-only "Close" button in the fullscreen variant of the macOS `Modal` component, utilizing the existing i18n translation key `common.close`.

**🎯 Why:** Icon-only buttons without accessible labels are invisible to screen readers, making it difficult for visually impaired users to close fullscreen modals. Additionally, non-screen reader users benefit from a native tooltip on hover to clarify the button's action.

**📸 Before/After:**
- Before: `<Button>✕</Button>`
- After: `<Button aria-label={t('common.close', 'Close')} title={t('common.close', 'Close')}>✕</Button>`

**♿ Accessibility:**
- Added `aria-label` to provide an accessible name for screen readers.
- Added `title` to provide a native hover tooltip.

---
*PR created automatically by Jules for task [11911772266230487686](https://jules.google.com/task/11911772266230487686) started by @drsapaev*