### PR TITLE
test(th-1): D4/D4b harness hardening — no silent worker disappearance

### DIFF
--- a/backend/tests/integration/test_gate_d.py
+++ b/backend/tests/integration/test_gate_d.py
@@ -460,6 +460,19 @@ def test_d4_concurrent_payment_creation_no_duplicate(db_engine, new_session_fact
             f"results: {results}"
         )
 
+    # TH-1 (post-merge stabilization): harness hardening.
+    # Every worker MUST record a result — "worker disappeared → test treats
+    # it as success" must NEVER happen. If a worker was silently aborted
+    # (e.g. GreenletExit from SQLAlchemy/greenlet pool without entering the
+    # BaseException handler), results would have fewer than 2 entries and
+    # the primary invariant could pass while hiding a harness defect.
+    assert len(results) == 2, (
+        f"D4 FAILED [harness]: expected 2 worker results, got {len(results)}. "
+        f"A worker may have disappeared without recording a result. "
+        f"Results: {results}. "
+        f"t1 alive: {t1.is_alive()}, t2 alive: {t2.is_alive()}"
+    )
+
     # PRIMARY invariant: at most 1 Payment in DB (no duplicate financial state)
     # This is the real invariant — the exact number of successes/rejections
     # depends on thread scheduling and is non-deterministic.
@@ -588,7 +601,11 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                 reason = e.detail[:100]
             with results_lock:
                 results.append(("create_payment", "rejected", e.status_code, reason))
-        except Exception as e:
+        except BaseException as e:
+            # TH-1 (post-merge stabilization): catch BaseException (not just
+            # Exception) to capture greenlet.GreenletExit, SystemExit, etc.
+            # A worker that disappears via GreenletExit without recording a
+            # result would hide a harness defect.
             with results_lock:
                 results.append(("create_payment", "error", type(e).__name__, str(e)[:200]))
         finally:
@@ -631,7 +648,8 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                 reason = e.detail[:100]
             with results_lock:
                 results.append(("mark_paid", "rejected", e.status_code, reason))
-        except Exception as e:
+        except BaseException as e:
+            # TH-1: catch BaseException to capture GreenletExit etc.
             session.rollback()
             with results_lock:
                 results.append(("mark_paid", "error", type(e).__name__, str(e)[:200]))
@@ -644,6 +662,20 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
     t2.start()
     t1.join(timeout=30)
     t2.join(timeout=30)
+
+    # TH-1 (post-merge stabilization): harness hardening.
+    # Every worker MUST record a result — "worker disappeared → test treats
+    # it as success" must NEVER happen. Both workers now catch BaseException
+    # (not just Exception) so GreenletExit/SystemExit are recorded. If a
+    # worker still disappeared without recording, results would have < 2
+    # entries and this assertion would fail — preventing a silent harness
+    # defect from being masked by a passing primary invariant.
+    assert len(results) == 2, (
+        f"D4b FAILED [harness]: expected 2 worker results, got {len(results)}. "
+        f"A worker may have disappeared without recording a result. "
+        f"Results: {results}. "
+        f"t1 alive: {t1.is_alive()}, t2 alive: {t2.is_alive()}"
+    )
 
     # ─── Primary Persisted Assertions (from NEW independent session) ──
 

