### PR TITLE
fix(e2e): flaky keyboard test + CI invariant parser (failed count missed)

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -806,12 +806,17 @@ jobs:
           echo "ERROR: ux-audit-output.txt not found. The UX Audit step may not have run."
           exit 1
         fi
-        # Extract the final summary line (e.g. "  27 passed (2.0m)")
-        SUMMARY=$(grep -E "^\s+[0-9]+ passed" ux-audit-output.txt | tail -1)
-        echo "Playwright summary: $SUMMARY"
-        PASSED=$(echo "$SUMMARY" | grep -oE "[0-9]+ passed" | grep -oE "[0-9]+" || echo "0")
-        SKIPPED=$(echo "$SUMMARY" | grep -oE "[0-9]+ skipped" | grep -oE "[0-9]+" || echo "0")
-        FAILED=$(echo "$SUMMARY" | grep -oE "[0-9]+ failed" | grep -oE "[0-9]+" || echo "0")
+        # Playwright outputs the summary on MULTIPLE lines when there are failures:
+        #   1 failed
+        #   26 passed (2.2m)
+        # We must extract ALL summary lines (failed, passed, skipped) separately.
+        FAILED_SUMMARY=$(grep -E "^\s+[0-9]+ failed" ux-audit-output.txt | tail -1 || echo "0 failed")
+        PASSED_SUMMARY=$(grep -E "^\s+[0-9]+ passed" ux-audit-output.txt | tail -1 || echo "0 passed")
+        SKIPPED_SUMMARY=$(grep -E "^\s+[0-9]+ skipped" ux-audit-output.txt | tail -1 || echo "0 skipped")
+        echo "Playwright summary: $FAILED_SUMMARY $PASSED_SUMMARY $SKIPPED_SUMMARY"
+        PASSED=$(echo "$PASSED_SUMMARY" | grep -oE "[0-9]+ passed" | grep -oE "[0-9]+" || echo "0")
+        SKIPPED=$(echo "$SKIPPED_SUMMARY" | grep -oE "[0-9]+ skipped" | grep -oE "[0-9]+" || echo "0")
+        FAILED=$(echo "$FAILED_SUMMARY" | grep -oE "[0-9]+ failed" | grep -oE "[0-9]+" || echo "0")
         echo "Parsed: passed=$PASSED skipped=$SKIPPED failed=$FAILED"
         if [ "$FAILED" != "0" ]; then
           echo "ERROR: $FAILED test(s) failed. UX/Visual E2E must have 0 failures."

--- a/frontend/e2e/registrar-ux-audit.spec.ts
+++ b/frontend/e2e/registrar-ux-audit.spec.ts
@@ -257,15 +257,16 @@ test.describe('UX Audit Registrar — new interactions', () => {
 
     // ArrowRight should switch to "Женский"
     await radiogroup.press('ArrowRight');
-    await page.waitForTimeout(300);
 
     const femaleRadio = radiogroup.locator('[role="radio"]').filter({ hasText: 'Женский' });
-    await expect(femaleRadio).toHaveAttribute('aria-checked', 'true');
+    // Use expect with timeout instead of fixed waitForTimeout — React state
+    // update may take variable time, and the assertion polls until it passes
+    // or times out. This is more reliable than a fixed 300ms sleep.
+    await expect(femaleRadio).toHaveAttribute('aria-checked', 'true', { timeout: 5000 });
 
     // ArrowLeft should switch back to "Мужской"
     await radiogroup.press('ArrowLeft');
-    await page.waitForTimeout(300);
-    await expect(maleRadio).toHaveAttribute('aria-checked', 'true');
+    await expect(maleRadio).toHaveAttribute('aria-checked', 'true', { timeout: 5000 });
   });
 
   // ========================================================================


### PR DESCRIPTION
## Summary

- Fix flaky E2E test: `gender radiogroup supports keyboard navigation` was flaky due to fixed `waitForTimeout(300)` before `aria-checked` assertion. Replaced with `expect().toHaveAttribute` with `timeout: 5000` (polls until pass or timeout).
- Fix CI invariant parser: when a test FAILED, Playwright outputs `1 failed` and `26 passed` on SEPARATE lines. The parser extracted only `26 passed` and missed `1 failed`, so the invariant incorrectly reported `0 failed` while a test actually failed. Fix: extract failed/passed/skipped from SEPARATE grep commands.

