### PR TITLE
ci: increase frontend-e2e timeout from 15 to 25 minutes

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -745,7 +745,7 @@ jobs:
   frontend-e2e:
     name: Frontend e2e
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: [ci-scope]
     if: |
       needs.ci-scope.outputs.frontend_e2e_required == 'true' &&


### PR DESCRIPTION
## Summary

- Fix: increase `frontend-e2e` job timeout from 15 to 25 minutes.
- Root cause: 19 pre-existing e2e test failures (each with 3 retries) take ~14 minutes, exceeding the 15-min job timeout. The job was cancelled, preventing subsequent e2e steps from running.
- The failing step has `continue-on-error: true` — the failures are non-blocking. Only the timeout cancellation is the problem.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `64f4fe4` (PR #2710 merge commit).
- Clean workspace: 1 file changed, 1 line changed.
- Branch: `fix/e2e-timeout`
- Scope gate: allowed `.github/workflows/ci-cd-unified.yml` only.
- Red-check handling: if any CI check is red, the issue will be fixed in this same PR before merge.

## Contract Impact

- not applicable - no API endpoint or production code changed. This is a CI timeout adjustment.

## RBAC / Permissions

- not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- not applicable - no frontend code changed. The e2e test failures are pre-existing (backend not running in e2e job).

## Scope Gate

- Allowed paths: `.github/workflows/ci-cd-unified.yml`.
- Denied paths: all other files.
- Migration/docs/test impact: no migration; no doc changes; no test changes.
- Rollback note: revert the single commit. Restores the 15-min timeout (which causes job cancellation).

## Validation

- Targeted tests or smoke run: no tests run locally (this is a CI config change).
- Result: will be verified by CI on this PR.
- Not checked: the underlying e2e test failures (pre-existing, unrelated to this change).

## NOT in this PR

- Fixing the 19 pre-existing e2e test failures (they require either better mocking or a real backend in the e2e job — separate follow-up).
- Any production code changes.

## Refs

CI infrastructure fix for frontend-e2e job timeout.