--- a/backend/tests/integration/test_gate_d.py
+++ b/backend/tests/integration/test_gate_d.py
@@ -395,53 +395,39 @@ def test_d4_concurrent_payment_creation_no_duplicate(db_engine, new_session_fact
 
     barrier = threading.Barrier(2)  # ensure both threads start simultaneously
     results = []
-    results_lock = threading.Lock()
 
-    def make_payment(thread_id="T"):
-        """Each thread gets its OWN Session. ALWAYS records a result.
+    # TH-1 P1 follow-up: ThreadPoolExecutor rewrite.
+    #
+    # The previous threading.Thread + shared-results-list + results_lock
+    # approach had a critical flaw: if the worker raised BaseException
+    # (e.g. GreenletExit), the except handler tried to acquire results_lock
+    # to record the result — but a SECOND BaseException during lock
+    # acquisition would cause the worker to disappear without recording.
+    # The main thread could not distinguish "worker crashed" from
+    # "worker succeeded" because the original exception was lost.
+    #
+    # ThreadPoolExecutor fixes this: WorkItem.run() catches BaseException
+    # and stores it in the Future. future.result() re-raises it in the
+    # main thread WITH FULL TRACEBACK. The worker function does NOT
+    # catch exceptions — it lets them propagate.
+    #
+    # This gives us three possible outcomes:
+    #   Case A: GreenletExit → investigate stack/traceback
+    #   Case B: Application exception (IntegrityError, OperationalError,
+    #           HTTPException, ValueError) → investigate production path
+    #   Case C: Both workers complete normally → harness artifact confirmed
 
-        TH-1 hardening (P1 follow-up per Codex review):
+    def make_payment(thread_id):
+        """Worker function. Does NOT catch exceptions.
 
-        Result tuple semantics (first element is the status):
-        - ("success", payment_id) — worker completed normally.
-        - ("rejected", status_code, reason) — EXPECTED HTTPException
-          (e.g. 409 from lock contention, 400 from validation). This
-          is a legitimate business-level rejection; the test can PASS.
-        - ("error", exception_type, message) — UNEXPECTED BaseException
-          (GreenletExit, SystemExit, RuntimeError, SQLAlchemyError,
-          etc.). The worker CRASHED. The test MUST FAIL.
-        - ("no_result_recorded", thread_id, message) — the worker
-          disappeared without entering any handler that records a
-          result. The test MUST FAIL.
-
-        The post-thread crash assertion rejects any result whose first
-        element is "error" or "no_result_recorded", so a worker crash
-        can NEVER produce a PASS.
+        Returns ("success", payment_id) on success.
+        Raises HTTPException on expected rejection (lock contention).
+        Lets any other exception propagate for diagnosis via
+        future.result().
         """
-        import sys as _sys
-
-        def _record(result_tuple) -> bool:
-            """Record a result. Returns True if recording succeeded.
-
-            TH-1: returns bool so the caller's `recorded` flag reflects
-            whether the result was actually persisted, not just whether
-            the handler was entered.
-            """
-            try:
-                with results_lock:
-                    results.append(result_tuple)
-                return True
-            except BaseException:
-                return False  # never let recording itself raise
-
-        print(f"D4 [{thread_id}]: starting", file=_sys.stderr, flush=True)
-        session = None
-        recorded = False
+        barrier.wait(timeout=10)
+        session = sessionmaker(bind=db_engine)()
         try:
-            barrier.wait(timeout=10)
-            print(f"D4 [{thread_id}]: barrier passed", file=_sys.stderr, flush=True)
-            session = sessionmaker(bind=db_engine)()
-            print(f"D4 [{thread_id}]: session created, calling create_payment", file=_sys.stderr, flush=True)
             payment = PaymentInvariantService(session).create_payment_for_visit(
                 visit_id=visit_id,
                 amount=Decimal("10000"),
@@ -450,83 +436,53 @@ def test_d4_concurrent_payment_creation_no_duplicate(db_engine, new_session_fact
                 current_user=type("U", (), {"id": 1})(),
                 commit=True,
             )
-            print(f"D4 [{thread_id}]: payment created id={payment.id}", file=_sys.stderr, flush=True)
-            recorded = _record(("success", payment.id))
-        except HTTPException as e:
-            reason = ""
-            if isinstance(e.detail, dict):
-                reason = e.detail.get("reason", "")
-            elif isinstance(e.detail, str):
-                reason = e.detail[:100]
-            recorded = _record(("rejected", e.status_code, reason))
-            print(f"D4 [{thread_id}]: HTTPException {e.status_code} reason={reason}", file=_sys.stderr, flush=True)
-        except BaseException as e:
-            # TH-1: catch BaseException (not just Exception) to capture
-            # greenlet.GreenletExit, SystemExit, etc. These are UNEXPECTED
-            # worker crashes — record as "error" (NOT "rejected") so the
-            # post-thread crash assertion FAILS the test.
-            #
-            # Record FIRST (before any print), so a second exception
-            # during logging does not lose the result.
-            recorded = _record(("error", type(e).__name__, str(e)[:200]))
-            print(f"D4 [{thread_id}]: BaseException {type(e).__name__}: {e}", file=_sys.stderr, flush=True)
+            return ("success", payment.id)
         finally:
-            if session is not None:
-                try:
-                    session.close()
-                except Exception:
-                    pass
-            # TH-1: if no result was recorded (e.g. exception during
-            # barrier.wait or session creation, OR _record() itself failed),
-            # record a fallback. This is "no_result_recorded" — the test
-            # MUST FAIL because the worker effectively disappeared.
-            if not recorded:
-                _record(("no_result_recorded", thread_id, "thread exited without recording a result"))
-            print(f"D4 [{thread_id}]: done", file=_sys.stderr, flush=True)
+            session.close()
 
-    t1 = threading.Thread(target=make_payment, args=("T1",))
-    t2 = threading.Thread(target=make_payment, args=("T2",))
-    t1.start()
-    t2.start()
-    t1.join(timeout=60)
-    t2.join(timeout=60)
+    import traceback as _tb
 
-    # Check if threads are still alive (timeout)
-    if t1.is_alive() or t2.is_alive():
-        # Give extra time — PostgreSQL lock contention may cause delay
-        t1.join(timeout=30)
-        t2.join(timeout=30)
-    if t1.is_alive() or t2.is_alive():
-        pytest.fail(
-            f"D4 FAILED: threads did not complete within 90s. "
-            f"t1 alive: {t1.is_alive()}, t2 alive: {t2.is_alive()}, "
-            f"results: {results}"
-        )
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            (executor.submit(make_payment, "T1"), "T1"),
+            (executor.submit(make_payment, "T2"), "T2"),
+        ]
 
-    # TH-1 (post-merge stabilization): harness hardening.
-    # Invariant 1: every worker MUST record a result — "worker disappeared
-    # → test treats it as success" must NEVER happen.
+        for future, thread_id in futures:
+            try:
+                outcome = future.result(timeout=90)
+                results.append(outcome)
+            except HTTPException as e:
+                reason = ""
+                if isinstance(e.detail, dict):
+                    reason = e.detail.get("reason", "")
+                elif isinstance(e.detail, str):
+                    reason = e.detail[:100]
+                results.append(("rejected", e.status_code, reason))
+            except TimeoutError:
+                results.append(("timeout", thread_id, "worker did not complete within 90s"))
+            except BaseException as e:
+                # TH-1: future.result() re-raises the ORIGINAL exception
+                # from the worker, including GreenletExit/SystemExit.
+                # Capture full traceback for classification.
+                tb_str = _tb.format_exc()
+                results.append(("error", type(e).__name__, str(e)[:200], tb_str))
+
+    # TH-1 Invariant 1: every worker MUST produce a result.
     assert len(results) == 2, (
         f"D4 FAILED [harness]: expected 2 worker results, got {len(results)}. "
-        f"A worker may have disappeared without recording a result. "
-        f"Results: {results}. "
-        f"t1 alive: {t1.is_alive()}, t2 alive: {t2.is_alive()}"
+        f"Results: {results}"
     )
 
-    # TH-1 Invariant 2: no worker may have crashed. A result with status
-    # "error" (unexpected BaseException: GreenletExit, SystemExit,
-    # RuntimeError, SQLAlchemyError, etc.) or "no_result_recorded"
-    # (worker disappeared without entering any recording handler) is a
-    # hard FAIL — the test must NOT pass if a worker crashed, even if
-    # the primary financial invariant (≤1 payment) happens to hold.
-    #
-    # Result tuple shape: (status, ...) where status ∈
-    #   {"success", "rejected", "error", "no_result_recorded"}.
-    crashed = [r for r in results if r[0] in ("error", "no_result_recorded")]
+    # TH-1 Invariant 2: no worker may have crashed.
+    # "error" = unexpected BaseException (GreenletExit, SystemExit, etc.)
+    # "timeout" = worker did not complete within 90s
+    # Both are hard FAIL — the test must NOT pass if a worker crashed.
+    crashed = [r for r in results if r[0] in ("error", "timeout")]
     assert not crashed, (
         f"D4 FAILED [worker crash]: a worker ended with an unexpected "
-        f"error or no_result_recorded status. The test must NOT pass when "
-        f"a worker crashes. Crashed results: {crashed}. All results: {results}"
+        f"error or timeout status. The test must NOT pass when a worker "
+        f"crashes. Crashed results: {crashed}. All results: {results}"
     )
 
     # PRIMARY invariant: at most 1 Payment in DB (no duplicate financial state)
@@ -620,7 +576,6 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
 
     barrier = threading.Barrier(2)
     results = []
-    results_lock = threading.Lock()
 
     # Create a lightweight user-like object for audit logging
     class _TestUser:
@@ -629,39 +584,20 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
             self.role = "Admin"
             self.username = f"test_user_{uid}"
 
-    def _record(result_tuple) -> bool:
-        """Record a result. Returns True if recording succeeded.
+    # TH-1 P1 follow-up: ThreadPoolExecutor rewrite (same as D4).
+    # Workers do NOT catch exceptions — they let them propagate.
+    # future.result() re-raises in the main thread with full traceback.
 
-        TH-1 hardening: returns bool so the caller's `recorded` flag
-        reflects whether the result was actually persisted, not just
-        whether the handler was entered.
+    def create_payment_worker():
+        """Worker A: PRODUCTION create_payment path.
+
+        Returns ("create_payment", "success", payment_id, amount) on success.
+        Raises HTTPException on expected rejection.
+        Lets any other exception propagate for diagnosis.
         """
+        barrier.wait()
+        session = sessionmaker(bind=db_engine)()
         try:
-            with results_lock:
-                results.append(result_tuple)
-            return True
-        except BaseException:
-            return False
-
-    def create_payment_thread():
-        """Thread A: PRODUCTION create_payment path.
-
-        Calls PaymentInvariantService.create_payment_for_visit() — the
-        EXACT same service method that the cashier/_payments.py:create_payment
-        endpoint calls. This is production code, not a test reconstruction.
-
-        TH-1 (P1 follow-up per Codex review): records result FIRST in
-        each handler, uses `recorded = _record(...)` so the flag reflects
-        actual recording success, and uses distinct status values:
-        - "success" / "rejected" (HTTPException) → test can PASS
-        - "error" (BaseException) → test MUST FAIL
-        - "no_result_recorded" (fallback) → test MUST FAIL
-        """
-        session = None
-        recorded = False
-        try:
-            barrier.wait()
-            session = sessionmaker(bind=db_engine)()
             payment = PaymentInvariantService(session).create_payment_for_visit(
                 visit_id=visit_id,
                 amount=Decimal("5000"),
@@ -670,50 +606,20 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                 current_user=_TestUser(1),
                 commit=True,
             )
-            recorded = _record(("create_payment", "success", payment.id, float(payment.amount)))
-        except HTTPException as e:
-            reason = ""
-            if isinstance(e.detail, dict):
-                reason = e.detail.get("reason", "")
-            elif isinstance(e.detail, str):
-                reason = e.detail[:100]
-            recorded = _record(("create_payment", "rejected", e.status_code, reason))
-        except BaseException as e:
-            # TH-1: catch BaseException (not just Exception) to capture
-            # greenlet.GreenletExit, SystemExit, etc. These are UNEXPECTED
-            # worker crashes — record as "error" so the crash assertion
-            # FAILS the test.
-            recorded = _record(("create_payment", "error", type(e).__name__, str(e)[:200]))
+            return ("create_payment", "success", payment.id, float(payment.amount))
         finally:
-            if session is not None:
-                try:
-                    session.close()
-                except Exception:
-                    pass
-            if not recorded:
-                _record(("create_payment", "no_result_recorded", None, "thread exited without recording a result"))
+            session.close()
 
-    def mark_paid_thread():
-        """Thread B: PRODUCTION mark_visit_as_paid endpoint function.
+    def mark_paid_worker():
+        """Worker B: PRODUCTION mark_visit_as_paid endpoint function.
 
-        Calls the ACTUAL async endpoint function `mark_visit_as_paid()`
-        from app.api.v1.endpoints.cashier._visits — NOT a manual
-        reconstruction. This is the real production code path.
-
-        The endpoint function is async, so we run it in an event loop.
-        We pass db and current_user directly (bypassing FastAPI Depends).
-
-        TH-1 (P1 follow-up per Codex review): same status semantics as
-        create_payment_thread — "error" / "no_result_recorded" → FAIL.
+        Returns ("mark_paid", "success", None, None) on success.
+        Raises HTTPException on expected rejection.
+        Lets any other exception propagate for diagnosis.
         """
-        session = None
-        recorded = False
+        barrier.wait()
+        session = sessionmaker(bind=db_engine)()
         try:
-            barrier.wait()
-            session = sessionmaker(bind=db_engine)()
-
-            # Call the PRODUCTION endpoint function directly
-            # (not a reconstruction — the actual function from the module)
             loop = asyncio.new_event_loop()
             try:
                 loop.run_until_complete(
@@ -723,64 +629,54 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                         current_user=_TestUser(2),
                     )
                 )
-                recorded = _record(("mark_paid", "success", None, None))
+                return ("mark_paid", "success", None, None)
             finally:
                 loop.close()
-        except HTTPException as e:
-            reason = ""
-            if isinstance(e.detail, dict):
-                reason = e.detail.get("reason", "")
-            elif isinstance(e.detail, str):
-                reason = e.detail[:100]
-            recorded = _record(("mark_paid", "rejected", e.status_code, reason))
-        except BaseException as e:
-            # TH-1: catch BaseException to capture GreenletExit etc.
-            if session is not None:
-                try:
-                    session.rollback()
-                except Exception:
-                    pass
-            recorded = _record(("mark_paid", "error", type(e).__name__, str(e)[:200]))
         finally:
-            if session is not None:
-                try:
-                    session.close()
-                except Exception:
-                    pass
-            if not recorded:
-                _record(("mark_paid", "no_result_recorded", None, "thread exited without recording a result"))
+            session.close()
 
-    t1 = threading.Thread(target=create_payment_thread)
-    t2 = threading.Thread(target=mark_paid_thread)
-    t1.start()
-    t2.start()
-    t1.join(timeout=30)
-    t2.join(timeout=30)
+    import traceback as _tb
 
-    # TH-1 (post-merge stabilization): harness hardening.
-    # Invariant 1: every worker MUST record a result — "worker disappeared
-    # → test treats it as success" must NEVER happen.
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            (executor.submit(create_payment_worker), "create_payment"),
+            (executor.submit(mark_paid_worker), "mark_paid"),
+        ]
+
+        for future, worker_name in futures:
+            try:
+                outcome = future.result(timeout=60)
+                results.append(outcome)
+            except HTTPException as e:
+                reason = ""
+                if isinstance(e.detail, dict):
+                    reason = e.detail.get("reason", "")
+                elif isinstance(e.detail, str):
+                    reason = e.detail[:100]
+                results.append((worker_name, "rejected", e.status_code, reason))
+            except TimeoutError:
+                results.append((worker_name, "timeout", None, "worker did not complete within 60s"))
+            except BaseException as e:
+                # TH-1: future.result() re-raises the ORIGINAL exception
+                # from the worker. Capture full traceback for classification.
+                tb_str = _tb.format_exc()
+                results.append((worker_name, "error", type(e).__name__, str(e)[:200], tb_str))
+
+    # TH-1 Invariant 1: every worker MUST produce a result.
     assert len(results) == 2, (
         f"D4b FAILED [harness]: expected 2 worker results, got {len(results)}. "
-        f"A worker may have disappeared without recording a result. "
-        f"Results: {results}. "
-        f"t1 alive: {t1.is_alive()}, t2 alive: {t2.is_alive()}"
+        f"Results: {results}"
     )
 
-    # TH-1 Invariant 2: no worker may have crashed. A result with status
-    # "error" (unexpected BaseException: GreenletExit, SystemExit,
-    # RuntimeError, SQLAlchemyError, etc.) or "no_result_recorded"
-    # (worker disappeared without entering any recording handler) is a
-    # hard FAIL — the test must NOT pass if a worker crashed, even if
-    # the primary financial invariant happens to hold.
-    #
-    # Result tuple shape: (worker_name, status, ...) where status ∈
-    #   {"success", "rejected", "error", "no_result_recorded"}.
-    crashed = [r for r in results if r[1] in ("error", "no_result_recorded")]
+    # TH-1 Invariant 2: no worker may have crashed.
+    # "error" = unexpected BaseException (GreenletExit, SystemExit, etc.)
+    # "timeout" = worker did not complete within 60s
+    # Both are hard FAIL — the test must NOT pass if a worker crashed.
+    crashed = [r for r in results if r[1] in ("error", "timeout")]
     assert not crashed, (
         f"D4b FAILED [worker crash]: a worker ended with an unexpected "
-        f"error or no_result_recorded status. The test must NOT pass when "
-        f"a worker crashes. Crashed results: {crashed}. All results: {results}"
+        f"error or timeout status. The test must NOT pass when a worker "
+        f"crashes. Crashed results: {crashed}. All results: {results}"
     )
 
     # ─── Primary Persisted Assertions (from NEW independent session) ──

--- a/backend/tests/integration/test_gate_d.py
+++ b/backend/tests/integration/test_gate_d.py
@@ -400,23 +400,39 @@ def test_d4_concurrent_payment_creation_no_duplicate(db_engine, new_session_fact
     def make_payment(thread_id="T"):
         """Each thread gets its OWN Session. ALWAYS records a result.
 
-        TH-1 hardening: the result is recorded as the FIRST action in
-        each except handler (before any print or other code that could
-        raise). This ensures that even if a second exception occurs
-        inside the handler (e.g. GreenletExit raised during results_lock
-        acquisition), the result is already recorded. If even that
-        fails, the outermost `record_fallback` ensures a result is
-        ALWAYS appended.
+        TH-1 hardening (P1 follow-up per Codex review):
+
+        Result tuple semantics (first element is the status):
+        - ("success", payment_id) — worker completed normally.
+        - ("rejected", status_code, reason) — EXPECTED HTTPException
+          (e.g. 409 from lock contention, 400 from validation). This
+          is a legitimate business-level rejection; the test can PASS.
+        - ("error", exception_type, message) — UNEXPECTED BaseException
+          (GreenletExit, SystemExit, RuntimeError, SQLAlchemyError,
+          etc.). The worker CRASHED. The test MUST FAIL.
+        - ("no_result_recorded", thread_id, message) — the worker
+          disappeared without entering any handler that records a
+          result. The test MUST FAIL.
+
+        The post-thread crash assertion rejects any result whose first
+        element is "error" or "no_result_recorded", so a worker crash
+        can NEVER produce a PASS.
         """
         import sys as _sys
 
-        def _record(result_tuple):
-            """Record a result, ignoring any exception during recording."""
+        def _record(result_tuple) -> bool:
+            """Record a result. Returns True if recording succeeded.
+
+            TH-1: returns bool so the caller's `recorded` flag reflects
+            whether the result was actually persisted, not just whether
+            the handler was entered.
+            """
             try:
                 with results_lock:
                     results.append(result_tuple)
+                return True
             except BaseException:
-                pass  # never let recording itself raise
+                return False  # never let recording itself raise
 
         print(f"D4 [{thread_id}]: starting", file=_sys.stderr, flush=True)
         session = None
@@ -435,24 +451,24 @@ def test_d4_concurrent_payment_creation_no_duplicate(db_engine, new_session_fact
                 commit=True,
             )
             print(f"D4 [{thread_id}]: payment created id={payment.id}", file=_sys.stderr, flush=True)
-            _record(("success", payment.id))
-            recorded = True
+            recorded = _record(("success", payment.id))
         except HTTPException as e:
             reason = ""
             if isinstance(e.detail, dict):
                 reason = e.detail.get("reason", "")
             elif isinstance(e.detail, str):
                 reason = e.detail[:100]
-            _record(("rejected", e.status_code, reason))
-            recorded = True
+            recorded = _record(("rejected", e.status_code, reason))
             print(f"D4 [{thread_id}]: HTTPException {e.status_code} reason={reason}", file=_sys.stderr, flush=True)
         except BaseException as e:
-            # Catch BaseException (not just Exception) to capture
-            # greenlet.GreenletExit, SystemExit, etc.
-            # Record FIRST, then log — so a second exception during
-            # logging does not lose the result.
-            _record(("rejected", type(e).__name__, str(e)[:200]))
-            recorded = True
+            # TH-1: catch BaseException (not just Exception) to capture
+            # greenlet.GreenletExit, SystemExit, etc. These are UNEXPECTED
+            # worker crashes — record as "error" (NOT "rejected") so the
+            # post-thread crash assertion FAILS the test.
+            #
+            # Record FIRST (before any print), so a second exception
+            # during logging does not lose the result.
+            recorded = _record(("error", type(e).__name__, str(e)[:200]))
             print(f"D4 [{thread_id}]: BaseException {type(e).__name__}: {e}", file=_sys.stderr, flush=True)
         finally:
             if session is not None:
@@ -461,11 +477,11 @@ def test_d4_concurrent_payment_creation_no_duplicate(db_engine, new_session_fact
                 except Exception:
                     pass
             # TH-1: if no result was recorded (e.g. exception during
-            # barrier.wait or session creation before the try body could
-            # record), record a fallback so the harness assertion
-            # len(results) == 2 can never be violated by a silent exit.
+            # barrier.wait or session creation, OR _record() itself failed),
+            # record a fallback. This is "no_result_recorded" — the test
+            # MUST FAIL because the worker effectively disappeared.
             if not recorded:
-                _record(("rejected", "no_result_recorded", f"thread {thread_id} exited without recording"))
+                _record(("no_result_recorded", thread_id, "thread exited without recording a result"))
             print(f"D4 [{thread_id}]: done", file=_sys.stderr, flush=True)
 
     t1 = threading.Thread(target=make_payment, args=("T1",))
@@ -488,16 +504,29 @@ def test_d4_concurrent_payment_creation_no_duplicate(db_engine, new_session_fact
         )
 
     # TH-1 (post-merge stabilization): harness hardening.
-    # Every worker MUST record a result — "worker disappeared → test treats
-    # it as success" must NEVER happen. If a worker was silently aborted
-    # (e.g. GreenletExit from SQLAlchemy/greenlet pool without entering the
-    # BaseException handler), results would have fewer than 2 entries and
-    # the primary invariant could pass while hiding a harness defect.
+    # Invariant 1: every worker MUST record a result — "worker disappeared
+    # → test treats it as success" must NEVER happen.
     assert len(results) == 2, (
         f"D4 FAILED [harness]: expected 2 worker results, got {len(results)}. "
         f"A worker may have disappeared without recording a result. "
         f"Results: {results}. "
         f"t1 alive: {t1.is_alive()}, t2 alive: {t2.is_alive()}"
+    )
+
+    # TH-1 Invariant 2: no worker may have crashed. A result with status
+    # "error" (unexpected BaseException: GreenletExit, SystemExit,
+    # RuntimeError, SQLAlchemyError, etc.) or "no_result_recorded"
+    # (worker disappeared without entering any recording handler) is a
+    # hard FAIL — the test must NOT pass if a worker crashed, even if
+    # the primary financial invariant (≤1 payment) happens to hold.
+    #
+    # Result tuple shape: (status, ...) where status ∈
+    #   {"success", "rejected", "error", "no_result_recorded"}.
+    crashed = [r for r in results if r[0] in ("error", "no_result_recorded")]
+    assert not crashed, (
+        f"D4 FAILED [worker crash]: a worker ended with an unexpected "
+        f"error or no_result_recorded status. The test must NOT pass when "
+        f"a worker crashes. Crashed results: {crashed}. All results: {results}"
     )
 
     # PRIMARY invariant: at most 1 Payment in DB (no duplicate financial state)
@@ -600,17 +629,19 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
             self.role = "Admin"
             self.username = f"test_user_{uid}"
 
-    def _record(result_tuple):
-        """Record a result, ignoring any exception during recording.
+    def _record(result_tuple) -> bool:
+        """Record a result. Returns True if recording succeeded.
 
-        TH-1 hardening: ensures the result is ALWAYS recorded even if
-        a second exception occurs during results_lock acquisition.
+        TH-1 hardening: returns bool so the caller's `recorded` flag
+        reflects whether the result was actually persisted, not just
+        whether the handler was entered.
         """
         try:
             with results_lock:
                 results.append(result_tuple)
+            return True
         except BaseException:
-            pass
+            return False
 
     def create_payment_thread():
         """Thread A: PRODUCTION create_payment path.
@@ -619,8 +650,12 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
         EXACT same service method that the cashier/_payments.py:create_payment
         endpoint calls. This is production code, not a test reconstruction.
 
-        TH-1: records result FIRST in each handler, with a fallback in
-        finally so the worker can never disappear without recording.
+        TH-1 (P1 follow-up per Codex review): records result FIRST in
+        each handler, uses `recorded = _record(...)` so the flag reflects
+        actual recording success, and uses distinct status values:
+        - "success" / "rejected" (HTTPException) → test can PASS
+        - "error" (BaseException) → test MUST FAIL
+        - "no_result_recorded" (fallback) → test MUST FAIL
         """
         session = None
         recorded = False
@@ -635,21 +670,20 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                 current_user=_TestUser(1),
                 commit=True,
             )
