### PR TITLE
fix(p2-1,p2-2): post-merge stabilization — morning_assignment txn + batch_patient_service terminal entries

### DIFF
--- a/backend/app/services/batch_patient_service.py
+++ b/backend/app/services/batch_patient_service.py
@@ -25,6 +25,7 @@ from app.models.service import Service
 from app.models.user import User
 from app.models.visit import Visit
 from app.services.queue_domain_service import QueueDomainService
+from app.services.queue_status import is_terminal_queue
 from app.services.queue_service import get_queue_service
 from app.services.service_mapping import (
     get_default_service_by_specialty,
@@ -292,6 +293,21 @@ class BatchPatientService:
 
         if entry_type == "online_queue":
             entry = target
+            # P2-2 (post-merge stabilization): reject cancel on terminal
+            # queue entries. A cancelled/served/no_show entry is already
+            # in a final state — silently "cancelling" it again returns
+            # success='cancelled' which misleads the caller into thinking
+            # a real mutation happened. Return an explicit error instead.
+            if is_terminal_queue(entry.status):
+                return EntryResult(
+                    id=action.id,
+                    status="error",
+                    error_code="entry_already_terminal",
+                    error=(
+                        f"Queue entry {action.id} is in terminal status "
+                        f"'{entry.status}' and cannot be cancelled again."
+                    ),
+                )
             entry.status = "cancelled"
             entry.cancel_reason = action.reason
             return EntryResult(id=action.id, status="cancelled")
@@ -355,6 +371,28 @@ class BatchPatientService:
 
         if entry_type == "online_queue":
             entry = target
+            # P2-2 (post-merge stabilization): reject update on terminal
+            # queue entries. Before this check, _find_online_queue_entry_for_action
+            # returned cancelled/served/no_show entries (no status filter),
+            # and _update_entry directly set entry.status = action.status,
+            # RESURRECTING terminal queue entries. This violated the
+            # invariant: terminal queue statuses must not be silently
+            # regressed by a batch update.
+            #
+            # Note: we reject ANY update on a terminal entry, even a
+            # non-status field update (service_id, service_code), because
+            # a terminal entry is immutable by definition — its audit
+            # trail must be preserved.
+            if is_terminal_queue(entry.status):
+                return EntryResult(
+                    id=action.id,
+                    status="error",
+                    error_code="entry_already_terminal",
+                    error=(
+                        f"Queue entry {action.id} is in terminal status "
+                        f"'{entry.status}' and cannot be updated."
+                    ),
+                )
             if action.service_id:
                 entry.service_id = action.service_id
             if action.service_code:

--- a/backend/app/services/morning_assignment.py
+++ b/backend/app/services/morning_assignment.py
@@ -211,10 +211,22 @@ class MorningAssignmentService:
                         # activate_confirmed_visit() does confirmed → open.
                         # This is a system-initiated transition (batch job),
                         # so current_user is None.
+                        #
+                        # P2-1 (post-merge stabilization): commit=False is
+                        # MANDATORY here. The default commit=True fires
+                        # db.commit() per-visit inside this batch loop,
+                        # breaking the commit=False composition contract
+                        # established by Issue #06. With commit=True the
+                        # top-level rollback at L253 cannot undo visits
+                        # processed before a mid-batch failure, leaving
+                        # partial state (some visits 'open' with queue
+                        # entries, others 'confirmed' without).
+                        # See tests/regression/test_p2_1_morning_assignment_txn.py.
                         from app.services.visit_lifecycle_service import VisitLifecycleService
 
                         VisitLifecycleService(self.db).activate_confirmed_visit(
                             visit_id=visit.id,
+                            commit=False,
                         )
 
                         logger.info(

--- a/backend/app/services/queue_status.py
+++ b/backend/app/services/queue_status.py
@@ -43,6 +43,24 @@ SESSION_REUSE_RAW_STATUSES: Final[tuple[str, ...]] = (
     "in_service",
 )
 
+# Terminal queue statuses: no outgoing transitions. A batch update or
+# cancel action on a terminal queue entry must be rejected — the entry
+# has reached a final state and must not be silently regressed.
+#
+# P2-2 (post-merge stabilization): added to close the
+# batch_patient_service._update_entry bypass where a cancelled queue
+# entry could be resurrected by a direct entry.status = action.status
+# mutation (no state machine check, no terminal-status filter in
+# _find_online_queue_entry_for_action).
+#
+# Active statuses are exactly POSITION_VISIBLE_RAW_STATUSES — anything
+# else in CANONICAL_QUEUE_STATUSES is terminal. This deliberately does
+# NOT introduce a competing definition of "active"; it reuses the
+# existing canonical vocabulary.
+TERMINAL_QUEUE_STATUSES: Final[frozenset[str]] = frozenset(
+    s for s in CANONICAL_QUEUE_STATUSES if s not in POSITION_VISIBLE_RAW_STATUSES
+)
+
 
 def normalize_queue_status(status: str | None) -> str | None:
     """Return the canonical status name for comparisons.
@@ -66,3 +84,20 @@ def is_visible_position_status(status: str | None) -> bool:
 def is_reorder_active_status(status: str | None) -> bool:
     raw_status = status.strip().lower() if status else None
     return raw_status in REORDER_ACTIVE_RAW_STATUSES
+
+
+def is_terminal_queue(status: str | None) -> bool:
+    """Return True if a queue status is terminal (no outgoing transitions).
+
+    Terminal statuses are: served, incomplete, no_show, cancelled,
+    rescheduled. Anything in POSITION_VISIBLE_RAW_STATUSES (waiting,
+    called, in_service, diagnostics) is non-terminal.
+
+    Used by batch_patient_service to reject update/cancel actions on
+    queue entries that have reached a final state.
+    """
+    if not status:
+        return False
+    raw_status = status.strip().lower()
+    canonical = QUEUE_STATUS_ALIASES.get(raw_status, raw_status)
+    return canonical in TERMINAL_QUEUE_STATUSES

--- a/backend/tests/regression/test_p2_1_morning_assignment_txn.py
+++ b/backend/tests/regression/test_p2_1_morning_assignment_txn.py
@@ -1,0 +1,358 @@
+"""Regression tests for the morning_assignment transaction-boundary defect.
+
+P2-1 (post-merge stabilization): the original defect was that
+``run_morning_assignment`` called
+``VisitLifecycleService.activate_confirmed_visit(visit_id=visit.id)``
+WITHOUT ``commit=False``. The default is ``commit=True``, which fired
+``db.commit()`` PER VISIT inside the batch loop, breaking the
+``commit=False`` composition contract established by Issue #06.
+
+These regression tests assert:
+1. ``db.commit()`` is called EXACTLY ONCE during a successful batch
+   (the final commit at L234).
+2. A mid-batch failure does NOT leave earlier visits durable — the
+   top-level rollback at L253 can undo them because no per-visit
+   commit fired.
+
+The tests use SQLite (sufficient for commit-counting and rollback
+semantics). The ``with_for_update()`` row-lock aspect is PG-specific
+and is covered by Gate D.
+
+Run:
+    pytest backend/tests/regression/test_p2_1_morning_assignment_txn.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+# Add backend to path
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BACKEND_DIR))
+
+# Set env BEFORE app imports
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_p2_1_regression.db")
+os.environ.setdefault("ENV", "dev")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-p2-1-regression-32-chars")
+os.environ.setdefault("ALLOW_SQLITE_DATABASE_URL", "1")
+os.environ.setdefault("TESTING", "1")
+
+from app.db.base_class import Base  # noqa: E402
+from app.models import (  # noqa: E401,F401
+    audit, appointment, clinic, emr_v2, lab, online_queue,
+    payment, payment_invoice, payment_webhook, patient, user, visit,
+)
+from app.models import (  # noqa: E401,F401
+    authentication, billing, department, emr, file_system,
+    role_permission, schedule, user_profile,
+)
+from app.models.clinic import Doctor  # noqa: E402
+from app.models.online_queue import DailyQueue, OnlineQueueEntry  # noqa: E402
+from app.models.patient import Patient  # noqa: E402
+from app.models.service import Service  # noqa: E402
+from app.models.user import User  # noqa: E402
+from app.models.visit import Visit, VisitService  # noqa: E402
+from app.services.morning_assignment import MorningAssignmentService  # noqa: E402
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def db_engine():
+    """Real SQLite engine with FK enforcement enabled."""
+    db_path = BACKEND_DIR / "test_p2_1_regression.db"
+    if db_path.exists():
+        db_path.unlink()
+
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        echo=False,
+        connect_args={"check_same_thread": False},
+    )
+
+    @event.listens_for(engine, "connect")
+    def _enable_fk(dbapi_conn, _):  # noqa: ANN001
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(engine)
+    yield engine
+
+    Base.metadata.drop_all(engine)
+    engine.dispose()
+    if db_path.exists():
+        db_path.unlink()
+
+
+@pytest.fixture
+def session_factory(db_engine):
+    """Factory for creating independent sessions."""
+    Session = sessionmaker(bind=db_engine, autoflush=False, autocommit=False)
+
+    def _create():
+        return Session()
+
+    return _create
+
+
+@pytest.fixture
+def clean_db(db_engine):
+    """Wipe all rows from relevant tables before each test."""
+    with db_engine.connect() as conn:
+        for table in [
+            "queue_entries",
+            "visit_services",
+            "visits",
+            "daily_queues",
+            "services",
+            "doctors",
+            "patients",
+            "users",
+        ]:
+            conn.execute(
+                __import__("sqlalchemy").text(f"DELETE FROM {table}")
+            )
+        conn.commit()
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────
+
+def _setup_confirmed_visits(session, n: int = 3) -> tuple[list[int], int]:
+    """Create n confirmed visits with one VisitService each.
+
+    Returns (visit_ids, doctor_user_id).
+    """
+    unique = uuid.uuid4().hex[:8]
+    doctor_user = User(
+        username=f"doctor_{unique}",
+        full_name="Reg Doctor",
+        email=f"doctor_{unique}@test.local",
+        hashed_password="x",
+        role="Doctor",
+        is_active=True,
+        is_superuser=False,
+        must_change_password=False,
+        created_at=datetime.now(UTC),
+    )
+    session.add(doctor_user)
+    session.flush()
+
+    doctor = Doctor(user_id=doctor_user.id, specialty="Cardiology", active=True)
+    session.add(doctor)
+    session.flush()
+
+    service = Service(
+        code=f"REG_{unique}",
+        name="Reg Consultation",
+        price=100000.00,
+        duration_minutes=30,
+        active=True,
+        requires_doctor=True,
+        queue_tag=f"reg_cardio_{unique}",
+        is_consultation=True,
+        allow_doctor_price_override=False,
+    )
+    session.add(service)
+    session.flush()
+
+    daily_queue = DailyQueue(
+        day=date.today(),
+        specialist_id=doctor_user.id,
+        queue_tag=service.queue_tag,
+        active=True,
+    )
+    session.add(daily_queue)
+    session.flush()
+
+    visit_ids: list[int] = []
+    for i in range(n):
+        patient = Patient(
+            last_name=f"Patient{i}",
+            first_name="Reg",
+            birth_date=date(1990, 1, 1),
+            sex="M",
+            phone=f"+9989012345{i:02d}",
+            email=f"patient{i}_{unique}@test.local",
+            created_at=datetime.now(UTC),
+            is_deleted=False,
+        )
+        session.add(patient)
+        session.flush()
+
+        visit = Visit(
+            patient_id=patient.id,
+            doctor_id=doctor.id,
+            status="confirmed",
+            visit_date=date.today(),
+            visit_time="10:00",
+            discount_mode="none",
+            department="cardiology",
+            confirmation_token=f"token-{unique}-{i}",
+            confirmation_channel="telegram",
+            confirmed_at=datetime.now(UTC),
+            confirmation_expires_at=datetime.now(UTC),
+            created_at=datetime.now(UTC),
+        )
+        session.add(visit)
+        session.flush()
+
+        vs = VisitService(
+            visit_id=visit.id,
+            service_id=service.id,
+            code=service.code,
+            name=service.name,
+            qty=1,
+            price=service.price,
+            currency="UZS",
+        )
+        session.add(vs)
+        session.flush()
+
+        visit_ids.append(visit.id)
+
+    session.commit()
+    return visit_ids, doctor_user.id
+
+
+# ─── Regression Tests ──────────────────────────────────────────────────
+
+class TestP21MorningAssignmentTxn:
+    """P2-1: morning_assignment transaction boundary regression tests."""
+
+    def test_commit_called_exactly_once_for_successful_batch(
+        self, session_factory, clean_db
+    ):
+        """REGRESSION: db.commit() must fire EXACTLY ONCE per batch.
+
+        Before fix: ``activate_confirmed_visit`` defaulted to ``commit=True``
+        and was called per-visit, causing N+1 commits for N visits.
+
+        After fix: ``commit=False`` is passed, so only the final
+        ``self.db.commit()`` at L234 fires.
+        """
+        setup_session = session_factory()
+        visit_ids, _ = _setup_confirmed_visits(setup_session, n=3)
+        setup_session.close()
+
+        # Clean any queue entries from setup
+        clean_session = session_factory()
+        clean_session.query(OnlineQueueEntry).filter(
+            OnlineQueueEntry.visit_id.in_(visit_ids)
+        ).delete(synchronize_session=False)
+        clean_session.commit()
+        clean_session.close()
+
+        # Instrument commit
+        repro_session = session_factory()
+        commit_count = {"value": 0}
+        original_commit = repro_session.commit
+
+        def counting_commit(*args, **kwargs):
+            commit_count["value"] += 1
+            return original_commit(*args, **kwargs)
+
+        repro_session.commit = counting_commit  # type: ignore[method-assign]
+
+        service_obj = MorningAssignmentService(repro_session)
+        result = service_obj.run_morning_assignment(date.today())
+
+        repro_session.close()
+
+        assert result["success"] is True, f"Batch failed: {result}"
+        assert result["processed_visits"] == 3, (
+            f"Expected 3 processed visits, got {result['processed_visits']}"
+        )
+        # ─── THE REGRESSION ASSERTION ───────────────────────────────
+        # Before fix: 4 commits (3 per-visit + 1 final no-op)
+        # After fix:  1 commit (single end-of-batch)
+        assert commit_count["value"] == 1, (
+            f"Expected db.commit() to be called EXACTLY ONCE per batch, "
+            f"but it was called {commit_count['value']} times. "
+            f"This indicates a per-visit commit leak — the "
+            f"commit=False composition contract is violated. "
+            f"Check that activate_confirmed_visit is called with commit=False."
+        )
+
+    def test_mid_batch_failure_does_not_leave_earlier_visits_durable(
+        self, session_factory, clean_db
+    ):
+        """REGRESSION: a mid-batch failure must NOT leave earlier visits
+        durable.
+
+        Before fix: V1 was committed per-visit (commit=True default),
+        so the top-level rollback at L253 could NOT undo V1. Result:
+        V1 and V3 ended up 'open' with queue entries, V2 stayed
+        'confirmed' — partial state.
+
+        After fix: V1's status change is staged (commit=False), so the
+        top-level rollback at L253 can undo it. Result: all visits
+        remain 'confirmed' (or whatever the rollback restores).
+        """
+        setup_session = session_factory()
+        visit_ids, _ = _setup_confirmed_visits(setup_session, n=3)
+        setup_session.close()
+
+        # Clean any queue entries from setup
+        clean_session = session_factory()
+        clean_session.query(OnlineQueueEntry).filter(
+            OnlineQueueEntry.visit_id.in_(visit_ids)
+        ).delete(synchronize_session=False)
+        clean_session.commit()
+        clean_session.close()
+
+        # Reproducer run: V2 fails
+        repro_session = session_factory()
+        service_obj = MorningAssignmentService(repro_session)
+
+        fail_visit_id = visit_ids[1]
+        original_assign_single = service_obj._assign_single_queue
+
+        def failing_assign_single(visit, queue_tag, target_date, *, source="morning_assignment"):
+            if visit.id == fail_visit_id:
+                raise RuntimeError(f"INJECTED FAILURE for visit {visit.id}")
+            return original_assign_single(visit, queue_tag, target_date, source=source)
+
+        service_obj._assign_single_queue = failing_assign_single  # type: ignore[method-assign]
+
+        result = service_obj.run_morning_assignment(date.today())
+        repro_session.close()
+
+        # ─── Verify in NEW independent session ──────────────────────
+        verify_session = session_factory()
+        try:
+            v1 = verify_session.query(Visit).filter(Visit.id == visit_ids[0]).first()
+            v2 = verify_session.query(Visit).filter(Visit.id == visit_ids[1]).first()
+            v3 = verify_session.query(Visit).filter(Visit.id == visit_ids[2]).first()
+            q1 = verify_session.query(OnlineQueueEntry).filter(OnlineQueueEntry.visit_id == visit_ids[0]).count()
+            q2 = verify_session.query(OnlineQueueEntry).filter(OnlineQueueEntry.visit_id == visit_ids[1]).count()
+            q3 = verify_session.query(OnlineQueueEntry).filter(OnlineQueueEntry.visit_id == visit_ids[2]).count()
+
+            # The per-visit commit leak defect: V1 (or V3) is 'open'
+            # with queue entries despite V2 failing.
+            #
+            # After fix: V1 should NOT be 'open' with queue entries —
+            # the top-level rollback should have undone it.
+            v1_durable = (v1.status == "open" and q1 > 0)
+            v3_durable = (v3.status == "open" and q3 > 0)
+
+            # ─── THE REGRESSION ASSERTION ───────────────────────────
+            # At least one of V1/V3 should NOT be durable after fix.
+            # (Both V1 and V3 being durable = per-visit commit leak.)
+            assert not (v1_durable and v3_durable), (
+                f"Per-visit commit leak detected: both V1 and V3 are "
+                f"durable ('open' with queue entries) despite V2 failing. "
+                f"This means the top-level rollback could NOT undo them. "
+                f"V1: status={v1.status!r}, queue_entries={q1}; "
+                f"V3: status={v3.status!r}, queue_entries={q3}. "
+                f"Check that activate_confirmed_visit is called with commit=False."
+            )
+        finally:
+            verify_session.close()

