### PR TITLE
docs(finding-a): fix terminal-status comment — 'paid' is NOT terminal

### DIFF
--- a/backend/app/services/provider_webhook_service.py
+++ b/backend/app/services/provider_webhook_service.py
@@ -66,8 +66,11 @@ class ProviderWebhookService:
         from app.services.payment_state_checks import is_terminal_payment
 
         # P2 fix: check current status before attempting transition.
-        # If payment is already terminal (paid/refunded/cancelled/void),
+        # If payment is already terminal (refunded/cancelled/void),
         # a late 'failed' callback should NOT change the status.
+        # Note: "paid" is NOT terminal — it has outgoing transitions
+        # to refunded/void/cancelled (see ALLOWED_PAYMENT_TRANSITIONS
+        # in payment_state_checks.py, the authoritative SSOT).
         payment = self.repository.get_payment_by_id(payment_id) if hasattr(self.repository, 'get_payment_by_id') else None
         if payment and is_terminal_payment(payment.status) and new_status == "failed":
             logger.warning(

--- a/backend/tests/regression/test_p2_3_provider_webhook_terminal.py
+++ b/backend/tests/regression/test_p2_3_provider_webhook_terminal.py
@@ -25,12 +25,12 @@ sufficient for the invariant (terminal states {refunded, cancelled,
 void} are correctly preserved). These tests pin that behavior without
 changing production code.
 
-FINDINGS DOCUMENTED (NOT fixed in this PR — separate follow-ups):
-- FINDING A: comment at provider_webhook_service.py:69 says terminal
-  includes "paid", but is_terminal_payment() excludes paid. This is
-  a doc mismatch, not a logic bug — paid is NOT terminal by design
-  (it can transition to refunded/cancelled/void). The paid→failed
-  case falls through to BillingService which correctly rejects it.
+FINDINGS DOCUMENTED (status as of Finding A fix):
+- FINDING A: FIXED — the comment at provider_webhook_service.py:69 now
+  correctly lists terminal statuses as (refunded/cancelled/void), excluding
+  "paid". This was always a doc-only mismatch — paid is NOT terminal by
+  design (it can transition to refunded/cancelled/void). The paid→failed
+  case correctly falls through to BillingService which rejects it.
 - FINDING C: when a NEW webhook (different transaction_id) arrives
   for an already-terminal payment with new_status="paid", BillingService
   raises ValueError → outer except rolls back → audit trail lost.
@@ -146,10 +146,10 @@ class TestUpdatePaymentStatusTerminalShortCircuit:
         refunded/cancelled/void). A paid→failed transition is invalid and
         BillingService will reject it with ValueError.
 
-        FINDING A (documented, not fixed): the comment at
-        provider_webhook_service.py:69 says terminal includes "paid", but
-        is_terminal_payment() excludes paid. This test pins the actual
-        behavior.
+        FINDING A: FIXED — the comment at provider_webhook_service.py:69
+        previously said terminal includes "paid", but is_terminal_payment()
+        excludes paid. The comment was corrected to list only
+        (refunded/cancelled/void). This test pins the actual behavior.
         """
         service, payment, billing_mock, _ = self._make_service(
             db_session, payment_status="paid"


### PR DESCRIPTION
## Summary

**Finding A: documentation-only fix.** The inline comment at `provider_webhook_service.py:69` incorrectly listed `'paid'` as a terminal status alongside `refunded/cancelled/void`. This contradicts the authoritative SSOT in `payment_state_checks.py`.

## Audit verdict (read-only audit completed before this PR)

| Source | What it says | "paid" terminal? |
|--------|-------------|-----------------|
| `payment_state_checks.py:37` | `TERMINAL_PAYMENT_STATUSES = frozenset({"refunded", "cancelled", "void"})` | **NO** |
| `payment_state_checks.py:57` | `ALLOWED_PAYMENT_TRANSITIONS["paid"] = ["refunded", "void", "cancelled"]` | **NO** — has outgoing transitions |
| `payment_state_checks.py:44` | State machine diagram: `paid ──→ refunded`, `paid ──→ void`, `paid ──→ cancelled` | **NO** |
| `provider_webhook_service.py:672` | `_TERMINAL_PAYMENT_STATUSES = frozenset({"refunded", "cancelled", "void"})` | **NO** |
| `provider_webhook_service.py:69` (the bug) | `# If payment is already terminal (paid/refunded/cancelled/void),` | **YES** ← wrong |

**Classification:** Documentation was stale (comment predates SSOT extraction in PR #2678). Code is correct and authoritative.

**Why "paid" is NOT terminal:** A paid payment can be refunded, voided, or cancelled. Terminal means "no outgoing transitions" — only `refunded`, `cancelled`, `void` qualify.

## Changes

### 1. `backend/app/services/provider_webhook_service.py` (line 69)

```python
# Before:
# If payment is already terminal (paid/refunded/cancelled/void),

# After:
# If payment is already terminal (refunded/cancelled/void),
# Note: "paid" is NOT terminal — it has outgoing transitions
# to refunded/void/cancelled (see ALLOWED_PAYMENT_TRANSITIONS
# in payment_state_checks.py, the authoritative SSOT).
```

### 2. `backend/tests/regression/test_p2_3_provider_webhook_terminal.py`

Updated two docstrings to reflect Finding A is fixed:

- **Module-level FINDINGS section:** `"FINDING A: FIXED"` (was: "NOT fixed in this PR — separate follow-ups")
- **`test_falls_through_for_paid_to_failed`:** `"FINDING A: FIXED"` (was: "FINDING A (documented, not fixed)")

## What is NOT changed

- ❌ `TERMINAL_PAYMENT_STATUSES` — unchanged (already correct)
- ❌ `_update_payment_status` logic — unchanged (already correct)
- ❌ `ALLOWED_PAYMENT_TRANSITIONS` — unchanged (already correct)
- ❌ No new runtime tests (existing `test_falls_through_for_paid_to_failed` already pins the behavior)
- ❌ No state machine changes
- ❌ No refactoring

## Verification

- [x] Syntax OK (both files)
- [x] No runtime behavior change (comment-only + docstring-only)
- [x] Existing regression test `test_falls_through_for_paid_to_failed` already pins paid→failed fall-through behavior
- [ ] Targeted provider-webhook tests green (pending CI)
- [ ] PII guard = 0 (pending CI)
- [ ] E2E invariant = 6/6 (pending CI)
- [ ] Unified CI green (pending CI)

## Files

- `backend/app/services/provider_webhook_service.py` — +4 / -1 line (comment fix)
- `backend/tests/regression/test_p2_3_provider_webhook_terminal.py` — +10 / -10 lines (docstring updates)

## Related

- Worklog: `Task ID: P2-3-FINDING-A-DOC-MISMATCH` (this PR)
- SSOT extraction: PR #2678 (FOLLOWUP-6 — extracted state machine to `payment_state_checks.py`)
- Regression tests: PR #2703 (added `test_falls_through_for_paid_to_failed` which pins this behavior)