-            _record(("create_payment", "success", payment.id, float(payment.amount)))
-            recorded = True
+            recorded = _record(("create_payment", "success", payment.id, float(payment.amount)))
         except HTTPException as e:
             reason = ""
             if isinstance(e.detail, dict):
                 reason = e.detail.get("reason", "")
             elif isinstance(e.detail, str):
                 reason = e.detail[:100]
-            _record(("create_payment", "rejected", e.status_code, reason))
-            recorded = True
+            recorded = _record(("create_payment", "rejected", e.status_code, reason))
         except BaseException as e:
             # TH-1: catch BaseException (not just Exception) to capture
-            # greenlet.GreenletExit, SystemExit, etc. Record FIRST.
-            _record(("create_payment", "error", type(e).__name__, str(e)[:200]))
-            recorded = True
+            # greenlet.GreenletExit, SystemExit, etc. These are UNEXPECTED
+            # worker crashes — record as "error" so the crash assertion
+            # FAILS the test.
+            recorded = _record(("create_payment", "error", type(e).__name__, str(e)[:200]))
         finally:
             if session is not None:
                 try:
@@ -657,7 +691,7 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                 except Exception:
                     pass
             if not recorded:
-                _record(("create_payment", "error", "no_result_recorded", "thread exited without recording"))
+                _record(("create_payment", "no_result_recorded", None, "thread exited without recording a result"))
 
     def mark_paid_thread():
         """Thread B: PRODUCTION mark_visit_as_paid endpoint function.
@@ -669,8 +703,8 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
         The endpoint function is async, so we run it in an event loop.
         We pass db and current_user directly (bypassing FastAPI Depends).
 
-        TH-1: records result FIRST in each handler, with a fallback in
-        finally so the worker can never disappear without recording.
+        TH-1 (P1 follow-up per Codex review): same status semantics as
+        create_payment_thread — "error" / "no_result_recorded" → FAIL.
         """
         session = None
         recorded = False
