### PR TITLE
fix(ci): frontend/.npmrc legacy-peer-deps — unblock npm install

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,4 @@
+# Peer-dependency conflicts are accepted repo-wide (React 19 vs @emoji-mart/react@1.1.1).
+# CI already installs with --legacy-peer-deps (ci-cd-unified.yml); this file makes
+# local `npm install` and non-unified workflows (mutation.yml) use the same mode.
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary

- Add `frontend/.npmrc` with `legacy-peer-deps=true` — single new file, no code changes.
- Unblocks every npm command that resolves dependencies: local `npm install` and the `mutation.yml` frontend job (`Install Stryker` step), red nightly since 2026-08-11.
- Root cause: React 19.2.8 vs `@emoji-mart/react@1.1.1` peer range (`^16.8 || ^17 || ^18`); 1.1.1 is the latest published version, so updating cannot resolve it.
- This pins the mode `ci-cd-unified.yml` already uses (`npm ci --legacy-peer-deps`, 4 call sites) for every other npm invocation — no new leniency introduced.

## Cyclic Execution Evidence

- Fresh main sync: branch created from origin/main at 772784e3d
- Clean workspace: verified clean before edits; only `frontend/.npmrc` added
- Branch: fix/ci-npmrc-legacy-peer-deps
- Scope gate: allowed frontend/.npmrc only; denied package.json/lockfile changes, workflow files, emoji-mart replacement
- Red-check handling: PR Review Quality Gate failure (missing template sections) fixed in this same PR by rewriting the body to the required template

## Contract Impact

not applicable - npm configuration file only; no endpoint, DTO, route, schema, or generated-type surface changed.

## RBAC / Permissions

not applicable - no auth, role, or permission behavior changed.

## Notification / Realtime

not applicable - no notification, websocket, chat, or realtime behavior changed.

## Frontend Resilience

not applicable - no UI component, data path, or error state changed; npm install config only.

## Scope Gate

- Allowed paths: frontend/.npmrc
- Denied paths: frontend/package.json, frontend/package-lock.json, .github/workflows/**, replacement of @emoji-mart packages
- Migration/docs/test impact: none — no migration, no docs, no tests affected
- Rollback note: delete frontend/.npmrc; install behavior returns to previous state (ERESOLVE without --legacy-peer-deps)

## Validation

- Targeted tests or smoke run: `npm install --dry-run` in frontend; exact reproduction of the failing CI step `npm install --save-dev @stryker-mutator/core @stryker-mutator/vitest-runner --dry-run`; dispatched mutation.yml on this branch (run 31822027875)
- Result: dry-runs exit 0 (88 packages resolved, no files modified); dispatched run shows `Install frontend dependencies` and `Install Stryker` steps SUCCESS (Stryker step was the 4-night red)
- Not checked: full CI matrix on the PR (running), Stryker runtime beyond install (separate config fix follows), backend-mutation job (separate mutmut PR follows)