### PR TITLE
fix(security): use execFileSync with argv array in type-debt-check

### DIFF
--- a/scripts/type-debt-check.mjs
+++ b/scripts/type-debt-check.mjs
@@ -25,7 +25,7 @@
  *   1 — debt exceeded baseline OR undocumented casts found (CI failure)
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { readFileSync } from 'fs';
@@ -74,10 +74,18 @@ const TECH_DEBT_PATTERN = /TECH-DEBT\([a-z0-9-]+\)/i;
 function runRgCount(pattern, cwd) {
   // rg -c returns `path:count` per file (one line per file with matches).
   // Exclude .d.ts ambient declaration files — see comment in findUndocumentedCasts.
+  //
+  // SECURITY (CodeQL js/shell-command-injection-from-environment #1249):
+  // Previously used execSync with a shell string `${pattern} ${cwd}` which
+  // could allow argument injection if pattern/cwd ever came from untrusted
+  // input. While both are currently trusted constants, we switch to
+  // execFileSync with an explicit argv array — this never invokes a shell,
+  // so there's no injection vector even if the inputs become untrusted later.
   try {
-    const output = execSync(`rg -c '${pattern}' ${cwd} -g '!*.d.ts' 2>/dev/null || true`, {
+    const output = execFileSync('rg', ['-c', pattern, cwd, '-g', '!*.d.ts'], {
       encoding: 'utf-8',
       maxBuffer: 1024 * 1024 * 10,
+      stdio: ['ignore', 'pipe', 'ignore'],  // suppress stderr (rg exits 1 on no matches)
     });
     return output
       .trim()
@@ -95,10 +103,14 @@ function runRgCount(pattern, cwd) {
 function runRgLines(pattern, cwd) {
   // rg -n returns `path:line:content` per match (one line per match).
   // Exclude .d.ts ambient declaration files — see comment in findUndocumentedCasts.
+  //
+  // SECURITY (CodeQL js/shell-command-injection-from-environment #1250):
+  // Same hardening as runRgCount — use execFileSync with argv array.
   try {
-    return execSync(`rg -n '${pattern}' ${cwd} -g '!*.d.ts' 2>/dev/null || true`, {
+    return execFileSync('rg', ['-n', pattern, cwd, '-g', '!*.d.ts'], {
       encoding: 'utf-8',
       maxBuffer: 1024 * 1024 * 10,
+      stdio: ['ignore', 'pipe', 'ignore'],
     });
   } catch {
     return '';


### PR DESCRIPTION
## Summary

Closes **2 CodeQL alerts** in `scripts/type-debt-check.mjs`:

| Rule | Count | Alert IDs |
|------|-------|-----------|
| `js/shell-command-injection-from-environment` | 2 | #1249, #1250 |

## Root cause

`runRgCount` and `runRgLines` used `execSync` with a **shell string**:

```javascript
execSync(`rg -c '${pattern}' ${cwd} -g '!*.d.ts' 2>/dev/null || true`, {...})
```

This invokes `/bin/sh -c "..."`, which means any shell metacharacter in `pattern` or `cwd` would be interpreted as shell syntax. While both values are currently trusted constants (`FRONTEND_DIR = resolve(__dirname, '..', 'frontend', 'src')`), CodeQL correctly flags this as a potential injection vector — if `pattern` or `cwd` ever became untrusted (e.g. via env override, future refactor that takes user input, etc.), the shell string interpolation would allow command injection.

## Fix

Replace `execSync(shellString)` with `execFileSync('rg', [argvArray])`:

```javascript
execFileSync('rg', ['-c', pattern, cwd, '-g', '!*.d.ts'], {
  encoding: 'utf-8',
  maxBuffer: 1024 * 1024 * 10,
  stdio: ['ignore', 'pipe', 'ignore'],  // suppress stderr (rg exits 1 on no matches)
})
```

`execFileSync` with an argv array **never invokes a shell** — each array element becomes one `argv[i]` passed directly to the `execve()` syscall. There's no injection vector regardless of input source.

### Additional cleanup

- Removed `2>/dev/null || true` shell idiom — no longer needed because:
  - `stdio: ['ignore', 'pipe', 'ignore']` suppresses stderr
  - The existing `try/catch` handles `rg`'s exit code 1 (no matches found, which is normal)
- Removed single-quote escaping around `${pattern}` — `execFileSync` doesn't need shell escaping, each arg is passed as-is

## Verification

Ran the script before and after the change — output identical:

```
$ node scripts/type-debt-check.mjs
Type Debt Check
================

  ✅ anyCasts: 21 (baseline: 21, delta: 0)
  ✅ tsIgnore: 0 (baseline: 0, delta: 0)
  ✅ tsNoCheck: 0 (baseline: 0, delta: 0)
  ✅ indexSignatureAny: 1 (baseline: 1, delta: 0)

✅ All 21 `any` cast(s) are documented with TECH-DEBT(...) markers.

✅ Type debt is within baseline and all casts are documented.
```

Exit code 0 (success) — same as before the fix.

## Threat model

This is a **defense-in-depth** fix:

1. **Current state**: `pattern` and `cwd` are trusted constants — no actual vulnerability today.
2. **Future-proofing**: If a future refactor takes `pattern` or `cwd` from CLI args, env vars, or config files, the shell-string form would become exploitable. The `execFileSync` form remains safe.
3. **CodeQL compliance**: The alert is closed regardless of the threat model.

## No regression tests

This script is a CI-only tool (run by the `code-quality-reports` job in `ci-cd-unified.yml`). The script itself IS the test — running it successfully on the repo (as we did in Verification above) confirms behavior is preserved. Adding a unit test harness for a 200-line CI script would be over-engineering.

## Files

- `scripts/type-debt-check.mjs` — +15 / -3 lines (1 file changed)

## Related

- Worklog: `Task ID: P2-4-CODEQL-TYPE-DEBT-CHECK` (this PR)
- CodeQL alerts: #1249, #1250 (will auto-close when this PR merges and CodeQL re-runs on main)
- Node.js security guidance: <https://nodejs.org/api/child_process.html#child_processspawncommand-args-options>
