### PR TITLE
🎨 Palette: Add aria-label and title to fullscreen modal close button

### DIFF
--- a/frontend/src/components/ui/macos/Modal.tsx
+++ b/frontend/src/components/ui/macos/Modal.tsx
@@ -287,6 +287,8 @@ const Modal = ({
           variant="ghost"
           size="small"
           onClick={onClose}
+          aria-label={t('misc.eat_close', 'Закрыть')}
+          title={t('misc.eat_close', 'Закрыть')}
           style={{
             position: 'absolute',
             top: '12px',

--- a/frontend/src/components/ui/macos/Modal.tsx
+++ b/frontend/src/components/ui/macos/Modal.tsx
@@ -287,8 +287,8 @@ const Modal = ({
           variant="ghost"
           size="small"
           onClick={onClose}
-          aria-label={t('misc.eat_close', 'Закрыть')}
-          title={t('misc.eat_close', 'Закрыть')}
+          aria-label={t('misc.eat_close') || 'Закрыть'}
+          title={t('misc.eat_close') || 'Закрыть'}
           style={{
             position: 'absolute',
             top: '12px',


### PR DESCRIPTION
### 💡 What: 
Added an `aria-label` and `title` tooltip to the icon-only (✕) close button for fullscreen Modals within `frontend/src/components/ui/macos/Modal.tsx`. 

### 🎯 Why:
The script auditing icon-only controls explicitly noted that conditionally rendered buttons (like this one within the `size === 'fullscreen'` block) are a common blind spot for its static analysis. When users interacted with a fullscreen modal, this close button previously only exposed its structural HTML properties and character text to screen readers, making its purpose unclear to visually impaired users and lacking a standard hover tooltip for mouse users.

### 📸 Before/After:
**Before**:
```tsx
<Button
  variant="ghost"
  size="small"
  onClick={onClose}
  // ...styles
>
```

**After**:
```tsx
<Button
  variant="ghost"
  size="small"
  onClick={onClose}
  aria-label={t('misc.eat_close', 'Закрыть')}
  title={t('misc.eat_close', 'Закрыть')}
  // ...styles
>
```

### ♿ Accessibility:
- Screen readers will now announce "Close" (or the localized equivalent) instead of "button" or "multiplication sign".
- Mouse users will see a standard system tooltip on hover.
- Leverages the existing `t` translation function for proper i18n support, using the `misc.eat_close` key and a fallback.

---
*PR created automatically by Jules for task [14813830258679546529](https://jules.google.com/task/14813830258679546529) started by @drsapaev*