### PR TITLE
fix(e2e): stabilize 19 UX/Visual regression test failures

### DIFF
--- a/frontend/e2e/cashier-ux-audit.spec.ts
+++ b/frontend/e2e/cashier-ux-audit.spec.ts
@@ -124,6 +124,8 @@ test.describe('UX Audit Cashier — new interactions', () => {
         await route.fulfill(jsonResponse({
           success: true,
           data: [samplePendingPayment],
+          items: [samplePendingPayment],
+          total: 1, page: 1, size: 20, pages: 1,
           pagination: { pages: 1, total: 1 },
         }));
         return;
@@ -132,6 +134,8 @@ test.describe('UX Audit Cashier — new interactions', () => {
         await route.fulfill(jsonResponse({
           success: true,
           data: [sampleHistoryPayment],
+          items: [sampleHistoryPayment],
+          total: 1, page: 1, size: 20, pages: 1,
           pagination: { pages: 1, total: 1 },
         }));
         return;
@@ -204,7 +208,7 @@ test.describe('UX Audit Cashier — new interactions', () => {
     await page.waitForTimeout(2000);
 
     const searchInput = page.locator('#cashier-search-input').first();
-    await expect(searchInput).toHaveAttribute('placeholder', /имя пациента.*ID.*телефон/i);
+    await expect(searchInput).toHaveAttribute('placeholder', /ФИО.*телефон.*ID|имя.*ID.*телефон/i);
   });
 
   // ========================================================================

--- a/frontend/e2e/registrar-ux-audit.spec.ts
+++ b/frontend/e2e/registrar-ux-audit.spec.ts
@@ -127,7 +127,7 @@ test.describe('UX Audit Registrar — new interactions', () => {
         }));
         return;
       }
-      if (pathname === '/api/v1/registrar/appointments') {
+      if (pathname === '/api/v1/registrar/appointments' || pathname === '/api/v1/registrar/all-appointments') {
         await route.fulfill(jsonResponse({
           appointments: [sampleAppointment],
           total: 1,
@@ -253,7 +253,7 @@ test.describe('UX Audit Registrar — new interactions', () => {
 
   test('payment badge does not render for paid status', async ({ page }) => {
     // Override appointments to return paid status
-    await page.route('**/api/v1/registrar/appointments', async (route) => {
+    await page.route('**/api/v1/registrar/all-appointments', async (route) => {
       await route.fulfill(jsonResponse({
         appointments: [{ ...sampleAppointment, payment_status: 'paid' }],
         total: 1,

--- a/frontend/e2e/visual-regression.spec.ts
+++ b/frontend/e2e/visual-regression.spec.ts
@@ -89,11 +89,11 @@ test.describe('Visual regression — cashier panel', () => {
       if (pathname === '/api/v1/setup/status') { await route.fulfill(jsonResponse({ initialized: true })); return; }
       if (pathname === '/api/v1/auth/me') { await route.fulfill(jsonResponse(cashierProfile)); return; }
       if (pathname === '/api/v1/cashier/pending-payments') {
-        await route.fulfill(jsonResponse({ success: true, data: [samplePendingPayment], pagination: { pages: 1, total: 1 } }));
+        await route.fulfill(jsonResponse({ success: true, data: [samplePendingPayment], items: [samplePendingPayment], total: 1, page: 1, size: 20, pages: 1, pagination: { pages: 1, total: 1 } }));
         return;
       }
       if (pathname === '/api/v1/cashier/payments') {
-        await route.fulfill(jsonResponse({ success: true, data: [sampleHistoryPayment], pagination: { pages: 1, total: 1 } }));
+        await route.fulfill(jsonResponse({ success: true, data: [sampleHistoryPayment], items: [sampleHistoryPayment], total: 1, page: 1, size: 20, pages: 1, pagination: { pages: 1, total: 1 } }));
         return;
       }
       if (pathname === '/api/v1/cashier/stats') {
@@ -190,7 +190,7 @@ test.describe('Visual regression — registrar wizard', () => {
         await route.fulfill(jsonResponse({ services_by_group: { cardio: [{ id: 101, code: 'C001', name: 'Консультация кардиолога', price: 150000, requires_doctor: true }] } }));
         return;
       }
-      if (pathname === '/api/v1/registrar/appointments') {
+      if (pathname === '/api/v1/registrar/appointments' || pathname === '/api/v1/registrar/all-appointments') {
         await route.fulfill(jsonResponse({ appointments: [], total: 0, has_more: false }));
         return;
       }


### PR DESCRIPTION
## Summary

- Fix 19 pre-existing UX/Visual E2E test failures by correcting test mock data shapes and endpoint paths.
- Root cause: 3 categories of test defects (not infrastructure, not production code).
- Production diff: 0 lines (test-only changes).

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `b3016b5` (PR #2712 merge commit).
- Clean workspace: 3 files changed, +10/-6 lines.
- Branch: `fix/e2e-ux-visual-stabilization`
- Scope gate: allowed `frontend/e2e/cashier-ux-audit.spec.ts`, `frontend/e2e/registrar-ux-audit.spec.ts`, `frontend/e2e/visual-regression.spec.ts`. Denied production code, backend, migrations.
- Red-check handling: if any CI check is red, the issue will be fixed in this same PR before merge.

## Contract Impact

- not applicable - no production code changed. Test-only fixes.

## RBAC / Permissions

- not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

- not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: the mock response shape fix ensures that when API returns empty data (items: []), the UI correctly renders empty state instead of staying in loading skeleton forever.
- Partial data proof: not applicable - mock data is deterministic and complete.
- Forbidden secondary path behavior: not applicable - no secondary paths introduced; tests use mocked API only.
- Missing draft/resource behavior: not applicable - no draft or resource creation in these test files.
- Stale route/deep-link behavior: not applicable - tests navigate to fixed routes (/cashier, /registrar) with mocked data.

## Scope Gate

- Allowed paths: `frontend/e2e/cashier-ux-audit.spec.ts`, `frontend/e2e/registrar-ux-audit.spec.ts`, `frontend/e2e/visual-regression.spec.ts`.
- Denied paths: production code, backend, migrations.
- Migration/docs/test impact: no migration; no doc changes; test fixes only.
- Rollback note: revert the single commit. Restores the 19 pre-existing failures (non-blocking due to continue-on-error: true).

## Validation

- Targeted tests or smoke run: `cashier-ux-audit.spec.ts`, `registrar-ux-audit.spec.ts`, `visual-regression.spec.ts` — will run in CI.
- Result: pending CI verification.
- Not checked: local Playwright run (requires Chromium + Vite dev server setup).

## Root cause analysis

### Category 1: Placeholder regex mismatch (1 test)
- Test expected: `/имя пациента.*ID.*телефон/i`
- Actual i18n: `"Поиск по ФИО, телефону, ID…"`
- Fix: updated regex to `/ФИО.*телефон.*ID|имя.*ID.*телефон/i`

### Category 2: Mock response shape mismatch (8 tests)
- `usePayments` expects: `{ items: [...], total, page, size, pages }`
- Mock returned: `{ data: [...], pagination: { pages, total } }`
- Result: `data.items` was undefined → empty array → no rows rendered → overflow menu, cancel dialog, cash payment modal not found
- Fix: added `items/total/page/size/pages` fields to mock responses

### Category 3: Wrong endpoint mock (10 tests)
- Tests mocked: `/api/v1/registrar/appointments`
- Actual endpoint: `/api/v1/registrar/all-appointments`
- Result: mock didn't match → fell through to catch-all → wrong response shape → registrar table didn't render
- Fix: mock now matches both `/registrar/appointments` and `/registrar/all-appointments`

### NOT infrastructure
The `ECONNREFUSED localhost:18000` errors are from Vite WebSocket proxy (HMR), NOT from API calls. The `page.route('**/api/v1/**')` mocks ARE catching all API requests correctly.

## NOT in this PR

- Visual regression baseline snapshot updates (may be needed if rendering changes after mock fixes — will update in CI if `--update-snapshots` is needed).
- Production code changes.
- Backend changes.

## Refs

E2E stabilization — 19 pre-existing UX/Visual regression test failures.