### PR TITLE
ci: E2E coverage invariant — forbid test.fixme/skip in UX/Visual E2E

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -781,10 +781,53 @@ jobs:
     - name: 📸 UX Audit e2e + Visual regression (Chromium)
       run: |
         cd frontend
-        npx playwright test e2e/registrar-ux-audit.spec.ts e2e/cashier-ux-audit.spec.ts e2e/visual-regression.spec.ts --project=chromium
+        # --retries=0 is MANDATORY for UX/Visual E2E. These tests must pass
+        # on the FIRST attempt — retries would mask flaky tests. The
+        # e2e-coverage-invariant.mjs gate enforces this.
+        # Output is tee'd to a file so the next step can verify the test count.
+        npx playwright test e2e/registrar-ux-audit.spec.ts e2e/cashier-ux-audit.spec.ts e2e/visual-regression.spec.ts --project=chromium --retries=0 2>&1 | tee ux-audit-output.txt
       # E2E root-cause fix: removed continue-on-error. All non-fixme tests
       # must pass. Tests marked test.fixme have documented root causes and
       # are tracked for follow-up. See PR description for details.
+
+    - name: 🔒 UX/Visual E2E test count invariant
+      run: |
+        cd frontend
+        # Verify that Playwright actually executed the expected number of tests.
+        # This catches the failure mode where tests are silently skipped via
+        # test.fixme/test.skip (the e2e-coverage-invariant.mjs gate catches
+        # the source-level patterns, but this catches the runtime-level
+        # reality: if the count drops below 27, something was skipped).
+        #
+        # Expected: 27 passed, 0 skipped, 0 failed (12 cashier + 9 registrar + 6 visual).
+        # If a test is intentionally added/removed, update EXPECTED_COUNT below.
+        EXPECTED_COUNT=27
+        if [ ! -f ux-audit-output.txt ]; then
+          echo "ERROR: ux-audit-output.txt not found. The UX Audit step may not have run."
+          exit 1
+        fi
+        # Extract the final summary line (e.g. "  27 passed (2.0m)")
+        SUMMARY=$(grep -E "^\s+[0-9]+ passed" ux-audit-output.txt | tail -1)
+        echo "Playwright summary: $SUMMARY"
+        PASSED=$(echo "$SUMMARY" | grep -oE "[0-9]+ passed" | grep -oE "[0-9]+" || echo "0")
+        SKIPPED=$(echo "$SUMMARY" | grep -oE "[0-9]+ skipped" | grep -oE "[0-9]+" || echo "0")
+        FAILED=$(echo "$SUMMARY" | grep -oE "[0-9]+ failed" | grep -oE "[0-9]+" || echo "0")
+        echo "Parsed: passed=$PASSED skipped=$SKIPPED failed=$FAILED"
+        if [ "$FAILED" != "0" ]; then
+          echo "ERROR: $FAILED test(s) failed. UX/Visual E2E must have 0 failures."
+          exit 1
+        fi
+        if [ "$SKIPPED" != "0" ]; then
+          echo "ERROR: $SKIPPED test(s) skipped. UX/Visual E2E must have 0 skipped (no test.fixme/test.skip allowed)."
+          echo "If a test was intentionally skipped, remove the skip and fix the test, or update EXPECTED_COUNT."
+          exit 1
+        fi
+        if [ "$PASSED" -lt "$EXPECTED_COUNT" ]; then
+          echo "ERROR: Only $PASSED tests passed, expected at least $EXPECTED_COUNT."
+          echo "This means some tests were silently excluded. Check for test.fixme/test.skip."
+          exit 1
+        fi
+        echo "✓ UX/Visual E2E count invariant intact: $PASSED passed, $SKIPPED skipped, $FAILED failed (expected ≥ $EXPECTED_COUNT)."
 
     - name: 📸 Update visual regression baseline snapshots (manual only)
       if: github.event_name == 'workflow_dispatch' && github.event.inputs.update_snapshots == 'true'

