### PR TITLE
fix(gate-c): bypass C — migrate registrar cancel to VisitLifecycleService

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard/_visits.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard/_visits.py
@@ -894,14 +894,55 @@ def _run_single_registrar_record_action(
 
         if action == "cancel":
             if record_kind == "visit":
-                visit = VisitsApiService(db).set_status(
+                # Gate C bypass fix: delegate to VisitLifecycleService.cancel_visit()
+                # instead of VisitsApiService.set_status().
+                #
+                # The old code (VisitsApiService.set_status) bypassed the state
+                # machine — it did NOT call is_valid_visit_transition(), allowing
+                # invalid transitions like completed→canceled, closed→canceled,
+                # expired→canceled. These silently broke financial/EMR invariants
+                # (a completed visit has clinical work done; a closed visit has
+                # EMR signed + payment collected).
+                #
+                # VisitLifecycleService.cancel_visit() provides:
+                #   - SELECT FOR UPDATE row lock (concurrency safety)
+                #   - is_valid_visit_transition() validation (state machine)
+                #   - Audit logging (logger.info with visit_id, user_id, reason)
+                #   - commit=False for caller-controlled transaction
+                #
+                # If the transition is invalid (e.g. completed→canceled), the
+                # service raises HTTPException(409), which is caught by the
+                # outer except HTTPException → returns success=False with error.
+                from app.services.visit_lifecycle_service import VisitLifecycleService
+
+                visit = VisitLifecycleService(db).cancel_visit(
                     visit_id=record_id,
-                    status_new="canceled",
+                    current_user=current_user,
+                    reason=request.reason,
+                    commit=False,  # caller owns the transaction
                 )
                 if request.reason:
                     visit.notes = (visit.notes or "") + f"\nCanceled: {request.reason}"
-                    db.commit()
-                    db.refresh(visit)
+                # Cascade cancel to queue entries (preserves behavior of the
+                # old VisitsApiService.set_status which did this internally).
+                # Uses commit=False — the cascade is staged in the same
+                # transaction as the visit status change.
+                try:
+                    from app.api.v1.endpoints.visits import (
+                        _update_queue_entries_for_visit_owner,
+                    )
+                    _update_queue_entries_for_visit_owner(
+                        db,
+                        visit_id=record_id,
+                        patient_id=visit.patient_id,
+                        status_value="canceled",
+                    )
+                except Exception:
+                    # Queue cascade failure must not block visit cancellation
+                    # (same behavior as the old code).
+                    pass
+                db.commit()
+                db.refresh(visit)
                 result = {"id": visit.id, "status": visit.status}
             elif record_kind == "online_queue":
                 entry = OnlineQueueNewService(db).cancel_entry(entry_id=record_id)

--- a/backend/tests/regression/test_gate_c_bypass_c_registrar_cancel.py
+++ b/backend/tests/regression/test_gate_c_bypass_c_registrar_cancel.py
@@ -1,0 +1,388 @@
+"""Regression tests for Gate C bypass C: registrar_wizard cancel action.
+
+Gate C bypass C (visits_api_service.py:set_status) was a real bypass
+of the visit state machine. The old code called
+``VisitsApiService.set_status(visit_id, status_new="canceled")`` which
+did NOT call ``is_valid_visit_transition()``, allowing invalid
+transitions like:
+
+    completed → canceled  (clinical work done, EMR may be signed)
+    closed → canceled     (EMR signed + payment collected)
+    expired → canceled    (confirmation timeout bypassed)
+
+Fix: migrate the caller (``registrar_wizard/_visits.py:897``) to
+``VisitLifecycleService.cancel_visit()``, which provides:
+    - SELECT FOR UPDATE row lock (concurrency safety)
+    - is_valid_visit_transition() validation (state machine)
+    - Audit logging (logger.info with visit_id, user_id, reason)
+    - commit=False for caller-controlled transaction
+
+These tests verify:
+    1. Valid transitions still succeed (open→canceled, confirmed→canceled, etc.)
+    2. Invalid transitions are rejected (completed→canceled, closed→canceled, expired→canceled)
+    3. Rollback: no partial persistence on rejection
+    4. request.reason is passed to the lifecycle service (audit logging)
+
+Run:
+    pytest backend/tests/regression/test_gate_c_bypass_c_registrar_cancel.py -v
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, UTC
+
+import pytest
+
+from app.models.visit import Visit
+
+
+def _create_visit_with_status(db_session, test_patient, test_doctor, status: str) -> Visit:
+    """Create a visit with the given status (bypasses state machine for setup)."""
+    visit = Visit(
+        patient_id=test_patient.id,
+        doctor_id=test_doctor.id,
+        visit_date=date.today(),
+        visit_time="10:00",
+        status=status,
+        discount_mode="none",
+        department="cardiology",
+        confirmation_token=f"test-token-{status}-{id(test_patient)}",
+        confirmation_channel="telegram",
+        confirmation_expires_at=datetime.now(UTC),
+        confirmed_at=datetime.now(UTC) if status != "pending_confirmation" else None,
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(visit)
+    db_session.commit()
+    db_session.refresh(visit)
+    return visit
+
+
+@pytest.mark.integration
+class TestGateCBypassCRegistrarCancel:
+    """Gate C bypass C: registrar cancel must use VisitLifecycleService."""
+
+    # ─── Valid transitions (should succeed) ───────────────────────────
+
+    def test_cancel_open_visit_succeeds(
+        self, client, db_session, registrar_auth_headers, test_patient, test_doctor
+    ):
+        """open → canceled: valid transition, should succeed."""
+        visit = _create_visit_with_status(db_session, test_patient, test_doctor, "open")
+
+        response = client.post(
+            "/api/v1/registrar/records/actions",
+            headers=registrar_auth_headers,
+            json={
+                "action": "cancel",
+                "records": [{"record_kind": "visit", "record_id": visit.id}],
+                "reason": "Patient requested cancellation",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["results"][0]["success"] is True
+
+        db_session.refresh(visit)
+        assert visit.status == "canceled"
+
+    def test_cancel_confirmed_visit_succeeds(
+        self, client, db_session, registrar_auth_headers, test_patient, test_doctor
+    ):
+        """confirmed → canceled: valid transition per state machine."""
+        visit = _create_visit_with_status(db_session, test_patient, test_doctor, "confirmed")
+
+        response = client.post(
+            "/api/v1/registrar/records/actions",
+            headers=registrar_auth_headers,
+            json={
+                "action": "cancel",
+                "records": [{"record_kind": "visit", "record_id": visit.id}],
+                "reason": "Patient changed mind",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["results"][0]["success"] is True
+
+        db_session.refresh(visit)
+        assert visit.status == "canceled"
+
+    def test_cancel_in_progress_visit_succeeds(
+        self, client, db_session, registrar_auth_headers, test_patient, test_doctor
+    ):
+        """in_progress → canceled: valid transition per state machine."""
+        visit = _create_visit_with_status(db_session, test_patient, test_doctor, "in_progress")
+
+        response = client.post(
+            "/api/v1/registrar/records/actions",
+            headers=registrar_auth_headers,
+            json={
+                "action": "cancel",
+                "records": [{"record_kind": "visit", "record_id": visit.id}],
+                "reason": "Doctor called in sick",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["results"][0]["success"] is True
+
+        db_session.refresh(visit)
+        assert visit.status == "canceled"
+
+    def test_cancel_pending_confirmation_visit_succeeds(
+        self, client, db_session, registrar_auth_headers, test_patient, test_doctor
+    ):
+        """pending_confirmation → canceled: valid transition per state machine."""
+        visit = _create_visit_with_status(
+            db_session, test_patient, test_doctor, "pending_confirmation"
+        )
+
+        response = client.post(
+            "/api/v1/registrar/records/actions",
+            headers=registrar_auth_headers,
+            json={
+                "action": "cancel",
+                "records": [{"record_kind": "visit", "record_id": visit.id}],
+                "reason": "Patient did not confirm",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["success"] is True
+        assert payload["results"][0]["success"] is True
+
+        db_session.refresh(visit)
+        assert visit.status == "canceled"
+
+    # ─── Invalid transitions (should be rejected — bypass fix) ────────
+
+    def test_cancel_completed_visit_rejected(
+        self, client, db_session, registrar_auth_headers, test_patient, test_doctor
+    ):
+        """completed → canceled: MUST be rejected.
+
+        A completed visit has clinical work finished. The state machine
+        only allows completed → in_progress (re-open) or completed → closed
+        (finalize). Canceling a completed visit loses the clinical audit
+        trail and may leave orphaned EMR records.
+
+        Before fix: VisitsApiService.set_status allowed this silently.
+        After fix: VisitLifecycleService.cancel_visit raises 409.
+        """
+        visit = _create_visit_with_status(db_session, test_patient, test_doctor, "completed")
+
+        response = client.post(
+            "/api/v1/registrar/records/actions",
+            headers=registrar_auth_headers,
+            json={
+                "action": "cancel",
+                "records": [{"record_kind": "visit", "record_id": visit.id}],
+                "reason": "Trying to cancel completed visit",
+            },
+        )
+
+        assert response.status_code == 200  # endpoint returns 200 with error in payload
+        payload = response.json()
+        # The action should fail (not succeed) — bypass is closed.
+        assert payload["results"][0]["success"] is False, (
+            "Canceling a completed visit must NOT succeed — this is the Gate C bypass C fix. "
+            "VisitLifecycleService.cancel_visit should reject completed→canceled."
+        )
+
+        # CRITICAL: visit status must NOT change.
+        db_session.refresh(visit)
+        assert visit.status == "completed", (
+            f"Completed visit status was changed to '{visit.status}'. "
+            f"Terminal/non-terminal→canceled bypass must NOT mutate status."
+        )
+
+    def test_cancel_closed_visit_rejected(
+        self, client, db_session, registrar_auth_headers, test_patient, test_doctor
+    ):
+        """closed → canceled: MUST be rejected.
+
+        A closed visit has EMR signed + payment collected. Canceling it
+        would break financial/EMR invariants. The only path to reopen
+        is admin force_reopen, not a registrar cancel.
+        """
+        visit = _create_visit_with_status(db_session, test_patient, test_doctor, "closed")
+
+        response = client.post(
+            "/api/v1/registrar/records/actions",
+            headers=registrar_auth_headers,
+            json={
+                "action": "cancel",
+                "records": [{"record_kind": "visit", "record_id": visit.id}],
+                "reason": "Trying to cancel closed visit",
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["results"][0]["success"] is False, (
+            "Canceling a closed visit must NOT succeed — terminal status bypass."
+        )
+
+        db_session.refresh(visit)
+        assert visit.status == "closed", (
+            f"Closed visit status was changed to '{visit.status}'. "
+            f"Terminal→canceled bypass must NOT mutate status."
+        )
+
+    def test_cancel_expired_visit_rejected(
+        self, client, db_session, registrar_auth_headers, test_patient, test_doctor
+    ):
+        """expired → canceled: MUST be rejected.
+
+        An expired visit has confirmation timeout. Canceling it bypasses
+        the confirmation security policy. The only path is admin force_reopen.
+        """
+        visit = _create_visit_with_status(db_session, test_patient, test_doctor, "expired")
+
+        response = client.post(
+            "/api/v1/registrar/records/actions",
+            headers=registrar_auth_headers,
+            json={
+                "action": "cancel",
+                "records": [{"record_kind": "visit", "record_id": visit.id}],
+                "reason": "Trying to cancel expired visit",
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["results"][0]["success"] is False, (
+            "Canceling an expired visit must NOT succeed — terminal status bypass."
+        )
+
+        db_session.refresh(visit)
+        assert visit.status == "expired", (
+            f"Expired visit status was changed to '{visit.status}'. "
+            f"Terminal→canceled bypass must NOT mutate status."
+        )
+
+    # ─── Idempotent / edge cases ──────────────────────────────────────
+
+    def test_cancel_already_canceled_visit_idempotent(
+        self, client, db_session, registrar_auth_headers, test_patient, test_doctor
+    ):
+        """canceled → canceled: idempotent success (no-op).
+
+        The state machine allows same-status transitions as idempotent
+        no-ops (duplicate click protection). This is INTENTIONAL —
+        a registrar clicking "cancel" twice on an already-canceled
+        visit should not get an error, just a no-op success.
+
+        This test pins that behavior: the cancel succeeds, but the
+        visit status stays "canceled" (no mutation to a different status).
+        """
+        visit = _create_visit_with_status(db_session, test_patient, test_doctor, "canceled")
+
+        response = client.post(
+            "/api/v1/registrar/records/actions",
+            headers=registrar_auth_headers,
+            json={
+                "action": "cancel",
+                "records": [{"record_kind": "visit", "record_id": visit.id}],
+                "reason": "Duplicate cancel attempt",
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        # Idempotent success — no error, but no status change either.
+        assert payload["results"][0]["success"] is True
+
+        db_session.refresh(visit)
+        assert visit.status == "canceled"
+
+    # ─── Rollback / partial persistence ───────────────────────────────
+
+    def test_cancel_rejection_no_partial_persistence(
+        self, client, db_session, registrar_auth_headers, test_patient, test_doctor
+    ):
+        """Invalid cancel must NOT partially persist.
+
+        When cancel_visit raises 409, the transaction must roll back:
+        - visit.status unchanged
+        - visit.notes unchanged (no "Canceled: ..." appended)
+        - No orphaned queue entry updates
+
+        This verifies the caller-controlled transaction (commit=False)
+        correctly rolls back on rejection.
+        """
+        visit = _create_visit_with_status(db_session, test_patient, test_doctor, "completed")
+        original_notes = visit.notes
+
+        response = client.post(
+            "/api/v1/registrar/records/actions",
+            headers=registrar_auth_headers,
+            json={
+                "action": "cancel",
+                "records": [{"record_kind": "visit", "record_id": visit.id}],
+                "reason": "Should not persist",
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["results"][0]["success"] is False
+
+        db_session.refresh(visit)
+        # Status must NOT change.
+        assert visit.status == "completed"
+        # Notes must NOT have "Canceled: ..." appended (rollback worked).
+        assert visit.notes == original_notes or (
+            visit.notes is not None and "Canceled: Should not persist" not in visit.notes
+        ), (
+            f"Notes were partially persisted: '{visit.notes}'. "
+            f"Transaction should have rolled back on rejection."
+        )
+
+    # ─── request.reason audit ─────────────────────────────────────────
+
+    def test_cancel_reason_passed_to_lifecycle_service(
+        self, client, db_session, registrar_auth_headers, test_patient, test_doctor
+    ):
+        """request.reason must be passed to VisitLifecycleService.cancel_visit().
+
+        The lifecycle service logs the reason via logger.info for audit.
+        This test verifies the reason is threaded through (not just
+        appended to notes).
+
+        We verify by checking that a valid cancel succeeds AND the reason
+        appears in the notes (which the caller appends after the lifecycle
+        call succeeds). If the lifecycle service rejected, notes would
+        not be updated.
+        """
+        visit = _create_visit_with_status(db_session, test_patient, test_doctor, "open")
+        reason = "Patient moved to another city"
+
+        response = client.post(
+            "/api/v1/registrar/records/actions",
+            headers=registrar_auth_headers,
+            json={
+                "action": "cancel",
+                "records": [{"record_kind": "visit", "record_id": visit.id}],
+                "reason": reason,
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["results"][0]["success"] is True
+
+        db_session.refresh(visit)
+        assert visit.status == "canceled"
+        # Reason should appear in notes (caller appends it after lifecycle success).
+        assert reason in (visit.notes or ""), (
+            f"Reason '{reason}' not found in visit.notes: '{visit.notes}'. "
+            f"The reason should be appended to notes after lifecycle success."
+        )


### PR DESCRIPTION
## Summary

- Fix Gate C bypass C: migrate `registrar_wizard/_visits.py:897` cancel action from `VisitsApiService.set_status()` to `VisitLifecycleService.cancel_visit()`.
- The old code bypassed the state machine — no `is_valid_visit_transition()` check — allowing invalid transitions like `completed → canceled`, `closed → canceled`, `expired → canceled`.
- 10 regression tests added: 4 valid transitions, 3 invalid (bypass fix), 3 edge cases (idempotent, rollback, reason audit).

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `974648e` (PR #2718 merge commit).
- Clean workspace: 2 files changed, +433/-4 lines.
- Branch: `fix/gate-c-bypass-registrar-cancel`
- Scope gate: allowed `backend/app/api/v1/endpoints/registrar_wizard/_visits.py`, `backend/tests/regression/test_gate_c_bypass_c_registrar_cancel.py`. Denied unrelated frontend, backend services, migrations.
- Red-check handling: if any CI check is red, the issue will be fixed in this same PR before merge.

## Contract Impact

- Canonical surface: `registrar_wizard/_visits.py` cancel action (record_kind == "visit", action == "cancel").
- Request shape: unchanged (`POST /registrar/records/actions` with action="cancel").
- Response shape: unchanged — success returns `{"success": true, "results": [...]}`. Invalid transitions now return `{"success": true, "results": [{"success": false, "error": "..."}]}` (endpoint catches HTTPException 409 and converts to error item, same as other actions).
- Status codes: endpoint returns 200 with per-record success/failure (batch contract). Individual invalid transitions are reported as `success: false` in the results array.
- Frontend consumer: registrar panel cancel button. The frontend already handles per-record success/failure (batch contract). No frontend change needed.
- Compatibility path or alias: none.
- Contract proof: 10 regression tests verify valid + invalid transitions, rollback, and reason audit.

## RBAC / Permissions

- Roles allowed: Admin, Registrar, Cashier, Receptionist, Doctor, cardio, cardiology, cardiologist, derma, dermatologist, dentist, Lab (unchanged — same as before).
- Roles denied: none changed.
- Positive auth proof: `test_cancel_open_visit_succeeds` with `registrar_auth_headers` succeeds.
- Negative auth proof: `test_registrar_record_action_rejects_doctor_mark_paid` (existing test) still passes — role enforcement unchanged.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed. The cancel action may trigger notifications via existing `_emit_payment_notification` flow, but that is unchanged.

## Frontend Resilience

- Empty data proof: not applicable - no frontend data flow changes.
- Partial data proof: `test_cancel_rejection_no_partial_persistence` verifies that when cancel is rejected (e.g. completed→canceled), NO partial persistence occurs — visit status unchanged, notes unchanged, no orphaned queue updates.
- Forbidden secondary path behavior: the fix closes the bypass that allowed terminal→canceled transitions. Now only `force_reopen` (Admin break-glass) can move out of terminal status.
- Missing draft/resource behavior: not applicable - no draft/resource scenarios affected.
- Stale route/deep-link behavior: not applicable - no routing changes.

## Scope Gate

- Allowed paths: `backend/app/api/v1/endpoints/registrar_wizard/_visits.py`, `backend/tests/regression/test_gate_c_bypass_c_registrar_cancel.py`
- Denied paths: all frontend, all other backend services, `VisitsApiService` (not modified — may still be used elsewhere), `VisitLifecycleService` (not modified), migrations, configs
- Migration/docs/test impact: 0 migrations, 0 docs, 1 production file modified + 1 new test file
- Rollback note: revert the 2-file commit. The old `VisitsApiService.set_status()` is still available (not removed). No data migrations, no env changes.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: `pytest backend/tests/regression/test_gate_c_bypass_c_registrar_cancel.py -v`
- Result: **10 passed, 0 failed** in 5.18s
- Related tests: `pytest tests/integration/test_registrar_record_actions.py tests/unit/test_visits_router_service_wiring.py` → **15 passed, 0 failed**
- Not checked: Gate C bypass A (visits.py endpoint) — separate item, not in this PR.

## Root Cause Analysis

### The bypass

`VisitsApiService.set_status()` (backend/app/services/visits_api_service.py:314) does NOT call `is_valid_visit_transition()`. It directly sets `visit.status = status_new` after only checking that `status_new` is in the accepted set. This allows any → canceled transition, including from terminal statuses.

### The caller

`registrar_wizard/_visits.py:897` — the registrar "cancel" action (`POST /registrar/records/actions` with action="cancel", record_kind="visit"). Called without pre-validation of current visit status. Roles: Admin, Registrar, Cashier, Receptionist, Doctor, Lab.

### The fix

Migrate the caller to `VisitLifecycleService.cancel_visit()`:
```python
visit = VisitLifecycleService(db).cancel_visit(
    visit_id=record_id,
    current_user=current_user,
    reason=request.reason,
    commit=False,  # caller owns the transaction
)
```

This provides:
- `SELECT FOR UPDATE` row lock (concurrency safety)
- `is_valid_visit_transition()` validation (state machine)
- Audit logging (`logger.info` with visit_id, user_id, reason)
- `commit=False` for caller-controlled transaction

Queue entry cascade is preserved by calling `_update_queue_entries_for_visit_owner()` after the lifecycle call succeeds (same transaction).

### What is NOT changed

- `VisitsApiService.set_status()` is NOT removed — it may have other callers (audit found only 1, but defensive).
- `VisitsApiService.set_status()` is NOT modified — the bypass is closed at the caller, not at the service.
- Gate C bypass A (visits.py endpoint) is NOT touched — it already validates transitions (not a bypass).
- State machine rules are NOT changed.
- `force_reopen` is NOT touched.

## Verification

| Scenario | Before fix | After fix |
|----------|-----------|-----------|
| open → canceled | ✓ success | ✓ success |
| confirmed → canceled | ✓ success | ✓ success |
| in_progress → canceled | ✓ success | ✓ success |
| pending_confirmation → canceled | ✓ success | ✓ success |
| completed → canceled | **✓ success (BYPASS)** | **✗ rejected (409)** |
| closed → canceled | **✓ success (BYPASS)** | **✗ rejected (409)** |
| expired → canceled | **✓ success (BYPASS)** | **✗ rejected (409)** |
| canceled → canceled | ✓ success (idempotent) | ✓ success (idempotent) |
| Rollback on rejection | N/A (no rejection) | ✓ no partial persistence |
| request.reason audit | ✗ only in notes | ✓ in lifecycle logger + notes |

## Files Changed

| File | Changes |
|------|---------|
| `backend/app/api/v1/endpoints/registrar_wizard/_visits.py` | Cancel action migrated to `VisitLifecycleService.cancel_visit(commit=False, reason=...)`. Queue cascade preserved via `_update_queue_entries_for_visit_owner()`. (+45/-4) |
| `backend/tests/regression/test_gate_c_bypass_c_registrar_cancel.py` | New file: 10 regression tests (4 valid, 3 invalid, 3 edge cases) (+388) |

## NOT in this PR

- Gate C bypass A (visits.py endpoint) — not a bypass, future refactor only.
- P2-3 Finding C (audit-trail loss on terminal→non-terminal callback) — separate audit-gap, low priority.
- VisitsApiService.set_status() removal — not modified (defensive; may have other callers).
- State machine rules — not changed.
- force_reopen — not touched.

## Refs

Follows PR #2714 (Gate C D/E fixed), #2716 (PR A — 7 registrar fixme), #2717 (PR B — visual regression), #2718 (CI invariant). User direction: "PR для C — рекомендуемый scope... не расширять PR за пределы этого конкретного bypass."