## Cyclic Execution Evidence

- Fresh main sync: branch created from `origin/main` at `16172d2` (PR #2719 merge commit).
- Clean workspace: 2 files changed, +16/-10 lines.
- Branch: `fix/gate-c-flaky-test-and-invariant-parser`
- Scope gate: allowed `frontend/e2e/registrar-ux-audit.spec.ts`, `.github/workflows/ci-cd-unified.yml`. Denied unrelated frontend source, backend, migrations.
- Red-check handling: if any CI check is red, the issue will be fixed in this same PR before merge.

## Contract Impact

not applicable - test-only + CI config. No API, websocket, event, or frontend consumer contract changed.

## RBAC / Permissions

not applicable - no route, endpoint, guard, role helper, or auth-sensitive behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

- Empty data proof: not applicable - test-only changes, no frontend data flow.
- Partial data proof: not applicable - test-only changes, no frontend data flow.
- Forbidden secondary path behavior: not applicable - test-only changes, no auth path.
- Missing draft/resource behavior: not applicable - test-only changes, no draft/resource scenarios.
- Stale route/deep-link behavior: not applicable - test-only changes, no routing changes.

## Scope Gate

- Allowed paths: `frontend/e2e/registrar-ux-audit.spec.ts`, `.github/workflows/ci-cd-unified.yml`
- Denied paths: all backend, all frontend source (`src/`), all migrations, all configs
- Migration/docs/test impact: 0 migrations, 0 docs, 1 test file modified + 1 CI config modified
- Rollback note: revert the 2-file commit. No data migrations, no env changes.

## DevBrain Memory Impact

- [x] no durable memory update needed

## Validation

- Targeted tests or smoke run: `npx playwright test e2e/registrar-ux-audit.spec.ts --project=chromium`
- Result: **9 passed, 0 failed** (including the previously flaky test)
- Not checked: the invariant parser fix will be verified by CI on this PR.

## Root Cause Analysis

### 1. Flaky test: `gender radiogroup supports keyboard navigation`

The test used a fixed `waitForTimeout(300)` after pressing `ArrowRight` / `ArrowLeft` before asserting `aria-checked`. In CI (slower than local), the React state update could take longer than 300ms, causing the assertion to fail.

Fix: replace fixed sleep with `expect().toHaveAttribute` with `timeout: 5000`. This polls until the attribute matches or times out — more reliable than a fixed sleep.

### 2. CI invariant parser: missed `failed` count

When a test fails, Playwright outputs the summary on MULTIPLE lines:
```
  1 failed
  26 passed (2.2m)
```

The old parser extracted only the `passed` line via `grep -E "^\s+[0-9]+ passed"`. The `1 failed` line was on a separate line and was missed. The parser then reported `passed=26 skipped=0 failed=0` — incorrectly claiming 0 failures.

The invariant step DID catch the issue (passed < 27), but for the wrong reason (count, not failure). This masked the actual failure message.

Fix: extract `failed`, `passed`, and `skipped` from SEPARATE grep commands so all three are captured independently. Now the parser correctly reports `failed=1` when a test fails.

## Files Changed

| File | Changes |
|------|---------|
| `frontend/e2e/registrar-ux-audit.spec.ts` | Replaced fixed `waitForTimeout(300)` with `expect().toHaveAttribute({ timeout: 5000 })` for keyboard navigation assertions |
| `.github/workflows/ci-cd-unified.yml` | Fixed invariant parser to extract failed/passed/skipped from separate grep commands |

## NOT in this PR

- Gate C bypass C (already merged in PR #2719).
- P2-3 Finding C (separate audit-gap, low priority).
- Other flaky tests (none identified currently).

## Refs

Follows PR #2719 (Gate C bypass C) and PR #2718 (CI invariant). The invariant correctly caught the flaky test failure on main CI #6561, but the parser reported the wrong reason. This PR fixes both the flaky test and the parser.
