### PR TITLE
fix(p1-3): Telegram webhook CSRF exemption

### DIFF
--- a/backend/app/middleware/csrf_middleware.py
+++ b/backend/app/middleware/csrf_middleware.py
@@ -85,11 +85,19 @@ SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 # - /health, /healthz, /api/v1/health: unauthenticated probes.
 # - /payments/webhook/*: PayMe/Click/Kaspi callbacks authenticate via
 #   HMAC signatures in Authorization header or body, not cookies.
-# - /telegram/webhook, /telegram/bot/webhook: Telegram Bot API callbacks
-#   authenticate via X-Telegram-Bot-Api-Secret-Token header (constant-time
-#   comparison in _validate_webhook_secret). Server-to-server, not browser.
+# - /telegram/webhook, /telegram/webhook/enhanced, /telegram/bot/webhook:
+#   Telegram Bot API callbacks authenticate via
+#   X-Telegram-Bot-Api-Secret-Token header (constant-time comparison in
+#   _validate_webhook_secret). Server-to-server, not browser.
+#   P1-3 (post-merge stabilization): these are EXACT-match only — NOT
+#   prefix-match. This prevents accidental over-exemption of sibling
+#   admin endpoints like /telegram/webhook/test (which is browser-facing
+#   and requires CSRF protection).
 # - /emergency: break-glass token-based access, not cookie auth.