@@ -689,8 +723,7 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                         current_user=_TestUser(2),
                     )
                 )
-                _record(("mark_paid", "success", None, None))
-                recorded = True
+                recorded = _record(("mark_paid", "success", None, None))
             finally:
                 loop.close()
         except HTTPException as e:
@@ -699,8 +732,7 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                 reason = e.detail.get("reason", "")
             elif isinstance(e.detail, str):
                 reason = e.detail[:100]
-            _record(("mark_paid", "rejected", e.status_code, reason))
-            recorded = True
+            recorded = _record(("mark_paid", "rejected", e.status_code, reason))
         except BaseException as e:
             # TH-1: catch BaseException to capture GreenletExit etc.
             if session is not None:
@@ -708,8 +740,7 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                     session.rollback()
                 except Exception:
                     pass
-            _record(("mark_paid", "error", type(e).__name__, str(e)[:200]))
-            recorded = True
+            recorded = _record(("mark_paid", "error", type(e).__name__, str(e)[:200]))
         finally:
             if session is not None:
                 try:
@@ -717,7 +748,7 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                 except Exception:
                     pass
             if not recorded:
-                _record(("mark_paid", "error", "no_result_recorded", "thread exited without recording"))
+                _record(("mark_paid", "no_result_recorded", None, "thread exited without recording a result"))
 
     t1 = threading.Thread(target=create_payment_thread)
     t2 = threading.Thread(target=mark_paid_thread)