--- a/.github/workflows/e2e-coverage-invariant.yml
+++ b/.github/workflows/e2e-coverage-invariant.yml
@@ -1,0 +1,56 @@
+# E2E Coverage Invariant Gate
+#
+# Runs scripts/e2e-coverage-invariant.mjs on every PR and push to verify
+# that UX/Visual E2E tests are fully executed — no test.fixme, test.skip,
+# describe.skip, it.skip, test.only, and that retries=0 is enforced.
+#
+# This gate exists because of a real incident (PR #2715): CI showed
+# "success" while 18 of 27 UX/Visual tests were silently skipped via
+# test.fixme + continue-on-error: true. The tests were "green" but not
+# actually running.
+#
+# See scripts/e2e-coverage-invariant.mjs for the full list of checks.
+
+name: E2E Coverage Invariant
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'frontend/e2e/cashier-ux-audit.spec.ts'
+      - 'frontend/e2e/registrar-ux-audit.spec.ts'
+      - 'frontend/e2e/visual-regression.spec.ts'
+      - 'frontend/playwright.config.js'
+      - '.github/workflows/ci-cd-unified.yml'
+      - 'scripts/e2e-coverage-invariant.mjs'
+      - '.github/workflows/e2e-coverage-invariant.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/e2e/cashier-ux-audit.spec.ts'
+      - 'frontend/e2e/registrar-ux-audit.spec.ts'
+      - 'frontend/e2e/visual-regression.spec.ts'
+      - 'frontend/playwright.config.js'
+      - '.github/workflows/ci-cd-unified.yml'
+      - 'scripts/e2e-coverage-invariant.mjs'
+      - '.github/workflows/e2e-coverage-invariant.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  e2e-coverage-invariant:
+    name: E2E Coverage Invariant
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run E2E coverage invariant checks
+        run: node scripts/e2e-coverage-invariant.mjs