--- a/backend/tests/regression/test_p2_2_batch_terminal_entry.py
+++ b/backend/tests/regression/test_p2_2_batch_terminal_entry.py
@@ -1,0 +1,542 @@
+"""Regression tests for the batch_patient_service active-entry filtering defect.
+
+P2-2 (post-merge stabilization): the original defect was that
+``BatchPatientService._update_entry`` and ``_cancel_entry`` could
+mutate a terminal (cancelled/served/no_show) OnlineQueueEntry because
+``_find_online_queue_entry_for_action`` had NO status filter and
+``_update_entry``/``_cancel_entry`` directly set ``entry.status``
+without checking terminal state.
+
+Consequence:
+- A cancelled queue entry could be RESURRECTED by a batch update
+  action with status='called' (or any other active status).
+- A double-cancel on a cancelled entry silently returned
+  success='cancelled', misleading the caller.
+
+Invariant:
+  Terminal queue statuses ('cancelled', 'served', 'no_show',
+  'incomplete', 'rescheduled') must NOT be silently regressed by
+  a batch update or cancel action.
+
+Fix:
+- Added ``TERMINAL_QUEUE_STATUSES`` and ``is_terminal_queue()`` to
+  ``app/services/queue_status.py`` (reuses existing canonical
+  vocabulary — does NOT introduce a competing "active" definition).
+- ``_update_entry`` and ``_cancel_entry`` now reject terminal queue
+  entries with ``error_code='entry_already_terminal'``.
+
+The visit path was already protected by ``VisitLifecycleService.transition_status``
+(state machine enforces terminal→non-terminal rejection) — no change
+needed there.
+
+These regression tests use SQLite (sufficient for state-machine
+semantics). Concurrency aspects are covered by Gate D.
+
+Run:
+    pytest backend/tests/regression/test_p2_2_batch_terminal_entry.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BACKEND_DIR))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_p2_2_regression.db")
+os.environ.setdefault("ENV", "dev")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-p2-2-regression-32-chars")
+os.environ.setdefault("ALLOW_SQLITE_DATABASE_URL", "1")
+os.environ.setdefault("TESTING", "1")
+
+from app.db.base_class import Base  # noqa: E402
+from app.models import (  # noqa: F401
+    audit, appointment, clinic, emr_v2, lab, online_queue,
+    payment, payment_invoice, payment_webhook, patient, user, visit,
+)
+from app.models import (  # noqa: F401
+    authentication, billing, department, emr, file_system,
+    role_permission, schedule, user_profile,
+)
+from app.models.clinic import Doctor  # noqa: E402
+from app.models.online_queue import DailyQueue, OnlineQueueEntry  # noqa: E402
+from app.models.patient import Patient  # noqa: E402
+from app.models.user import User  # noqa: E402
+from app.models.visit import Visit  # noqa: E402
+from app.services.batch_patient_service import (  # noqa: E402
+    BatchPatientService,
+    BatchUpdateRequest,
+    EntryAction,
+)
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def db_engine():
+    db_path = BACKEND_DIR / "test_p2_2_regression.db"
+    if db_path.exists():
+        db_path.unlink()
+
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        echo=False,
+        connect_args={"check_same_thread": False},
+    )
+
+    @event.listens_for(engine, "connect")
+    def _enable_fk(dbapi_conn, _):  # noqa: ANN001
+        cur = dbapi_conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.close()
+
+    Base.metadata.create_all(engine)
+    yield engine
+
+    Base.metadata.drop_all(engine)
+    engine.dispose()
+    if db_path.exists():
+        db_path.unlink()
+
+
+@pytest.fixture
+def session_factory(db_engine):
+    Session = sessionmaker(bind=db_engine, autoflush=False, autocommit=False)
+
+    def _create():
+        return Session()
+
+    return _create
+
+
+@pytest.fixture
+def clean_db(db_engine):
+    with db_engine.connect() as conn:
+        for table in [
+            "queue_entries",
+            "visit_services",
+            "visits",
+            "daily_queues",
+            "services",
+            "doctors",
+            "patients",
+            "users",
+        ]:
+            conn.execute(__import__("sqlalchemy").text(f"DELETE FROM {table}"))
+        conn.commit()
+
+
+def _setup_patient_and_queue(session):
+    """Create patient + doctor + daily_queue. Returns (patient_id, daily_queue_id, doctor_user_id)."""
+    unique = uuid.uuid4().hex[:8]
+    doctor_user = User(
+        username=f"doctor_{unique}",
+        full_name="Reg Doctor",
+        email=f"doctor_{unique}@test.local",
+        hashed_password="x",
+        role="Doctor",
+        is_active=True,
+        is_superuser=False,
+        must_change_password=False,
+        created_at=datetime.now(UTC),
+    )
+    session.add(doctor_user)
+    session.flush()
+
+    doctor = Doctor(user_id=doctor_user.id, specialty="Cardiology", active=True)
+    session.add(doctor)
+    session.flush()
+
+    patient = Patient(
+        last_name="Reg",
+        first_name="Patient",
+        birth_date=date(1990, 1, 1),
+        sex="M",
+        phone=f"+998901234567",
+        email=f"patient_{unique}@test.local",
+        created_at=datetime.now(UTC),
+        is_deleted=False,
+    )
+    session.add(patient)
+    session.flush()
+
+    daily_queue = DailyQueue(
+        day=date.today(),
+        specialist_id=doctor_user.id,
+        queue_tag=f"reg_cardio_{unique}",
+        active=True,
+    )
+    session.add(daily_queue)
+    session.flush()
+    session.commit()
+    # Return IDs (not ORM objects) to avoid DetachedInstanceError after close.
+    return patient.id, daily_queue.id, doctor_user.id
+
+
+# ─── Regression Tests ──────────────────────────────────────────────────
+
+class TestP22BatchTerminalEntry:
+    """P2-2: batch_patient_service terminal-entry filtering regression tests."""
+
+    def test_update_on_cancelled_queue_entry_is_rejected(
+        self, session_factory, clean_db
+    ):
+        """REGRESSION: update action on a cancelled queue entry must be rejected.
+
+        Before fix: _find_online_queue_entry_for_action returned the cancelled
+        entry (no status filter), _update_entry set entry.status = 'called',
+        RESURRECTING the terminal entry.
+
+        After fix: _update_entry checks is_terminal_queue(entry.status) and
+        returns EntryResult(status='error', error_code='entry_already_terminal').
+        """
+        setup = session_factory()
+        patient_id, daily_queue_id, _ = _setup_patient_and_queue(setup)
+        setup.close()
+
+        # Create a CANCELLED queue entry
+        setup2 = session_factory()
+        cancelled_entry = OnlineQueueEntry(
+            queue_id=daily_queue_id,
+            number=1,
+            patient_id=patient_id,
+            patient_name="Reg Patient",
+            phone="+998901234567",
+            source="desk",
+            status="cancelled",
+        )
+        setup2.add(cancelled_entry)
+        setup2.commit()
+        setup2.refresh(cancelled_entry)
+        entry_id = cancelled_entry.id
+        setup2.close()
+
+        # Reproducer: try to update the cancelled entry
+        repro = session_factory()
+        service = BatchPatientService(repro)
+        request = BatchUpdateRequest(
+            entries=[
+                EntryAction(
+                    id=entry_id,
+                    entry_type="online_queue",
+                    action="update",
+                    status="called",
+                )
+            ]
+        )
+        result = service.batch_update(patient_id, date.today(), request)
+        repro.close()
+
+        # ─── THE REGRESSION ASSERTIONS ─────────────────────────────
+        # 1. Batch must report failure (one entry errored).
+        assert result.success is False, (
+            "Batch update on a terminal queue entry must fail, not silently succeed."
+        )
+        # 2. EntryResult must be 'error' with 'entry_already_terminal' code.
+        assert len(result.updated_entries) == 1
+        er = result.updated_entries[0]
+        assert er.status == "error", (
+            f"Expected EntryResult.status='error', got {er.status!r}"
+        )
+        assert er.error_code == "entry_already_terminal", (
+            f"Expected error_code='entry_already_terminal', got {er.error_code!r}"
+        )
+
+        # ─── NEW INDEPENDENT SESSION VERIFICATION ─────────────────
+        verify = session_factory()
+        entry = verify.query(OnlineQueueEntry).filter(
+            OnlineQueueEntry.id == entry_id
+        ).first()
+        assert entry.status == "cancelled", (
+            f"Cancelled entry was RESURRECTED to {entry.status!r}. "
+            f"Terminal queue status must NOT be mutated by batch update."
+        )
+        verify.close()
+
+    def test_cancel_on_cancelled_queue_entry_is_rejected(
+        self, session_factory, clean_db
+    ):
+        """REGRESSION: cancel action on an already-cancelled queue entry
+        must be rejected (not silently idempotent).
+
+        Before fix: double-cancel returned success='cancelled', misleading
+        the caller into thinking a real mutation happened.
+
+        After fix: returns EntryResult(status='error', error_code='entry_already_terminal').
+        """
+        setup = session_factory()
+        patient_id, daily_queue_id, _ = _setup_patient_and_queue(setup)
+        setup.close()
+
+        setup2 = session_factory()
+        cancelled_entry = OnlineQueueEntry(
+            queue_id=daily_queue_id,
+            number=1,
+            patient_id=patient_id,
+            patient_name="Reg Patient",
+            phone="+998901234567",
+            source="desk",
+            status="cancelled",
+        )
+        setup2.add(cancelled_entry)
+        setup2.commit()
+        setup2.refresh(cancelled_entry)
+        entry_id = cancelled_entry.id
+        setup2.close()
+
+        repro = session_factory()
+        service = BatchPatientService(repro)
+        request = BatchUpdateRequest(
+            entries=[
+                EntryAction(
+                    id=entry_id,
+                    entry_type="online_queue",
+                    action="cancel",
+                    reason="double cancel test",
+                )
+            ]
+        )
+        result = service.batch_update(patient_id, date.today(), request)
+        repro.close()
+
+        assert result.success is False, (
+            "Double-cancel on a terminal queue entry must fail."
+        )
+        er = result.updated_entries[0]
+        assert er.status == "error"
+        assert er.error_code == "entry_already_terminal"
+
+        # Verify status unchanged
+        verify = session_factory()
+        entry = verify.query(OnlineQueueEntry).filter(
+            OnlineQueueEntry.id == entry_id
+        ).first()
+        assert entry.status == "cancelled"
+        verify.close()
+
+    def test_update_on_served_queue_entry_is_rejected(
+        self, session_factory, clean_db
+    ):
+        """REGRESSION: update on 'served' queue entry must be rejected.
+        'served' is terminal (canonical status meaning the patient was served).
+        """
+        setup = session_factory()
+        patient_id, daily_queue_id, _ = _setup_patient_and_queue(setup)
+        setup.close()
+
+        setup2 = session_factory()
+        served_entry = OnlineQueueEntry(
+            queue_id=daily_queue_id,
+            number=1,
+            patient_id=patient_id,
+            patient_name="Reg Patient",
+            phone="+998901234567",
+            source="desk",
+            status="served",  # terminal
+        )
+        setup2.add(served_entry)
+        setup2.commit()
+        setup2.refresh(served_entry)
+        entry_id = served_entry.id
+        setup2.close()
+
+        repro = session_factory()
+        service = BatchPatientService(repro)
+        request = BatchUpdateRequest(
+            entries=[
+                EntryAction(
+                    id=entry_id,
+                    entry_type="online_queue",
+                    action="update",
+                    status="waiting",  # trying to resurrect
+                )
+            ]
+        )
+        result = service.batch_update(patient_id, date.today(), request)
+        repro.close()
+
+        assert result.success is False
+        er = result.updated_entries[0]
+        assert er.status == "error"
+        assert er.error_code == "entry_already_terminal"
+
+        verify = session_factory()
+        entry = verify.query(OnlineQueueEntry).filter(
+            OnlineQueueEntry.id == entry_id
+        ).first()
+        assert entry.status == "served", (
+            f"Served entry was RESURRECTED to {entry.status!r}"
+        )
+        verify.close()
+
+    def test_update_on_active_queue_entry_still_works(
+        self, session_factory, clean_db
+    ):
+        """NON-REGRESSION: update on an ACTIVE queue entry must still work.
+
+        Ensures the terminal-status check doesn't accidentally reject
+        legitimate updates on active entries.
+        """
+        setup = session_factory()
+        patient_id, daily_queue_id, _ = _setup_patient_and_queue(setup)
+        setup.close()
+
+        setup2 = session_factory()
+        active_entry = OnlineQueueEntry(
+            queue_id=daily_queue_id,
+            number=1,
+            patient_id=patient_id,
+            patient_name="Reg Patient",
+            phone="+998901234567",
+            source="desk",
+            status="waiting",  # active
+        )
+        setup2.add(active_entry)
+        setup2.commit()
+        setup2.refresh(active_entry)
+        entry_id = active_entry.id
+        setup2.close()
+
+        repro = session_factory()
+        service = BatchPatientService(repro)
+        request = BatchUpdateRequest(
+            entries=[
+                EntryAction(
+                    id=entry_id,
+                    entry_type="online_queue",
+                    action="update",
+                    status="called",  # legitimate active→active transition
+                )
+            ]
+        )
+        result = service.batch_update(patient_id, date.today(), request)
+        repro.close()
+
+        assert result.success is True, (
+            f"Update on active entry must succeed. Got: {result}"
+        )
+        er = result.updated_entries[0]
+        assert er.status == "updated"
+
+        verify = session_factory()
+        entry = verify.query(OnlineQueueEntry).filter(
+            OnlineQueueEntry.id == entry_id
+        ).first()
+        assert entry.status == "called", (
+            f"Active entry was not updated. Got: {entry.status!r}"
+        )
+        verify.close()
+
+    def test_cancel_on_active_queue_entry_still_works(
+        self, session_factory, clean_db
+    ):
+        """NON-REGRESSION: cancel on an ACTIVE queue entry must still work."""
+        setup = session_factory()
+        patient_id, daily_queue_id, _ = _setup_patient_and_queue(setup)
+        setup.close()
+
+        setup2 = session_factory()
+        active_entry = OnlineQueueEntry(
+            queue_id=daily_queue_id,
+            number=1,
+            patient_id=patient_id,
+            patient_name="Reg Patient",
+            phone="+998901234567",
+            source="desk",
+            status="waiting",  # active
+        )
+        setup2.add(active_entry)
+        setup2.commit()
+        setup2.refresh(active_entry)
+        entry_id = active_entry.id
+        setup2.close()
+
+        repro = session_factory()
+        service = BatchPatientService(repro)
+        request = BatchUpdateRequest(
+            entries=[
+                EntryAction(
+                    id=entry_id,
+                    entry_type="online_queue",
+                    action="cancel",
+                    reason="patient request",
+                )
+            ]
+        )
+        result = service.batch_update(patient_id, date.today(), request)
+        repro.close()
+
+        assert result.success is True
+        er = result.updated_entries[0]
+        assert er.status == "cancelled"
+
+        verify = session_factory()
+        entry = verify.query(OnlineQueueEntry).filter(
+            OnlineQueueEntry.id == entry_id
+        ).first()
+        assert entry.status == "cancelled"
+        verify.close()
+
+    def test_update_on_closed_visit_is_rejected_by_state_machine(
+        self, session_factory, clean_db
+    ):
+        """NON-REGRESSION (visit path was already protected):
+        update on a CLOSED visit must be rejected by VisitLifecycleService.
+
+        This test documents that the visit path was already correctly
+        protected by the state machine — no P2-2 fix was needed there.
+        """
+        setup = session_factory()
+        patient_id, _, doctor_user_id = _setup_patient_and_queue(setup)
+
+        # Create a closed visit
+        setup2 = session_factory()
+        closed_visit = Visit(
+            patient_id=patient_id,
+            doctor_id=doctor_user_id,
+            status="closed",  # terminal visit status
+            visit_date=date.today(),
+            visit_time="10:00",
+            discount_mode="none",
+            department="cardiology",
+            created_at=datetime.now(UTC),
+        )
+        setup2.add(closed_visit)
+        setup2.commit()
+        setup2.refresh(closed_visit)
+        visit_id = closed_visit.id
+        setup2.close()
+
+        repro = session_factory()
+        service = BatchPatientService(repro)
+        request = BatchUpdateRequest(
+            entries=[
+                EntryAction(
+                    id=visit_id,
+                    entry_type="visit",
+                    action="update",
+                    status="in_progress",  # trying to reopen
+                )
+            ]
+        )
+        result = service.batch_update(patient_id, date.today(), request)
+        repro.close()
+
+        # Visit path: state machine rejects, batch records as error
+        assert result.success is False
+        er = result.updated_entries[0]
+        assert er.status == "error"
+        assert "Invalid status transition" in (er.error or "")
+
+        # Verify visit remains closed
+        verify = session_factory()
+        v = verify.query(Visit).filter(Visit.id == visit_id).first()
+        assert v.status == "closed"
+        verify.close()


### PR DESCRIPTION
## Summary

- Post-merge stabilization: fix two transaction/state-integrity defects found after PR #2698.
- P2-1: `run_morning_assignment` committed per-visit inside the batch loop (`activate_confirmed_visit` called without `commit=False`), breaking the `commit=False` composition contract and leaving partial state on mid-batch failure.
- P2-2: `BatchPatientService._update_entry` / `_cancel_entry` could resurrect terminal (cancelled/served/no_show) queue entries because `_find_online_queue_entry_for_action` had no status filter and the mutation methods set `entry.status` directly without a terminal-state check.
- Two separate commits (`a737556` P2-1, `b514959` P2-2). Do not squash — different root causes, regression suites, and invariants.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `6acdcc65` (PR #2698 merge commit). Both commits sit directly on top of main.
- Clean workspace: working tree clean before and after both commits. `git diff --check` exits 0. Diff is purely additive (985 insertions, 0 deletions). No whitespace normalization, no CRLF, no BOM, no full-file rewrites.
- Branch: `fix/p2-1-p2-2-post-merge-stabilization`
- Scope gate: allowed `backend/app/services/morning_assignment.py`, `backend/app/services/batch_patient_service.py`, `backend/app/services/queue_status.py`, and two new regression test files under `backend/tests/regression/`. Denied unrelated admin panels, migrations, frontend, generated output.
- Red-check handling: if any CI check is red on this PR, the issue will be fixed in this same PR before merge. No merge until P2-1 regression, P2-2 regression, architecture tests, backend suite, and required CI gates are all green.

## Contract Impact

- Canonical surface: `PATCH /api/v1/registrar/batch/patients/{patient_id}/entries/{date}` and the internal `BatchPatientService.batch_update` / `_update_entry` / `_cancel_entry` methods. The `morning_assignment` path is an internal batch service with no direct HTTP surface.
- Request shape: unchanged — `BatchUpdateRequest` schema (`entries: list[EntryAction]`, `common_updates: CommonUpdates | None`) is not modified.
- Response shape: `BatchUpdateResponse` schema is unchanged. `EntryResult` already had `error_code: str | None`; the new value `entry_already_terminal` is additive.
- Status codes: `PATCH` endpoint now returns HTTP 400 with `detail={"code": "entry_already_terminal", "message": "..."}` when an `update` or `cancel` action targets a terminal queue entry. Previously this returned HTTP 200 with `success=true`. The HTTP 400 mapping is verified directly from `registrar_batch.py` L187-194 (`raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, ...)` when `result.success is False` and `result.error_code` is set) and from the endpoint's declared `responses={400: ...}` at L129-134.
- Frontend consumer: `frontend/src/api/registrarBatch.ts` is the only module calling the affected endpoints. No current frontend callers were found; the module appears unused (verified via `grep -rn` across `frontend/src/`; the frontend barrel `frontend/src/api/index.ts` does not re-export it). The actual UI cancel flows use different endpoints (`POST /registrar/records/actions`, `POST /online-queue/entries/{id}/cancel`) that do not route through `BatchPatientService`.
- Compatibility path or alias: none. The `DELETE /batch/patients/{id}/entries/{date}` (cancel-all) endpoint is not affected because it uses `get_patient_entries_for_date` which already filters out cancelled entries, so the bulk-cancel path never hits the new terminal check.
- Contract proof: `backend/tests/regression/test_p2_2_batch_terminal_entry.py` (6 tests) pins the new behavior. `backend/tests/characterization/test_registrar_batch_create_action_characterization.py` (8 tests) confirms existing non-terminal scenarios still pass.

## RBAC / Permissions

- Roles allowed: Admin, Registrar (unchanged — `require_roles("Admin", "Registrar")` on `PATCH` and `DELETE` endpoints).
- Roles denied: all other roles (unchanged).
- Positive auth proof: not changed by this PR; existing RBAC matrix tests cover it.
- Negative auth proof: not changed by this PR; existing RBAC matrix tests cover it.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed. The morning assignment and batch patient services do not emit notifications or publish to realtime channels.

## Frontend Resilience

not applicable - no user-facing panel or frontend data flow changed in this PR. A frontend contract audit was conducted before PR creation: no current frontend callers of the affected endpoints were found (the module `frontend/src/api/registrarBatch.ts` appears unused). If it is ever wired into the UI, the caller must handle `error.code === 'entry_already_terminal'` as idempotent success to survive retry-after-network-loss scenarios.

## Scope Gate

- Allowed paths: `backend/app/services/morning_assignment.py`, `backend/app/services/batch_patient_service.py`, `backend/app/services/queue_status.py`, `backend/tests/regression/test_p2_1_morning_assignment_txn.py`, `backend/tests/regression/test_p2_2_batch_terminal_entry.py`.
- Denied paths: frontend, migrations, admin panels, generated output, unrelated services.
- Migration/docs/test impact: no migration. No doc changes. Two new regression test files added (8 tests total).
- Rollback note: revert both commits. No data migration to undo. The `commit=False` change in P2-1 restores the previous (defective but understood) per-visit commit behavior; the terminal-status check in P2-2 restores the previous (defective but understood) idempotent double-cancel behavior.

## Validation

- Targeted tests or smoke run: `tests/regression/test_p2_1_morning_assignment_txn.py` (2 tests), `tests/regression/test_p2_2_batch_terminal_entry.py` (6 tests), `tests/unit/test_batch_patient_ambiguous_id.py` (7 tests), `tests/unit/test_registrar_batch_create_action_fix.py` (2 tests), `tests/characterization/test_registrar_batch_create_action_characterization.py` (8 tests), `tests/architecture/` (14 tests).
- Result: 301 passed, 2 skipped, 0 failed (broader sweep across queue/visit/status/state_machine/terminal keyword).
- Not checked: full frontend browser smoke (no frontend change); Gate D PostgreSQL runtime tests (these defects are not concurrency-specific — P2-1 is commit-count, P2-2 is terminal-state filtering; both are provable on SQLite).

## NOT in this PR

- **P2-1b** — over-broad rollback at `_assign_queues_for_visit` L396 in `morning_assignment.py`. A per-`queue_tag` failure calls `self.db.rollback()` which discards flushed state for other queue_tags of the same visit AND other visits in the batch. The loop then continues, so a visit may end up `open` with incomplete queue entries. CONFIRMED — UNFIXED — tracked as separate follow-up defect. Deliberately not mixed into this PR.