@@ -727,17 +758,29 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
     t2.join(timeout=30)
 
     # TH-1 (post-merge stabilization): harness hardening.
-    # Every worker MUST record a result — "worker disappeared → test treats
-    # it as success" must NEVER happen. Both workers now catch BaseException
-    # (not just Exception) so GreenletExit/SystemExit are recorded. If a
-    # worker still disappeared without recording, results would have < 2
-    # entries and this assertion would fail — preventing a silent harness
-    # defect from being masked by a passing primary invariant.
+    # Invariant 1: every worker MUST record a result — "worker disappeared
+    # → test treats it as success" must NEVER happen.
     assert len(results) == 2, (
         f"D4b FAILED [harness]: expected 2 worker results, got {len(results)}. "
         f"A worker may have disappeared without recording a result. "
         f"Results: {results}. "
         f"t1 alive: {t1.is_alive()}, t2 alive: {t2.is_alive()}"
+    )
+
+    # TH-1 Invariant 2: no worker may have crashed. A result with status
+    # "error" (unexpected BaseException: GreenletExit, SystemExit,
+    # RuntimeError, SQLAlchemyError, etc.) or "no_result_recorded"
+    # (worker disappeared without entering any recording handler) is a
+    # hard FAIL — the test must NOT pass if a worker crashed, even if
+    # the primary financial invariant happens to hold.
+    #
+    # Result tuple shape: (worker_name, status, ...) where status ∈
+    #   {"success", "rejected", "error", "no_result_recorded"}.
+    crashed = [r for r in results if r[1] in ("error", "no_result_recorded")]
+    assert not crashed, (
+        f"D4b FAILED [worker crash]: a worker ended with an unexpected "
+        f"error or no_result_recorded status. The test must NOT pass when "
+        f"a worker crashes. Crashed results: {crashed}. All results: {results}"
     )
 
     # ─── Primary Persisted Assertions (from NEW independent session) ──

