### PR TITLE
fix(cl-1b): migrate PaymentTestInitService to PaymentInvariantService

### DIFF
--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -426,6 +426,7 @@ def test_init_payment(
             description=payment_request.description,
             return_url=payment_request.return_url,
             cancel_url=payment_request.cancel_url,
+            current_user=current_user,
         )
         return PaymentInitResponse(**result)
     except PaymentTestInitDomainError as exc:

--- a/backend/app/services/payment_test_init_service.py
+++ b/backend/app/services/payment_test_init_service.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Any
 
 from app.models.enums import PaymentStatus
 from app.repositories.payment_test_init_repository import PaymentTestInitRepository
 from app.services.billing_service import BillingService
+from app.services.payment_invariant_service import PaymentInvariantService
 
 
 @dataclass
@@ -23,6 +25,7 @@ class PaymentTestInitService:
         self.repository = PaymentTestInitRepository(db)
         self.billing_service = BillingService(db)
         self.payment_manager = payment_manager
+        self.db = db
 
     def init_test_payment(
         self,
@@ -34,15 +37,48 @@ class PaymentTestInitService:
         description: str | None,
         return_url: str | None,
         cancel_url: str | None,
+        current_user: Any = None,
     ) -> dict[str, Any]:
+        """Initialize a test online payment.
+
+        CL-1b migration: now delegates payment creation to
+        ``PaymentInvariantService.create_pending_payment(commit=False)``
+        instead of the deprecated ``BillingService.create_payment()``.
+
+        This provides:
+        - ``with_for_update()`` lock on Visit row (serializes concurrent inits)
+        - Duplicate pending payment check (B1/B4 coordination)
+        - ``IntegrityError`` defense-in-depth (degrades to 409)
+
+        The provider redirect flow (payment_url, provider_payment_id) and
+        status transitions (pending → processing/failed) are preserved.
+        """
         try:
-            payment = self.billing_service.create_payment(
+            # CL-1b: Use PaymentInvariantService for race-condition protection.
+            # This replaces the deprecated self.billing_service.create_payment() call.
+            # create_pending_payment() acquires with_for_update() on Visit,
+            # checks for duplicate pending payments with the same provider,
+            # and wraps the insert in IntegrityError defense-in-depth.
+            #
+            # commit=False because we need to:
+            # 1. Set provider_payment_id and payment_url after creation
+            # 2. Update payment status to processing/failed
+            # 3. Commit everything in one transaction
+            payment_service = PaymentInvariantService(self.db)
+
+            # Build current_user if not provided (backward compatibility)
+            # — the endpoint always has current_user, but tests may not.
+            if current_user is None:
+                current_user = type("UserRef", (), {"id": None})()
+
+            payment = payment_service.create_pending_payment(
                 visit_id=visit_id,
-                amount=float(amount),
+                amount=Decimal(str(amount)),
                 currency=currency,
                 method="online",
-                status=PaymentStatus.PENDING.value,
                 provider=provider,
+                note=description,
+                current_user=current_user,
                 commit=False,
             )
 


### PR DESCRIPTION
## Summary

**CL-1b:** migrate gated caller `PaymentTestInitService` from deprecated `BillingService.create_payment()` to `PaymentInvariantService.create_pending_payment(commit=False)`. Preserves provider redirect flow and status transition semantics.

After CL-1b, the deprecated `BillingService.create_payment()` has **0 production callers** — ready for CL-1c removal.

## Changes

### 1. `payment_test_init_service.py:init_test_payment()`

**Before:** called `self.billing_service.create_payment(commit=False, status=PENDING)` (deprecated, no locking)

**After:** calls `PaymentInvariantService.create_pending_payment(commit=False)` (with `with_for_update()` + duplicate pending check + IntegrityError defense)

```python
# CL-1b: Use PaymentInvariantService for race-condition protection.
payment_service = PaymentInvariantService(self.db)
payment = payment_service.create_pending_payment(
    visit_id=visit_id,
    amount=Decimal(str(amount)),
    currency=currency,
    method="online",
    provider=provider,
    note=description,
    current_user=current_user,
    commit=False,
)

# Provider redirect flow preserved (same as before)
result = self.payment_manager.create_payment(...)
if result.success:
    payment.provider_payment_id = result.payment_id
    payment.payment_url = result.payment_url
    self.billing_service.update_payment_status(
        payment_id=payment.id,
        new_status=PaymentStatus.PROCESSING.value,
    )
```

### 2. `api/v1/endpoints/payments.py:test_init_payment` endpoint

Added `current_user=current_user` to `init_test_payment()` call.

## Safety improvements (from `create_pending_payment`)

| Mechanism | Before (deprecated) | After (CL-1b) |
|-----------|---------------------|---------------|
| `with_for_update()` on Visit | ❌ | ✅ |
| Duplicate pending payment check (B1/B4) | ❌ | ✅ |
| `IntegrityError` defense-in-depth | ❌ | ✅ |

## Signature mapping

| Deprecated `create_payment()` | `create_pending_payment()` | Notes |
|-------------------------------|---------------------------|-------|
| `amount: float` | `amount: Decimal` | Converted via `Decimal(str(amount))` |
| `status: PENDING` | (not accepted) | `create_pending_payment` always sets `'pending'` |
| `method: "online"` | `method: "online"` | Same |
| `provider` | `provider` | Same |
| (not passed) | `note: description` | Now passed (was ignored before) |
| (not passed) | `current_user` | NEW — added to `init_test_payment` signature |
| `commit: False` | `commit: False` | Same |
| `provider_payment_id` | (not accepted) | Set after call (same pattern as CL-1a) |

## Backward compatibility

- `current_user: Any = None` — if not provided, wraps into `UserRef(id=None)`
- Existing tests don't pass `current_user` — they still work (default None)
- Endpoint always has `current_user` from `require_roles` dependency

## NOT changed (deferred to CL-1c)

- ❌ `BillingService.create_payment()` method NOT removed (safe rollback)
- ❌ `DeprecationWarning` still in place

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| Pending Payment created | ✅ (via `create_pending_payment`) |
| Provider initialization preserved | ✅ |
| Redirect/payment URL preserved | ✅ |
| Existing provider failure semantics preserved | ✅ |
| Feature gate preserved | ✅ (`ENABLE_TEST_PAYMENT_INIT=False` default) |
| Existing 2 tests green | ⏳ Pending CI |
| Deprecated `create_payment()` not called | ⏳ Pending CI |
| Billing/Payment regression suite green | ⏳ Pending CI |
| PII guard = 0 | ⏳ Pending CI |
| CodeQL = 0 | ⏳ Pending CI |
| Unified CI green | ⏳ Pending CI |

## Files

- `backend/app/services/payment_test_init_service.py` — +39 / -3 lines
- `backend/app/api/v1/endpoints/payments.py` — +1 line

## Related

- CL-1a: PR #2746 (migrated `record_payment` — production caller #1)
- CL-1 audit: PR #2706 (docstring fix, identified 2 callers)
- Worklog: `Task ID: CL-1B-PAYMENT-TEST-INIT-MIGRATION` (this PR)
- Follow-up: CL-1c (remove deprecated `create_payment` method — now 0 callers)