--- a/scripts/e2e-coverage-invariant.mjs
+++ b/scripts/e2e-coverage-invariant.mjs
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+/**
+ * e2e-coverage-invariant.mjs
+ *
+ * CI gate that verifies UX/Visual E2E tests are fully executed — no
+ * test.fixme, test.skip, describe.skip, or it.skip — and that the
+ * expected number of tests actually ran.
+ *
+ * This invariant exists because of a real incident (PR #2715 → #2716 → #2717):
+ * CI showed "success" for the UX Audit step while 18 of 27 tests were
+ * silently skipped via test.fixme + continue-on-error: true. The tests
+ * were "green" but not actually running.
+ *
+ * Scope: ONLY the UX/Visual E2E files. Other E2E suites (business/,
+ * security/, load/, chaos/) may legitimately use skip and are NOT
+ * checked by this invariant.
+ *
+ * Usage:
+ *   node scripts/e2e-coverage-invariant.mjs
+ *   node scripts/e2e-coverage-invariant.mjs --check-count 27
+ *
+ * Exit codes:
+ *   0 — all invariants intact
+ *   1 — one or more invariants violated
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(__dirname, '..');
+const FRONTEND = resolve(REPO, 'frontend');
+
+// Target E2E files — ONLY these are checked. Other suites may use skip.
+const TARGET_E2E_FILES = [
+  'e2e/cashier-ux-audit.spec.ts',
+  'e2e/registrar-ux-audit.spec.ts',
+  'e2e/visual-regression.spec.ts',
+];
+
+// Patterns that silently disable tests. Each is a RegExp source.
+// We check for these as function calls (with optional whitespace/skip prefix).
+const FORBIDDEN_PATTERNS = [
+  {
+    name: 'test.fixme',
+    pattern: /\btest\s*\.\s*fixme\s*\(/,
+    reason: 'test.fixme silently excludes the test from execution. Fix the test or remove it.',
+  },
+  {
+    name: 'test.skip',
+    pattern: /\btest\s*\.\s*skip\s*\(/,
+    reason: 'test.skip silently excludes the test from execution. Fix the test or remove it.',
+  },
+  {
+    name: 'describe.skip',
+    pattern: /\bdescribe\s*\.\s*skip\s*\(/,
+    reason: 'describe.skip silently excludes the entire describe block. Fix the tests or remove them.',
+  },
+  {
+    name: 'describe.fixme',
+    pattern: /\bdescribe\s*\.\s*fixme\s*\(/,
+    reason: 'describe.fixme silently excludes the entire describe block. Fix the tests or remove them.',
+  },
+  {
+    name: 'it.skip',
+    pattern: /\bit\s*\.\s*skip\s*\(/,
+    reason: 'it.skip silently excludes the test from execution.',
+  },
+  {
+    name: 'it.fixme',
+    pattern: /\bit\s*\.\s*fixme\s*\(/,
+    reason: 'it.fixme silently excludes the test from execution.',
+  },
+  {
+    name: 'test.only (forbidden on CI)',
+    pattern: /\btest\s*\.\s*only\s*\(/,
+    reason: 'test.only runs only one test and skips all others. Remove before merge.',
+  },
+];
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+const warnings = [];
+
+function log(msg) {
+  console.log(msg);
+}
+
+function recordPass(name) {
+  passed++;
+  log(`  ✓ ${name}`);
+}
+
+function recordFail(name, reason, file, line) {
+  failed++;
+  failures.push({ name, reason, file, line });
+  log(`  ✗ ${name}`);
+  if (file) log(`    file: ${file}${line ? `:${line}` : ''}`);
+  if (reason) log(`    reason: ${reason}`);
+}
+
+/**
+ * Check a single file for forbidden patterns.
+ * Returns the list of violations (empty if none).
+ */
+function checkFile(filePath) {
+  const fullPath = join(FRONTEND, filePath);
+  if (!existsSync(fullPath)) {
+    recordFail(
+      `File exists: ${filePath}`,
+      `Expected E2E file does not exist. The invariant cannot be verified.`,
+      filePath,
+      null,
+    );
+    return;
+  }
+
+  const content = readFileSync(fullPath, 'utf-8');
+  const lines = content.split('\n');
+
+  let fileHasViolation = false;
+
+  for (const { name, pattern, reason } of FORBIDDEN_PATTERNS) {
+    lines.forEach((line, idx) => {
+      // Skip comment lines (lines that start with // or * after trim)
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+        return;
+      }
+      if (pattern.test(line)) {
+        recordFail(
+          `${name} in ${filePath}`,
+          reason,
+          filePath,
+          idx + 1,
+        );
+        fileHasViolation = true;
+      }
+    });
+  }
+
+  if (!fileHasViolation) {
+    recordPass(`No forbidden patterns in ${filePath}`);
+  }
+}
+
+/**
+ * Check that playwright.config.js does not set retries > 0 for the
+ * target E2E files. We check the global retries setting; if it's > 0
+ * on CI, the UX/Visual suite inherits it UNLESS the CI command
+ * explicitly overrides with --retries=0 (which takes precedence).
+ *
+ * The check logic:
+ *   1. If global config retries=0 on CI → PASS
+ *   2. If global config retries>0 on CI, but CI step has --retries=0 → PASS (override)
+ *   3. If global config retries>0 on CI, and CI step has no --retries=0 → FAIL
+ */
+function checkRetriesConfig() {
+  const configPath = join(FRONTEND, 'playwright.config.js');
+  if (!existsSync(configPath)) {
+    recordFail(
+      'playwright.config.js exists',
+      'Cannot verify retries setting — config file missing.',
+      'playwright.config.js',
+      null,
+    );
+    return;
+  }
+
+  const content = readFileSync(configPath, 'utf-8');
+
+  // Find the retries line
+  const retriesMatch = content.match(/retries\s*:\s*([^,}\n]+)/);
+  if (!retriesMatch) {
+    recordPass('retries setting (absent = 0)');
+    return;
+  }
+
+  const retriesValue = retriesMatch[1].trim();
+
+  // Determine CI retries value from global config
+  let ciRetriesFromConfig = 0;
+  let parsed = false;
+
+  if (retriesValue.includes('process.env.CI')) {
+    const ciMatch = retriesValue.match(/CI\s*\?\s*(\d+)\s*:\s*(\d+)/);
+    if (ciMatch) {
+      ciRetriesFromConfig = parseInt(ciMatch[1], 10);
+      parsed = true;
+    }
+  } else if (/^\d+$/.test(retriesValue)) {
+    ciRetriesFromConfig = parseInt(retriesValue, 10);
+    parsed = true;
+  }
+
+  if (!parsed) {
+    warnings.push(`Could not parse retries value: ${retriesValue}. Manual review needed.`);
+    recordPass(`retries setting present (manual review: ${retriesValue})`);
+    return;
+  }
+
+  if (ciRetriesFromConfig === 0) {
+    recordPass(`retries=0 on CI (config: ${retriesValue})`);
+    return;
+  }
+
+  // Global config allows retries > 0 on CI. Check if the CI workflow
+  // step explicitly overrides with --retries=0.
+  const workflowPath = join(REPO, '.github', 'workflows', 'ci-cd-unified.yml');
+  if (!existsSync(workflowPath)) {
+    recordFail(
+      'retries=0 for UX/Visual on CI',
+      `playwright.config.js sets retries: ${retriesValue} (CI retries = ${ciRetriesFromConfig}), and ci-cd-unified.yml not found to verify --retries=0 override.`,
+      'playwright.config.js',
+      null,
+    );
+    return;
+  }
+
+  const workflowContent = readFileSync(workflowPath, 'utf-8');
+  const uxStepMatch = workflowContent.match(
+    /name:\s*📸\s*UX Audit e2e.*?(?=\n\s*-\s*name:|\n\s*-\s*uses:|$)/s,
+  );
+
+  if (!uxStepMatch) {
+    recordFail(
+      'retries=0 for UX/Visual on CI',
+      `playwright.config.js sets retries: ${retriesValue} (CI retries = ${ciRetriesFromConfig}), and UX Audit step not found in workflow to verify --retries=0 override.`,
+      'playwright.config.js',
+      null,
+    );
+    return;
+  }
+
+  const uxStep = uxStepMatch[0];
+  if (uxStep.includes('--retries=0') || uxStep.includes('--retries 0')) {
+    recordPass(
+      `retries=0 for UX/Visual on CI (config has ${ciRetriesFromConfig}, but CI step overrides with --retries=0)`,
+    );
+  } else {
+    recordFail(
+      'retries=0 for UX/Visual on CI',
+      `playwright.config.js sets retries: ${retriesValue} (CI retries = ${ciRetriesFromConfig}). UX/Visual E2E must run with retries=0 to catch flaky tests. Add --retries=0 to the UX Audit CI step, or set retries: process.env.CI ? 0 : 0 in playwright.config.js.`,
+      'playwright.config.js',
+      null,
+    );
+  }
+}
+
+/**
+ * Check that the CI workflow command for UX Audit includes --retries=0
+ * OR that the global config is already retries=0.
+ * This is a secondary check — if the config allows retries, the CI
+ * command must explicitly override to 0.
+ */
+function checkCIWorkflowRetries() {
+  const workflowPath = join(REPO, '.github', 'workflows', 'ci-cd-unified.yml');
+  if (!existsSync(workflowPath)) {
+    warnings.push('ci-cd-unified.yml not found — cannot verify UX Audit retries override.');
+    return;
+  }
+
+  const content = readFileSync(workflowPath, 'utf-8');
+
+  // Find the UX Audit step
+  const uxStepMatch = content.match(
+    /name:\s*📸\s*UX Audit e2e.*?(?=\n\s*-\s*name:|\n\s*-\s*uses:|$)/s,
+  );
+  if (!uxStepMatch) {
+    warnings.push('Could not find UX Audit e2e step in ci-cd-unified.yml.');
+    return;
+  }
+
+  const uxStep = uxStepMatch[0];
+
+  // Check if the command includes --retries=0
+  if (uxStep.includes('--retries=0') || uxStep.includes('--retries 0')) {
+    recordPass('UX Audit CI step includes --retries=0');
+  } else {
+    // Check if the global config is already retries=0 on CI
+    const configPath = join(FRONTEND, 'playwright.config.js');
+    const configContent = readFileSync(configPath, 'utf-8');
+    const retriesMatch = configContent.match(/retries\s*:\s*([^,}\n]+)/);
+    if (retriesMatch) {
+      const retriesValue = retriesMatch[1].trim();
+      const ciMatch = retriesValue.match(/CI\s*\?\s*(\d+)/);
+      if (ciMatch && parseInt(ciMatch[1], 10) === 0) {
+        recordPass('UX Audit retries=0 (via global config CI ? 0)');
+      } else {
+        recordFail(
+          'UX Audit CI step has --retries=0',
+          'The UX Audit e2e CI step does NOT include --retries=0, and the global playwright config allows retries > 0 on CI. Add --retries=0 to the npx playwright test command, OR set retries: process.env.CI ? 0 : 0 in playwright.config.js.',
+          '.github/workflows/ci-cd-unified.yml',
+          null,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Check that the CI workflow step for UX Audit does NOT have
+ * continue-on-error: true (which would mask failures).
+ */
+function checkCIWorkflowContinueOnError() {
+  const workflowPath = join(REPO, '.github', 'workflows', 'ci-cd-unified.yml');
+  if (!existsSync(workflowPath)) {
+    return;
+  }
+
+  const content = readFileSync(workflowPath, 'utf-8');
+
+  // Find the UX Audit step block
+  const uxStepMatch = content.match(
+    /name:\s*📸\s*UX Audit e2e.*?(?=\n\s*-\s*name:|\n\s*-\s*uses:|$)/s,
+  );
+  if (!uxStepMatch) {
+    return;
+  }
+
+  const uxStep = uxStepMatch[0];
+
+  if (/continue-on-error\s*:\s*true/i.test(uxStep)) {
+    recordFail(
+      'UX Audit step has no continue-on-error: true',
+      'The UX Audit e2e step has continue-on-error: true, which masks test failures. CI shows "success" even when tests fail. Remove the continue-on-error: true line.',
+      '.github/workflows/ci-cd-unified.yml',
+      null,
+    );
+  } else {
+    recordPass('UX Audit step has no continue-on-error: true');
+  }
+}
+
+// ─── Main ───────────────────────────────────────────────────────────
+
+log('');
+log('══════════════════════════════════════════════════════════════════════');
+log('  E2E Coverage Invariant — UX/Visual E2E must be fully executed');
+log('══════════════════════════════════════════════════════════════════════');
+log('');
+log('Checking for forbidden patterns (test.fixme, test.skip, etc.):');
+log('');
+
+for (const file of TARGET_E2E_FILES) {
+  checkFile(file);
+}
+
+log('');
+log('Checking retries configuration:');
+log('');
+checkRetriesConfig();
+
+log('');
+log('Checking CI workflow retries override:');
+log('');
+checkCIWorkflowRetries();
+
+log('');
+log('Checking CI workflow continue-on-error:');
+log('');
+checkCIWorkflowContinueOnError();
+
+log('');
+log('────────────────────────────────────────────────────────────────────');
+log(`  Result: ${passed} passed, ${failed} failed`);
+if (warnings.length > 0) {
+  log(`  Warnings: ${warnings.length}`);
+  warnings.forEach((w) => log(`    ⚠ ${w}`));
+}
+log('────────────────────────────────────────────────────────────────────');
+
+if (failed > 0) {
+  log('');
+  log('FAILURES:');
+  failures.forEach((f) => {
+    log(`  • ${f.name}`);
+    if (f.file) log(`    file: ${f.file}${f.line ? `:${f.line}` : ''}`);
+    if (f.reason) log(`    reason: ${f.reason}`);
+  });
+  log('');
+  log('This invariant exists because of a real incident where CI showed');
+  log('"success" while 18 of 27 UX/Visual tests were silently skipped.');
+  log('See PR #2715, #2716, #2717 for context.');
+  process.exit(1);
+}
+
+log('');
+log('✓ All E2E coverage invariants intact.');
+process.exit(0);


### PR DESCRIPTION
## Summary

- Add CI invariant that prevents the regression from PR #2715's incident: CI showed "success" while 18 of 27 UX/Visual tests were silently skipped via `test.fixme` + `continue-on-error: true`.
- The invariant forbids `test.fixme`, `test.skip`, `describe.skip`, `it.skip`, `test.only` in the 3 target UX/Visual E2E files.
- Enforces `retries=0` for UX/Visual suite (via `--retries=0` in CI command).
- Adds a runtime test-count check: Playwright output is parsed to verify `passed ≥ 27, skipped = 0, failed = 0`.
- Scope: ONLY the 3 UX/Visual E2E files. Other suites (business/, security/, load/, chaos/) are NOT checked.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `f73dcec` (PR #2717 merge commit).
- Clean workspace: 3 files changed, +492/-1 lines.
- Branch: `fix/e2e-ci-invariant`
- Scope gate: allowed `scripts/e2e-coverage-invariant.mjs`, `.github/workflows/e2e-coverage-invariant.yml`, `.github/workflows/ci-cd-unified.yml`. Denied unrelated frontend source, backend, migrations.
- Red-check handling: if any CI check is red, the issue will be fixed in this same PR before merge.

## Contract Impact

not applicable - CI infrastructure only. No API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - CI infrastructure only, no frontend data flow.
- Partial data proof: not applicable - CI infrastructure only.
- Forbidden secondary path behavior: not applicable - CI infrastructure only.
- Missing draft/resource behavior: not applicable - CI infrastructure only.
- Stale route/deep-link behavior: not applicable - CI infrastructure only.

## Scope Gate

- Allowed paths: `scripts/e2e-coverage-invariant.mjs`, `.github/workflows/e2e-coverage-invariant.yml`, `.github/workflows/ci-cd-unified.yml`
- Denied paths: all backend, all frontend source (`src/`), all migrations, all configs
- Migration/docs/test impact: 0 migrations, 0 docs, 1 new script + 1 new workflow + 1 modified workflow
- Rollback note: revert the 3-file commit. No data migrations, no env changes.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: `node scripts/e2e-coverage-invariant.mjs`
- Result: **6 passed, 0 failed** on current main baseline
- Negative test: temporarily added `test.fixme(...)` to cashier-ux-audit.spec.ts → invariant correctly detected it (1 failed). Removed after verification.
- Not checked: the runtime test-count check step will be verified by CI on this PR.

## What the invariant enforces

### Source-level checks (scripts/e2e-coverage-invariant.mjs)

| Check | Pattern | Reason |
|-------|---------|--------|
| test.fixme | `test.fixme(` | Silently excludes test from execution |
| test.skip | `test.skip(` | Silently excludes test from execution |
| describe.skip | `describe.skip(` | Silently excludes entire describe block |
| describe.fixme | `describe.fixme(` | Silently excludes entire describe block |
| it.skip | `it.skip(` | Silently excludes test |
| it.fixme | `it.fixme(` | Silently excludes test |
| test.only | `test.only(` | Runs only one test, skips all others |

### Configuration checks

| Check | Requirement |
|-------|-------------|
| retries=0 on CI | Global config `retries: 0` OR CI step has `--retries=0` |
| continue-on-error | UX Audit CI step must NOT have `continue-on-error: true` |

### Runtime check (CI workflow step)

The "🔒 UX/Visual E2E test count invariant" step:
1. Parses the Playwright output (tee'd to `ux-audit-output.txt`)
2. Extracts the final summary line (e.g. `27 passed (2.0m)`)
3. Verifies: `passed ≥ 27`, `skipped = 0`, `failed = 0`
4. Fails the CI step if any constraint is violated

This catches the failure mode where tests are silently excluded at runtime — even if the source-level patterns somehow pass (e.g. dynamic skip via `test.skip(condition, ...)`).

## Why this invariant matters

PR #2715 had `continue-on-error: true` on the UX Audit step. 18 of 27 tests were marked `test.fixme`. CI showed "success" because:
1. `test.fixme` excluded the tests from execution (Playwright reported `passed` count without them)
2. `continue-on-error: true` masked the fact that tests were excluded
3. No check verified the ACTUAL number of tests that ran

This invariant closes all three holes:
1. Source-level: `test.fixme`/`test.skip` are now forbidden → CI fails at the invariant check
2. Config-level: `continue-on-error: true` is forbidden → CI fails at the invariant check
3. Runtime-level: the test-count step verifies ≥27 passed, 0 skipped → CI fails if count drops

## Files Changed

| File | Changes |
|------|---------|
| `scripts/e2e-coverage-invariant.mjs` | New script: 7 source-level pattern checks + retries config check + continue-on-error check (392 lines) |
| `.github/workflows/e2e-coverage-invariant.yml` | New standalone workflow: runs the invariant on PR/push when target files change |
| `.github/workflows/ci-cd-unified.yml` | Added `--retries=0` to UX Audit command + added "🔒 UX/Visual E2E test count invariant" step that parses Playwright output |

## NOT in this PR

- Gate C bypass items A, C (separate PRs per user direction).
- P2-3 Finding C (separate PR).

## Refs

Follows PR #2715, #2716, #2717 (E2E fixme tests fixed). User direction: "сделать отдельный PR для CI invariant... Запретить test.fixme, test.skip, describe.skip и аналогичные... Сделать нарушение blocking CI failure... CI должен проверять не только exit code Playwright, но и фактическое количество выполненных тестов."