--- a/backend/tests/integration/test_gate_d.py
+++ b/backend/tests/integration/test_gate_d.py
@@ -67,6 +67,7 @@ from app.models.payment import Payment  # noqa: E402
 from app.models.patient import Patient  # noqa: E402
 from app.models.user import User  # noqa: E402
 from app.models.visit import Visit  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
 from app.services.payment_invariant_service import PaymentInvariantService  # noqa: E402
 from app.services.visit_lifecycle_service import VisitLifecycleService  # noqa: E402
 

--- a/backend/tests/integration/test_gate_d.py
+++ b/backend/tests/integration/test_gate_d.py
@@ -398,10 +398,29 @@ def test_d4_concurrent_payment_creation_no_duplicate(db_engine, new_session_fact
     results_lock = threading.Lock()
 
     def make_payment(thread_id="T"):
-        """Each thread gets its OWN Session. ALWAYS records a result."""
+        """Each thread gets its OWN Session. ALWAYS records a result.
+
+        TH-1 hardening: the result is recorded as the FIRST action in
+        each except handler (before any print or other code that could
+        raise). This ensures that even if a second exception occurs
+        inside the handler (e.g. GreenletExit raised during results_lock
+        acquisition), the result is already recorded. If even that
+        fails, the outermost `record_fallback` ensures a result is
+        ALWAYS appended.
+        """
         import sys as _sys
+
+        def _record(result_tuple):
+            """Record a result, ignoring any exception during recording."""
+            try:
+                with results_lock:
+                    results.append(result_tuple)
+            except BaseException:
+                pass  # never let recording itself raise
+
         print(f"D4 [{thread_id}]: starting", file=_sys.stderr, flush=True)
         session = None
+        recorded = False
         try:
             barrier.wait(timeout=10)
             print(f"D4 [{thread_id}]: barrier passed", file=_sys.stderr, flush=True)
@@ -416,29 +435,37 @@ def test_d4_concurrent_payment_creation_no_duplicate(db_engine, new_session_fact
                 commit=True,
             )
             print(f"D4 [{thread_id}]: payment created id={payment.id}", file=_sys.stderr, flush=True)
-            with results_lock:
-                results.append(("success", payment.id))
+            _record(("success", payment.id))
+            recorded = True
         except HTTPException as e:
             reason = ""
             if isinstance(e.detail, dict):
                 reason = e.detail.get("reason", "")
             elif isinstance(e.detail, str):
                 reason = e.detail[:100]
+            _record(("rejected", e.status_code, reason))
+            recorded = True
             print(f"D4 [{thread_id}]: HTTPException {e.status_code} reason={reason}", file=_sys.stderr, flush=True)
-            with results_lock:
-                results.append(("rejected", e.status_code, reason))
         except BaseException as e:
             # Catch BaseException (not just Exception) to capture
             # greenlet.GreenletExit, SystemExit, etc.
+            # Record FIRST, then log — so a second exception during
+            # logging does not lose the result.
+            _record(("rejected", type(e).__name__, str(e)[:200]))
+            recorded = True
             print(f"D4 [{thread_id}]: BaseException {type(e).__name__}: {e}", file=_sys.stderr, flush=True)
-            with results_lock:
-                results.append(("rejected", type(e).__name__, str(e)[:200]))
         finally:
             if session is not None:
                 try:
                     session.close()
                 except Exception:
                     pass
+            # TH-1: if no result was recorded (e.g. exception during
+            # barrier.wait or session creation before the try body could
+            # record), record a fallback so the harness assertion
+            # len(results) == 2 can never be violated by a silent exit.
+            if not recorded:
+                _record(("rejected", "no_result_recorded", f"thread {thread_id} exited without recording"))
             print(f"D4 [{thread_id}]: done", file=_sys.stderr, flush=True)
 
     t1 = threading.Thread(target=make_payment, args=("T1",))
@@ -573,16 +600,33 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
             self.role = "Admin"
             self.username = f"test_user_{uid}"
 
+    def _record(result_tuple):
+        """Record a result, ignoring any exception during recording.
+
+        TH-1 hardening: ensures the result is ALWAYS recorded even if
+        a second exception occurs during results_lock acquisition.
+        """
+        try:
+            with results_lock:
+                results.append(result_tuple)
+        except BaseException:
+            pass
+
     def create_payment_thread():
         """Thread A: PRODUCTION create_payment path.
 
         Calls PaymentInvariantService.create_payment_for_visit() — the
         EXACT same service method that the cashier/_payments.py:create_payment
         endpoint calls. This is production code, not a test reconstruction.
+
+        TH-1: records result FIRST in each handler, with a fallback in
+        finally so the worker can never disappear without recording.
         """
-        barrier.wait()
-        session = sessionmaker(bind=db_engine)()
+        session = None
+        recorded = False
         try:
+            barrier.wait()
+            session = sessionmaker(bind=db_engine)()
             payment = PaymentInvariantService(session).create_payment_for_visit(
                 visit_id=visit_id,
                 amount=Decimal("5000"),
@@ -591,25 +635,29 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                 current_user=_TestUser(1),
                 commit=True,
             )
-            with results_lock:
-                results.append(("create_payment", "success", payment.id, float(payment.amount)))
+            _record(("create_payment", "success", payment.id, float(payment.amount)))
+            recorded = True
         except HTTPException as e:
             reason = ""
             if isinstance(e.detail, dict):
                 reason = e.detail.get("reason", "")
             elif isinstance(e.detail, str):
                 reason = e.detail[:100]
-            with results_lock:
-                results.append(("create_payment", "rejected", e.status_code, reason))
+            _record(("create_payment", "rejected", e.status_code, reason))
+            recorded = True
         except BaseException as e:
-            # TH-1 (post-merge stabilization): catch BaseException (not just
-            # Exception) to capture greenlet.GreenletExit, SystemExit, etc.
-            # A worker that disappears via GreenletExit without recording a
-            # result would hide a harness defect.
-            with results_lock:
-                results.append(("create_payment", "error", type(e).__name__, str(e)[:200]))
+            # TH-1: catch BaseException (not just Exception) to capture
+            # greenlet.GreenletExit, SystemExit, etc. Record FIRST.
+            _record(("create_payment", "error", type(e).__name__, str(e)[:200]))
+            recorded = True
         finally:
-            session.close()
+            if session is not None:
+                try:
+                    session.close()
+                except Exception:
+                    pass
+            if not recorded:
+                _record(("create_payment", "error", "no_result_recorded", "thread exited without recording"))
 
     def mark_paid_thread():
         """Thread B: PRODUCTION mark_visit_as_paid endpoint function.
@@ -620,11 +668,16 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
 
         The endpoint function is async, so we run it in an event loop.
         We pass db and current_user directly (bypassing FastAPI Depends).
-        """
-        barrier.wait()
-        session = sessionmaker(bind=db_engine)()
 
+        TH-1: records result FIRST in each handler, with a fallback in
+        finally so the worker can never disappear without recording.
+        """
+        session = None
+        recorded = False
         try:
+            barrier.wait()
+            session = sessionmaker(bind=db_engine)()
+
             # Call the PRODUCTION endpoint function directly
             # (not a reconstruction — the actual function from the module)
             loop = asyncio.new_event_loop()
@@ -636,8 +689,8 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                         current_user=_TestUser(2),
                     )
                 )
-                with results_lock:
-                    results.append(("mark_paid", "success", None, None))
+                _record(("mark_paid", "success", None, None))
+                recorded = True
             finally:
                 loop.close()
         except HTTPException as e:
@@ -646,15 +699,25 @@ def test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate(db_engine, ne
                 reason = e.detail.get("reason", "")
             elif isinstance(e.detail, str):
                 reason = e.detail[:100]
-            with results_lock:
-                results.append(("mark_paid", "rejected", e.status_code, reason))
+            _record(("mark_paid", "rejected", e.status_code, reason))
+            recorded = True
         except BaseException as e:
             # TH-1: catch BaseException to capture GreenletExit etc.
-            session.rollback()
-            with results_lock:
-                results.append(("mark_paid", "error", type(e).__name__, str(e)[:200]))
+            if session is not None:
+                try:
+                    session.rollback()
+                except Exception:
+                    pass
+            _record(("mark_paid", "error", type(e).__name__, str(e)[:200]))
+            recorded = True
         finally:
-            session.close()
+            if session is not None:
+                try:
+                    session.close()
+                except Exception:
+                    pass
+            if not recorded:
+                _record(("mark_paid", "error", "no_result_recorded", "thread exited without recording"))
 
     t1 = threading.Thread(target=create_payment_thread)
     t2 = threading.Thread(target=mark_paid_thread)


### PR DESCRIPTION
## Summary

- Post-merge stabilization TH-1: harden the D4/D4b concurrency test harness so that "worker disappeared → test treats it as success" can NEVER happen.
- Root issue: D4 did not verify both workers recorded a result; D4b caught only `Exception` (not `BaseException`), so `GreenletExit` would not be caught and a worker could disappear silently.
- Test-only change — no production code modified.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `6d61c3c` (PR #2703 merge commit).
- Clean workspace: working tree clean before commit. Diff is +34 lines, -2 lines in a single test file.
- Branch: `fix/th-1-d4-greenlet-exit-harness-hardening`
- Scope gate: allowed `backend/tests/integration/test_gate_d.py` only. Denied production code, frontend, migrations, other tests.
- Red-check handling: if any CI check is red (especially the Gate D workflow on PostgreSQL), the issue will be fixed in this same PR before merge.

## Contract Impact

- not applicable - no production code changed. This PR hardens test harness code only.

## RBAC / Permissions

- not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- not applicable - no user-facing panel or frontend data flow changed.

## Scope Gate

- Allowed paths: `backend/tests/integration/test_gate_d.py`.
- Denied paths: production code, frontend, migrations, other tests.
- Migration/docs/test impact: no migration; no doc changes; one existing test file modified (+34/-2 lines).
- Rollback note: revert the single commit. No production behavior change.

## Validation

- Targeted tests or smoke run: Gate D tests collect 9/9 (verified with `--collect-only -m gate_d`). Gate D tests require PostgreSQL and run in the dedicated `gate-d.yml` workflow (excluded from regular CI via `pytest.ini addopts: -m "not gate_d"`).
- Result: collection PASS. Runtime execution requires PostgreSQL 16 service container (not available in this local environment).
- Not checked: actual Gate D runtime on PostgreSQL — will be exercised by the `gate-d.yml` workflow on this PR.

## Changes

1. **D4** (`test_d4_concurrent_payment_creation_no_duplicate`): added post-thread assertion `assert len(results) == 2` — verifies both workers recorded a result. If a worker disappeared (e.g. `GreenletExit` without entering the `BaseException` handler), this fails with a clear `[harness]` diagnostic.
2. **D4b** (`test_d4b_concurrent_create_payment_plus_mark_paid_no_duplicate`):
   - Changed `except Exception` to `except BaseException` in BOTH workers (`create_payment_thread` and `mark_paid_thread`) so `GreenletExit`/`SystemExit` are recorded as error results.
   - Added the same `assert len(results) == 2` post-thread assertion.

## Invariant

Every worker MUST record a result:
- worker completed normally (success), OR
- worker raised expected exception (HTTPException/rejected), OR
- worker raised unexpected exception (error, including `BaseException`)

But NEVER:
- worker disappeared → test treats it as success

The primary invariant (no duplicate financial state) remains independent of worker bookkeeping — the harness assertion runs BEFORE the primary assertions and fails fast if a worker disappeared.

## NOT in this PR

- **TH-2** (3 xfail E2E/concurrency tests investigation) — separate follow-up in the same phase.
- **P2-1b** — over-broad rollback at `_assign_queues_for_visit` L396 (CONFIRMED — UNFIXED — separate).
- **P2-3 Finding C** — audit-trail loss on terminal→non-terminal callback (separate auditable-webhook-events problem).

## Refs

Post-merge stabilization PHASE 10 — TH-1. Follows PR #2703 (P2-3).