-CSRF_EXEMPT_PATHS: tuple[str, ...] = (
+#
+# P1-3: paths that are exempted by PREFIX (e.g. /payments/webhook/ is a
+# prefix for /payments/webhook/click, /payments/webhook/payme, etc.).
+CSRF_EXEMPT_PREFIXES: tuple[str, ...] = (
     "/auth/login",
     "/auth/json-login",
     "/auth/refresh",
@@ -99,11 +107,28 @@ CSRF_EXEMPT_PATHS: tuple[str, ...] = (
     "/healthz",
     "/api/v1/health",
     "/api/v1/payments/webhook/",
-    "/api/v1/telegram/webhook",
-    "/api/v1/telegram/bot/webhook",
     "/emergency",
     "/api/v1/emergency",
 )
+
+# P1-3: paths that are exempted by EXACT match only (no prefix matching).
+# These are webhook endpoints that share a path prefix with browser-facing
+# admin endpoints. Using exact match prevents the admin endpoints from
+# accidentally losing CSRF protection.
+#
+# Example: /api/v1/telegram/webhook is a webhook (exempted), but
+# /api/v1/telegram/webhook/test is an admin endpoint (NOT exempted).
+# If we used prefix match, /webhook/test would be incorrectly exempted.
+CSRF_EXEMPT_EXACT: frozenset[str] = frozenset({
+    "/api/v1/telegram/webhook",
+    "/api/v1/telegram/webhook/enhanced",
+    "/api/v1/telegram/bot/webhook",
+})
+
+# Backward compatibility: combined set for any code that still references
+# CSRF_EXEMPT_PATHS. New code should use CSRF_EXEMPT_PREFIXES or
+# CSRF_EXEMPT_EXACT directly.
+CSRF_EXEMPT_PATHS: tuple[str, ...] = CSRF_EXEMPT_PREFIXES
 
 # Cookie name — must match /auth/csrf-token endpoint (auth.py:149).
 CSRF_COOKIE_NAME = "csrf_token"
@@ -149,9 +174,19 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         path = request.url.path
 
         # Exempt paths (login, csrf-token issue, webhooks, health).
-        for exempt in CSRF_EXEMPT_PATHS:
+        # P1-3: prefix-based exemption for paths that are genuinely
+        # hierarchical (e.g. /payments/webhook/click).
+        for exempt in CSRF_EXEMPT_PREFIXES:
             if path == exempt or path.startswith(exempt):
                 return await call_next(request)
+
+        # P1-3: exact-match exemption for webhook endpoints that share
+        # a path prefix with browser-facing admin endpoints. Using exact
+        # match prevents the admin endpoints from accidentally losing
+        # CSRF protection (e.g. /telegram/webhook/test must NOT be
+        # exempted just because /telegram/webhook is).
+        if path in CSRF_EXEMPT_EXACT:
+            return await call_next(request)
 
         # WebSocket upgrade requests — CSRF does not apply; the WS
         # handler validates the JWT via Sec-WebSocket-Protocol

--- a/backend/app/middleware/csrf_middleware.py
+++ b/backend/app/middleware/csrf_middleware.py
@@ -85,6 +85,9 @@ SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 # - /health, /healthz, /api/v1/health: unauthenticated probes.
 # - /payments/webhook/*: PayMe/Click/Kaspi callbacks authenticate via
 #   HMAC signatures in Authorization header or body, not cookies.
+# - /telegram/webhook, /telegram/bot/webhook: Telegram Bot API callbacks
+#   authenticate via X-Telegram-Bot-Api-Secret-Token header (constant-time
+#   comparison in _validate_webhook_secret). Server-to-server, not browser.
 # - /emergency: break-glass token-based access, not cookie auth.
 CSRF_EXEMPT_PATHS: tuple[str, ...] = (
     "/auth/login",
@@ -96,6 +99,8 @@ CSRF_EXEMPT_PATHS: tuple[str, ...] = (
     "/healthz",
     "/api/v1/health",
     "/api/v1/payments/webhook/",
+    "/api/v1/telegram/webhook",
+    "/api/v1/telegram/bot/webhook",
     "/emergency",
     "/api/v1/emergency",
 )

--- a/backend/tests/regression/test_p1_3_csrf_exemption_boundaries.py
+++ b/backend/tests/regression/test_p1_3_csrf_exemption_boundaries.py
@@ -1,0 +1,184 @@
+"""Regression tests for P1-3 CSRF exemption boundaries.
+
+P1-3 (post-merge stabilization): verifies that the CSRF middleware
+correctly exempts Telegram webhook endpoints while NOT exempting
+sibling admin endpoints that share a path prefix.
+
+Security contract:
+- /api/v1/telegram/webhook          → CSRF exempt (server-to-server webhook)
+- /api/v1/telegram/webhook/enhanced → CSRF exempt (server-to-server webhook)
+- /api/v1/telegram/bot/webhook      → CSRF exempt (server-to-server webhook)
+- /api/v1/telegram/webhook/test     → CSRF PROTECTED (browser-facing admin endpoint)
+- /api/v1/telegram/send-message     → CSRF PROTECTED (browser-facing admin endpoint)
+
+The over-exemption bug: before P1-3 fix, the middleware used
+`path.startswith(exempt)` for ALL exempt paths. Adding
+`/api/v1/telegram/webhook` to the exempt list caused
+`/api/v1/telegram/webhook/test` to also be exempted (prefix match),
+even though /webhook/test is an admin endpoint that should have CSRF
+protection.
+
+Fix: split exempt paths into two sets:
+- CSRF_EXEMPT_PREFIXES: prefix-match (e.g. /payments/webhook/ for /click)
+- CSRF_EXEMPT_EXACT: exact-match only (Telegram webhooks)
+
+Run:
+    pytest backend/tests/regression/test_p1_3_csrf_exemption_boundaries.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BACKEND_DIR))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_p1_3_csrf.db")
+os.environ.setdefault("ENV", "dev")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-p1-3-csrf-regression-32")
+os.environ.setdefault("ALLOW_SQLITE_DATABASE_URL", "1")
+os.environ.setdefault("TESTING", "1")
+
+
+@pytest.mark.unit
+class TestCSRFExemptionBoundaries:
+    """P1-3: verify CSRF exemption boundaries for Telegram webhook paths."""
+
+    @pytest.fixture
+    def csrf_client(self):
+        """Create a test client with CSRF middleware enabled."""
+        from app.middleware.csrf_middleware import CSRFMiddleware
+
+        # Build a minimal Starlette app with just the CSRF middleware
+        # and a dummy handler that returns 200 for any POST.
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+
+        async def dummy_handler(request):
+            from starlette.responses import JSONResponse
+            return JSONResponse({"status": "ok"})
+
+        routes = [
+            Route("/api/v1/telegram/webhook", dummy_handler, methods=["POST"]),
+            Route("/api/v1/telegram/webhook/enhanced", dummy_handler, methods=["POST"]),
+            Route("/api/v1/telegram/webhook/test", dummy_handler, methods=["POST"]),
+            Route("/api/v1/telegram/bot/webhook", dummy_handler, methods=["POST"]),
+            Route("/api/v1/telegram/send-message", dummy_handler, methods=["POST"]),
+            Route("/api/v1/payments/webhook/click", dummy_handler, methods=["POST"]),
+        ]
+
+        app = Starlette(routes=routes)
+        app.add_middleware(CSRFMiddleware, enabled=True)
+
+        with TestClient(app) as client:
+            yield client
+
+    def test_telegram_webhook_exempt_from_csrf(self, csrf_client):
+        """POST /api/v1/telegram/webhook without CSRF token → NOT 403.
+
+        This is a server-to-server webhook from Telegram Bot API.
+        It authenticates via X-Telegram-Bot-Api-Secret-Token header,
+        not CSRF tokens.
+        """
+        response = csrf_client.post("/api/v1/telegram/webhook")
+        assert response.status_code != 403, (
+            f"Telegram webhook should be CSRF-exempt, got 403. "
+            f"Response: {response.status_code}"
+        )
+
+    def test_telegram_webhook_enhanced_exempt_from_csrf(self, csrf_client):
+        """POST /api/v1/telegram/webhook/enhanced without CSRF token → NOT 403.
+
+        This is also a server-to-server webhook with its own secret validation.
+        """
+        response = csrf_client.post("/api/v1/telegram/webhook/enhanced")
+        assert response.status_code != 403, (
+            f"Telegram enhanced webhook should be CSRF-exempt, got 403. "
+            f"Response: {response.status_code}"
+        )
+
+    def test_telegram_bot_webhook_exempt_from_csrf(self, csrf_client):
+        """POST /api/v1/telegram/bot/webhook without CSRF token → NOT 403.
+
+        This is the second Telegram webhook endpoint (telegram_bot router).
+        """
+        response = csrf_client.post("/api/v1/telegram/bot/webhook")
+        assert response.status_code != 403, (
+            f"Telegram bot webhook should be CSRF-exempt, got 403. "
+            f"Response: {response.status_code}"
+        )
+
+    def test_telegram_webhook_test_csrf_protected(self, csrf_client):
+        """POST /api/v1/telegram/webhook/test without CSRF token → 403.
+
+        This is a browser-facing admin endpoint (require_roles("Admin")).
+        It must NOT be exempted from CSRF just because it shares a path
+        prefix with /telegram/webhook.
+
+        Before P1-3 fix: this was incorrectly exempted (prefix match).
+        After P1-3 fix: exact match only — /webhook/test is NOT exempted.
+        """
+        response = csrf_client.post("/api/v1/telegram/webhook/test")
+        assert response.status_code == 403, (
+            f"Telegram /webhook/test (admin endpoint) should be CSRF-protected, "
+            f"got {response.status_code}. This is the P1-3 over-exemption bug — "
+            f"the path matches /telegram/webhook as a prefix."
+        )
+
+    def test_telegram_send_message_csrf_protected(self, csrf_client):
+        """POST /api/v1/telegram/send-message without CSRF token → 403.
+
+        This is a browser-facing admin endpoint, not a webhook.
+        """
+        response = csrf_client.post("/api/v1/telegram/send-message")
+        assert response.status_code == 403, (
+            f"Telegram /send-message (admin endpoint) should be CSRF-protected, "
+            f"got {response.status_code}."
+        )
+
+    def test_payments_webhook_prefix_still_works(self, csrf_client):
+        """POST /api/v1/payments/webhook/click without CSRF token → NOT 403.
+
+        The /payments/webhook/ prefix exemption must still work —
+        PayMe/Click/Kaspi callbacks use HMAC signatures, not CSRF tokens.
+        This test verifies that the P1-3 fix did not break the existing
+        prefix-based exemption for payment webhooks.
+        """
+        response = csrf_client.post("/api/v1/payments/webhook/click")
+        assert response.status_code != 403, (
+            f"Payments webhook should be CSRF-exempt (prefix match), got 403. "
+            f"Response: {response.status_code}"
+        )
+
+
+@pytest.mark.unit
+class TestCSRFExemptSets:
+    """P1-3: verify the CSRF_EXEMPT_EXACT set contains exactly the right paths."""
+
+    def test_exact_exempt_set_contains_telegram_webhooks(self):
+        """CSRF_EXEMPT_EXACT must contain exactly the 3 Telegram webhook paths."""
+        from app.middleware.csrf_middleware import CSRF_EXEMPT_EXACT
+
+        assert "/api/v1/telegram/webhook" in CSRF_EXEMPT_EXACT
+        assert "/api/v1/telegram/webhook/enhanced" in CSRF_EXEMPT_EXACT
+        assert "/api/v1/telegram/bot/webhook" in CSRF_EXEMPT_EXACT
+
+    def test_exact_exempt_set_does_not_contain_admin_endpoints(self):
+        """CSRF_EXEMPT_EXACT must NOT contain admin endpoints."""
+        from app.middleware.csrf_middleware import CSRF_EXEMPT_EXACT
+
+        assert "/api/v1/telegram/webhook/test" not in CSRF_EXEMPT_EXACT
+        assert "/api/v1/telegram/send-message" not in CSRF_EXEMPT_EXACT
+
+    def test_prefix_set_does_not_contain_telegram_webhooks(self):
+        """CSRF_EXEMPT_PREFIXES must NOT contain Telegram webhook paths
+        (they are in CSRF_EXEMPT_EXACT, not PREFIXES)."""
+        from app.middleware.csrf_middleware import CSRF_EXEMPT_PREFIXES
+
+        # Telegram webhooks should NOT be in the prefix set
+        assert "/api/v1/telegram/webhook" not in CSRF_EXEMPT_PREFIXES
+        assert "/api/v1/telegram/bot/webhook" not in CSRF_EXEMPT_PREFIXES


### PR DESCRIPTION
## Summary

- P1-3: Telegram webhook CSRF exemption with exact-match boundary.
- Original PR exempted `/api/v1/telegram/webhook` using prefix match, which accidentally over-exempted `/api/v1/telegram/webhook/test` (an admin endpoint).
- Fix: split exempt paths into `CSRF_EXEMPT_PREFIXES` (prefix match) and `CSRF_EXEMPT_EXACT` (exact match only). Telegram webhooks use exact match.
- 9 regression tests added — verify the boundary between exempted webhooks and protected admin endpoints.

## Cyclic Execution Evidence

- Fresh main sync: branch rebased on `origin/main` at `a8eb11f` (PR #2707 merge commit).
- Clean workspace: working tree clean before commit.
- Branch: `fix/p1-3-telegram-webhook-csrf-exempt`
- Scope gate: allowed `backend/app/middleware/csrf_middleware.py` (exemption fix), `backend/tests/regression/test_p1_3_csrf_exemption_boundaries.py` (new tests). Denied unrelated services, frontend, migrations.
- Red-check handling: if any CI check is red, the issue will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: CSRF middleware applies to all POST/PUT/DELETE/PATCH endpoints. The fix changes which paths are exempted from CSRF validation.
- Request shape: unchanged.
- Response shape: unchanged.
- Status codes: `/api/v1/telegram/webhook/test` without CSRF token now returns 403 (was: incorrectly exempted). All other paths unchanged.
- Frontend consumer: none affected — the admin endpoint `/webhook/test` is called from the browser and should include the CSRF token (as all browser-facing endpoints do).
- Compatibility path or alias: none.
- Contract proof: 9 regression tests pin the boundary.

## RBAC / Permissions

- not applicable - no route guard or role helper changed. The CSRF middleware is a security layer that runs before route handlers. The fix corrects the exemption boundary, it does not change RBAC.

## Notification / Realtime

- not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- not applicable - no frontend code changed. The admin endpoint `/webhook/test` already includes CSRF tokens in its requests (via the frontend axios interceptor). The fix ensures the middleware actually validates the token for this endpoint.

## Scope Gate

- Allowed paths: `backend/app/middleware/csrf_middleware.py`, `backend/tests/regression/test_p1_3_csrf_exemption_boundaries.py`.
- Denied paths: unrelated services, frontend, migrations, production logic changes.
- Migration/docs/test impact: no migration; no doc changes; 9 new regression tests.
- Rollback note: revert the commit. No data migration to undo. Reverting restores the over-exemption bug (confirming the fix is necessary).

## Validation

- Targeted tests or smoke run: `tests/regression/test_p1_3_csrf_exemption_boundaries.py` (9 tests).
- Result: 9 passed, 0 failed.
- Not checked: full E2E (the CSRF middleware is tested in isolation; the Telegram webhook endpoints have their own existing tests for secret validation).

## NOT in this PR

- CL-1 migration — separate follow-up.
- P2-1b — separate follow-up.
- P2-3 Finding A/C/F — separate follow-ups.

## Refs

Post-merge stabilization PHASE 13 — P1-3. Follows PR #2707 (P1-1).