### PR TITLE
fix(cl-1c): remove deprecated BillingService.create_payment() method

### DIFF
--- a/backend/app/api/v1/endpoints/registrar_wizard/_invoice.py
+++ b/backend/app/api/v1/endpoints/registrar_wizard/_invoice.py
@@ -194,10 +194,6 @@ def check_invoice_status(
                                 # commit=False because this is inside a larger
                                 # transaction (invoice status + payment + visit
                                 # status all committed together at line 171).
-                                #
-                                # Note: billing_service.create_payment() above is
-                                # another potential bypass (Gate B) — will be
-                                # caught in the second adversarial audit.
                                 from app.services.visit_lifecycle_service import VisitLifecycleService
 
                                 class _InvoiceActor:

--- a/backend/app/crud/payment.py
+++ b/backend/app/crud/payment.py
@@ -48,7 +48,8 @@ def list_payments(
     return list(db.execute(stmt).scalars().all())
 
 
-# create_payment() удалена - используйте billing_service.create_payment() (SSOT)
+# create_payment() удалена — используйте PaymentInvariantService.create_payment_for_visit()
+# или PaymentInvariantService.create_pending_payment() (SSOT).
 
 
 def sum_paid_by_visit(db: Session, *, visit_id: int) -> float:

--- a/backend/app/services/billing_service_pkg/_payments.py
+++ b/backend/app/services/billing_service_pkg/_payments.py
@@ -12,101 +12,6 @@ from decimal import Decimal
 class PaymentsMixin(BillingServiceMixinBase):
     """Payments methods for BillingService."""
 
-    def create_payment(
-        self,
-        visit_id: int,
-        amount: float,
-        currency: str = "UZS",
-        method: str = "cash",
-        status: str = "paid",
-        receipt_no: str | None = None,
-        note: str | None = None,
-        provider: str | None = None,
-        provider_payment_id: str | None = None,
-        commit: bool = True,
-    ) -> Payment:
-        """Create a payment (DEPRECATED — use PaymentInvariantService).
-
-        Issue #06 Phase 4b: this method is DEPRECATED. All 3 original
-        production callers have been migrated to ``PaymentInvariantService``:
-
-        - ``payment_init_service.py`` → ``create_pending_payment()``
-        - ``payment_create_service.py`` → ``create_payment_for_visit()``
-        - ``registrar_wizard/_invoice.py`` → ``create_payment_for_visit()``
-
-        CL-1 audit (post-merge stabilization): 2 production callers remain:
-        - ``billing_service_pkg/_payments.py:record_payment()`` (L540) —
-          called from ``POST /billing/payments`` endpoint (billing.py L351).
-          ACTIVE in production for BILLING_WRITE_ROLES.
-        - ``payment_test_init_service.py`` (L39) — gated by
-          ``ENABLE_TEST_PAYMENT_INIT`` (default False, must be False in
-          production). Dev/staging only.
-
-        This method will be removed after both callers are migrated to
-        ``PaymentInvariantService``. See follow-up issue: "Migrate
-        record_payment() and payment_test_init_service to
-        PaymentInvariantService, then remove BillingService.create_payment()".
-
-        For new code, use:
-        - ``PaymentInvariantService.create_payment_for_visit()`` for
-          cashier/full/partial payments (status='paid')
-        - ``PaymentInvariantService.create_pending_payment()`` for
-          online provider redirect flow (status='pending')
-
-        Both methods provide ``with_for_update()`` lock, paid_amount
-        check (where applicable), overpayment policy, and
-        IntegrityError defense-in-depth — none of which this method
-        provides.
-        """
-        import warnings
-
-        warnings.warn(
-            "BillingService.create_payment() is deprecated. Use "
-            "PaymentInvariantService.create_payment_for_visit() for paid "
-            "payments or create_pending_payment() for online provider "
-            "flow. This method will be removed after record_payment() "
-            "and payment_test_init_service are migrated.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        # Валидация визита
-        visit = self.db.query(Visit).filter(Visit.id == visit_id).first()
-        if not visit:
-            raise ValueError(f"Визит {visit_id} не найден")
-
-        # Валидация суммы
-        if amount <= 0:
-            raise ValueError("Сумма платежа должна быть больше нуля")
-
-        # Создаем платеж
-        payment = Payment(
-            visit_id=visit_id,
-            amount=amount,
-            currency=currency,
-            method=method,
-            status=status,
-            receipt_no=receipt_no,
-            note=note,
-            provider=provider,
-            provider_payment_id=provider_payment_id,
-        )
-
-        # Устанавливаем paid_at если статус "paid"
-        if status == PaymentStatus.PAID.value:
-            payment.paid_at = self._get_local_timestamp_naive()
-
-        self.db.add(payment)
-
-        if commit:
-            self.db.commit()
-            self.db.refresh(payment)
-        else:
-            self.db.flush()
-
-        return payment
-
-
     def get_payments_list(
         self,
         visit_id: int | None = None,
@@ -509,9 +414,8 @@ class PaymentsMixin(BillingServiceMixinBase):
         """
         Записать платеж для счета.
 
-        CL-1a migration: now delegates payment creation to
-        ``PaymentInvariantService.create_payment_for_visit(commit=False)``
-        instead of the deprecated ``BillingService.create_payment()``.
+        Delegates payment creation to
+        ``PaymentInvariantService.create_payment_for_visit(commit=False)``.
 
         This provides:
         - ``with_for_update()`` lock on Visit row (serializes concurrent payments)
@@ -569,8 +473,7 @@ class PaymentsMixin(BillingServiceMixinBase):
                 f"payment_method must be PaymentMethod enum or string, got {type(payment_method)}"
             )
 
-        # CL-1a: Delegate to PaymentInvariantService for race-condition protection.
-        # This replaces the deprecated self.create_payment() call with:
+        # Delegate to PaymentInvariantService for race-condition protection:
         #   - with_for_update() on Visit row
         #   - paid_amount vs total_cost check
         #   - overpayment policy
@@ -580,8 +483,7 @@ class PaymentsMixin(BillingServiceMixinBase):
         # The Visit lock is held until we commit at the end of this method.
         #
         # Note: create_payment_for_visit() sets status='paid' and paid_at automatically.
-        # The deprecated create_payment() also accepted receipt_no and provider_payment_id;
-        # create_payment_for_visit() does not, so we set them after the call.
+        # It does not accept receipt_no and provider_payment_id, so we set them after.
         from app.services.payment_invariant_service import PaymentInvariantService
 
         # Build current_user object if only created_by (int) was provided

--- a/backend/app/services/payment_test_init_service.py
+++ b/backend/app/services/payment_test_init_service.py
@@ -41,9 +41,8 @@ class PaymentTestInitService:
     ) -> dict[str, Any]:
         """Initialize a test online payment.
 
-        CL-1b migration: now delegates payment creation to
-        ``PaymentInvariantService.create_pending_payment(commit=False)``
-        instead of the deprecated ``BillingService.create_payment()``.
+        Delegates payment creation to
+        ``PaymentInvariantService.create_pending_payment(commit=False)``.
 
         This provides:
         - ``with_for_update()`` lock on Visit row (serializes concurrent inits)
@@ -54,8 +53,7 @@ class PaymentTestInitService:
         status transitions (pending → processing/failed) are preserved.
         """
         try:
-            # CL-1b: Use PaymentInvariantService for race-condition protection.
-            # This replaces the deprecated self.billing_service.create_payment() call.
+            # Use PaymentInvariantService for race-condition protection.
             # create_pending_payment() acquires with_for_update() on Visit,
             # checks for duplicate pending payments with the same provider,
             # and wraps the insert in IntegrityError defense-in-depth.

--- a/backend/tests/unit/test_record_payment_migration.py
+++ b/backend/tests/unit/test_record_payment_migration.py
@@ -263,36 +263,6 @@ class TestRecordPaymentMigration:
         assert mock_payment.receipt_no == "RCPT-TEST-001"
         assert mock_payment.provider_payment_id == "REF-12345"
 
-    def test_record_payment_does_not_call_deprecated_create_payment(self, db_session):
-        """Verify record_payment does NOT call the deprecated BillingService.create_payment()."""
-        from unittest.mock import patch, MagicMock
-        from app.models.payment import Payment
-
-        service = self._make_service(db_session)
-        invoice = self._make_invoice(db_session, visit_id=1, total_amount=10000)
-
-        mock_payment = Payment(
-            id=1, visit_id=1, amount=10000, currency="UZS",
-            method="cash", status="paid", paid_at=datetime.now(UTC),
-        )
-
-        # Patch BOTH create_payment_for_visit AND the deprecated create_payment
-        with patch(
-            "app.services.payment_invariant_service.PaymentInvariantService.create_payment_for_visit",
-            return_value=mock_payment,
-        ), patch.object(
-            service, "create_payment",
-        ) as mock_deprecated:
-            service.record_payment(
-                invoice_id=invoice.id,
-                amount=10000,
-                payment_method="cash",
-                current_user=type("U", (), {"id": 1})(),
-            )
-
-        # The deprecated create_payment must NOT have been called
-        mock_deprecated.assert_not_called()
-
     def test_record_payment_amount_passed_as_decimal(self, db_session):
         """Verify amount is converted to Decimal before passing to create_payment_for_visit."""
         from unittest.mock import patch


### PR DESCRIPTION
## Summary

**CL-1c:** remove deprecated `BillingService.create_payment()` method. After CL-1a (`record_payment` migration, PR #2746) and CL-1b (`PaymentTestInitService` migration, PR #2747), the deprecated method has **0 production callers**.

## Read-only audit (completed before removal)

| Check | Result |
|-------|--------|
| Production callers (`backend/app/`) | **0** — all `.create_payment()` calls are on different objects (PaymentCreateService, payment_manager, provider) |
| Test callers (`backend/tests/`) | **0** — only negative assertion (now deleted) |
| Dynamic access (getattr/monkeypatch) | **0** |
| Documentation (`docs/`) | **0** |
| Replacement services | ✅ `create_payment_for_visit()` + `create_pending_payment()` exist |

## Changes

### 1. Removed `BillingService.create_payment()` method (93 lines)
- Method definition (lines 15-107 in `_payments.py`)
- `DeprecationWarning` emission
- Deprecated docstring
- Implementation (Visit lookup, Payment creation, commit/flush)

### 2. Cleaned up historical references

| File | Change |
|------|--------|
| `_payments.py:record_payment()` docstring | Removed "CL-1a migration" and "deprecated" language |
| `_payments.py:record_payment()` inline comment | Removed "This replaces the deprecated self.create_payment() call" |
| `payment_test_init_service.py` docstring | Removed "CL-1b migration" and "deprecated" language |
| `payment_test_init_service.py` inline comment | Removed "This replaces the deprecated self.billing_service.create_payment() call" |
| `crud/payment.py:51` comment | Updated to point to `PaymentInvariantService` instead of removed `billing_service.create_payment()` |
| `registrar_wizard/_invoice.py:198` | Removed misleading comment about "billing_service.create_payment() above is another potential bypass" |

### 3. Deleted obsolete test

`test_record_payment_does_not_call_deprecated_create_payment` — verified the deprecated method was NOT called. Now the method doesn't exist, so the test is meaningless.

## NOT changed

- ❌ `record_payment()` runtime logic (CL-1a migration intact)
- ❌ `PaymentTestInitService` runtime logic (CL-1b migration intact)
- ❌ `PaymentInvariantService` (untouched)

## Historical comments left intact

Some comments in `_invoice.py`, `payment_init_service.py`, and `payment_create_service.py` reference "Replaced BillingService.create_payment() with..." — these are **historical context** explaining why the migration happened, and are still accurate. They were left unchanged.

## CL-1 is now fully closed

| Phase | PR | Status |
|-------|-----|--------|
| CL-1a | #2746 | ✅ `record_payment()` migrated to `PaymentInvariantService` |
| CL-1b | #2747 | ✅ `PaymentTestInitService` migrated to `PaymentInvariantService` |
| CL-1c | this PR | ✅ Deprecated `BillingService.create_payment()` removed |

## Acceptance criteria

| Check | Status |
|-------|--------|
| `create_payment()` production callers | **0** ✅ |
| Test callers | **0** (deleted obsolete test) ✅ |
| Backend tests | ⏳ Pending CI |
| Billing/payment tests | ⏳ Pending CI |
| PostgreSQL integration | ⏳ Pending CI |
| CodeQL | ⏳ Pending CI |
| PII guard | ⏳ Pending CI |
| E2E invariant | ⏳ Pending CI |
| Unified CI | ⏳ Pending CI |

## Files

- `backend/app/services/billing_service_pkg/_payments.py` — -106 / +3 lines (method removed, docstrings cleaned)
- `backend/app/services/payment_test_init_service.py` — +4 / -4 lines (docstring cleanup)
- `backend/app/crud/payment.py` — +2 / -1 line (comment updated)
- `backend/app/api/v1/endpoints/registrar_wizard/_invoice.py` — -4 lines (misleading comment removed)
- `backend/tests/unit/test_record_payment_migration.py` — -30 lines (obsolete test deleted)

**Net: -142 lines, +9 lines**

## Related

- CL-1a: PR #2746 (migrated `record_payment`)
- CL-1b: PR #2747 (migrated `PaymentTestInitService`)
- CL-1 audit: PR #2706 (docstring fix, identified 2 callers)
- Worklog: `Task ID: CL-1C-REMOVE-DEPRECATED-METHOD` (this PR)
