### PR TITLE
docs: sync stack claims to post-TS-migration reality (React 19 / TypeScript)

### DIFF
--- a/.ai-factory/ARCHITECTURE.md
+++ b/.ai-factory/ARCHITECTURE.md
@@ -9,7 +9,7 @@ Inside the monolith, each domain follows layered flow: API endpoint -> service -
 ## Decision Rationale
 
 - **Project type:** EMR/clinic platform with payments, queueing, chat, and role-based workflows.
-- **Tech stack:** FastAPI + SQLAlchemy + Alembic + PostgreSQL, React 18 + Vite, GitHub Actions CI/CD.
+- **Tech stack:** FastAPI + SQLAlchemy + Alembic + PostgreSQL, React 19 + Vite + TypeScript (strict), GitHub Actions CI/CD.
 - **Key factor:** High domain complexity with strong consistency and audit requirements, but better served by single deployment and strict internal boundaries.
 
 ## Folder Structure

--- a/.ai-factory/DESCRIPTION.md
+++ b/.ai-factory/DESCRIPTION.md
@@ -20,7 +20,7 @@ System covers patient lifecycle from registration and queue to visit documentati
 - **Backend:** Python 3.11, FastAPI, SQLAlchemy, Pydantic v2
 - **Database:** PostgreSQL (primary), Alembic migrations
 - **Realtime/Infra:** Redis pub/sub for multi-instance WebSocket broadcast
-- **Frontend:** React 18, Vite, React Router, Axios
+- **Frontend:** React 19, Vite, React Router, Axios, TypeScript (strict)
 - **Testing:** Pytest, Vitest, Playwright, k6 (CI load tests)
 - **CI/CD:** GitHub Actions workflows for lint/test/security/deploy gates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Primary repo-level operating rules for Codex, Cursor agents, Claude Code style a
 - Product: clinic EMR and operations platform for admin, registrar, doctor, cashier, lab, queue, billing, and rollout workflows. Supports multiple doctors per specialty with per-doctor queues, extensible to new specialties without code changes.
 - Backend: Python 3.11, FastAPI, SQLAlchemy, Pydantic v2, PostgreSQL, Alembic, Redis/WebSocket.
 - Architecture: see `docs/adr/ADR-001-queue-ownership-and-specialty-architecture.md` for queue ownership and specialty routing decisions.
-- Frontend: React 18, Vite, React Router, JavaScript/JSX.
+- Frontend: React 19, Vite, React Router, TypeScript (strict) / TSX.
 - Runtime defaults: backend `18000`, frontend `5173`, staging Postgres `55432`.
 - Context SSOT: `.ai-factory/DESCRIPTION.md`, `.ai-factory/ARCHITECTURE.md`, this file, and the canonical source/test files found for the task.
 - Active local dev-brain tooling lives outside runtime in `ai/langgraph`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ For backend pytest in this Windows checkout, prefer `C:\final\scripts\run_backen
 
 **Canonical Anchors in This Project:**
 - Roles: `backend/app/models/role_permission.py` (SINGLE SOURCE OF TRUTH)
-- Routes: `frontend/src/routing/routeRegistry.js`
+- Routes: `frontend/src/routing/routeRegistry.ts`
 - Service codes: `backend/app/services/service_mapping.py`
 - Queue groups: `backend/app/services/service_mapping.py` (QUEUE_GROUPS)
 - Auth flow: `backend/app/services/authentication_service.py`
@@ -235,9 +235,9 @@ docker compose logs -f frontend
 
 ### Frontend Structure
 
-**Framework:** React 18 with React Router v6, Vite bundler
+**Framework:** React 19 with React Router v6, Vite bundler, TypeScript (strict)
 
-**Entry Point:** `frontend/src/main.jsx` → `App.jsx`
+**Entry Point:** `frontend/src/main.tsx` → `App.tsx`
 
 **Key Frontend Features:**
 - **macOS-inspired UI** with custom design system (CSS variables in `styles/macos.css`)
@@ -248,7 +248,7 @@ docker compose logs -f frontend
 **Important Frontend Directories:**
 - `src/pages/` - Page components (AdminPanel, DoctorPanel, RegistrarPanel, etc.)
 - `src/components/` - Reusable UI components
-  - `components/auth/` - Authentication forms (**USE LoginFormStyled.jsx, NOT Login.jsx**)
+  - `components/auth/` - Authentication forms (**USE LoginFormStyled.tsx**)
   - `components/medical/` - EMR, medical records
   - `components/ui/macos/` - macOS UI components (Sidebar, Header, Icon)
   - `components/tables/` - Data tables
@@ -280,7 +280,7 @@ docker compose logs -f frontend
 - Specialized: cardio, derma, dentist
 
 **Role Routing:**
-- Frontend: `App.jsx` defines role-based routes
+- Frontend: `App.tsx` defines role-based routes
 - Backend: Role checks in endpoints via dependencies
 - Test after changes: `python test_role_routing.py`
 
@@ -291,7 +291,7 @@ docker compose logs -f frontend
 1. **Blocking 2FA Flow:** Never issue `access_token` before 2FA verification
 2. **Single Role Source:** Use ONLY `app/models/role_permission.py`
 3. **Password Hashing:** argon2 for new passwords, maintain bcrypt compatibility
-4. **Login Form:** Use `LoginFormStyled.jsx` as primary, NOT `Login.jsx`
+4. **Login Form:** Use `LoginFormStyled.tsx` as primary
 5. **Protected Users:** Never delete: admin, registrar, doctor, cardio, derma, dentist
 
 **Authentication Flow:**
@@ -324,7 +324,7 @@ docker compose logs -f frontend
 - Black formatter (line length 88)
 - Import order: isort with black profile
 
-**JavaScript/React (Frontend):**
+**TypeScript/React (Frontend):**
 - Functional components with hooks
 - ESLint for linting (`npm run lint`)
 - Avoid direct CSS class manipulation - use theme system
@@ -413,7 +413,7 @@ For risky tasks that should not execute yet, output `plan`, `dossier`, or `hando
 
 1. **DON'T** bypass the blocking 2FA flow
 2. **DON'T** create duplicate role models outside `role_permission.py`
-3. **DON'T** use `Login.jsx` - use `LoginFormStyled.jsx`
+3. **DON'T** create a new login form - use `LoginFormStyled.tsx`
 4. **DON'T** import designTokens directly - use theme hooks
 5. **DON'T** run backend commands from root directory - always use `backend/`
 6. **DON'T** hardcode secrets - use environment variables
@@ -429,7 +429,7 @@ For risky tasks that should not execute yet, output `plan`, `dossier`, or `hando
 ## Domain Guardrails (from AGENTS.md)
 
 ### Routing
-- Start from routing SSOT: `frontend/src/routing/routeRegistry.js`
+- Start from routing SSOT: `frontend/src/routing/routeRegistry.ts`
 - Verify route contract/snapshot tests before broad cleanup
 - Do not mass-edit unrelated routes in first slice
 
@@ -485,7 +485,7 @@ For risky tasks that should not execute yet, output `plan`, `dossier`, or `hando
 - `ADMIN_USERNAME`, `ADMIN_PASSWORD` - Default admin credentials
 
 **Frontend:**
-- API endpoint configured in `src/api/interceptors.js`
+- API endpoint configured in `src/api/interceptors.ts`
 - Uses `http://localhost:18000` for backend in dev mode
 
 ## Project-Specific Conventions
@@ -556,7 +556,7 @@ GraphQL endpoint available at `/api/graphql` with schema explorer in admin panel
 
 **Key Files:**
 - Backend: `app/api/v1/endpoints/services.py`, `app/services/service_audit_service.py`, `app/models/service_audit.py`
-- Frontend: `components/admin/ServiceCatalog.jsx`, `components/admin/ServiceAuditHistory.jsx`, `components/admin/ServiceChangesPreview.jsx`, `components/admin/ServiceBatchEdit.jsx`
+- Frontend: `components/admin/ServiceCatalog.tsx`, `components/admin/ServiceAuditHistory.tsx`, `components/admin/ServiceChangesPreview.tsx`, `components/admin/ServiceBatchEdit.tsx`
 - Migration: `alembic/versions/0022_service_audit_log.py`
 
 ## Local Dev-Brain Commands (from AGENTS.md)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 - **WebSocket** - реальное время
 
 ### Frontend
-- **React 18** - UI библиотека
+- **React 19** - UI библиотека (TypeScript, strict)
 - **Vite** - сборщик и dev сервер
 - **React Router** - маршрутизация
 - **Axios** - HTTP клиент

--- a/docs/adr/ADR-0012-typescript-migration.md
+++ b/docs/adr/ADR-0012-typescript-migration.md
@@ -140,6 +140,8 @@ All 4 previously-documented casts were eliminated in Phase F5:
 **Zero explicit `any` casts remain** (`as any`, `: any`).
 
 > **Note on implicit `any`:** `strict` and `noImplicitAny` remain disabled in `tsconfig.json`. This means implicit `any` (untyped function parameters, untyped variables) is NOT yet prohibited at the compiler level. The codebase has zero *explicit* `any` casts, but implicit `any` may still exist in untyped code paths. Enabling `strict: true` is tracked as a separate project (see Phase G below and Future Work).
+>
+> **[Update 2026-08-15:** this note described the pre-G8 state. Phase G8 (PR #2598) enabled `strict: true` in `frontend/tsconfig.json` with 0 errors — implicit `any` and null-unsafety are now prohibited across `src/`, and the e2e + node-config boundaries were added in PR #2755.**]
 
 ---
 

--- a/frontend/MIGRATION_PLAN.md
+++ b/frontend/MIGRATION_PLAN.md
@@ -1,6 +1,14 @@
 # 🚀 MIGRATION PLAN
 ## From Chaotic Styles → Unified Design System
 
+> **Status: historical planning document (pre-TypeScript-migration era).**
+> This plan was never implemented as written — `unifiedTheme.js` and
+> `styles/unified.css` do not exist in the codebase. All `.jsx` file
+> references below predate the JS→TS migration; the files are now `.tsx`
+> (e.g. `src/App.tsx`, `src/main.tsx`). Design-system work that did land
+> uses the CSS-token approach under `src/styles/` (see `emr-tokens.css`,
+> `macos.css` and the theme compliance scripts). Kept for planning history.
+
 **Goal:** Full design system unification in 4 weeks  
 **Team:** 2-3 developers  
 **Complexity:** Medium  


### PR DESCRIPTION
## Summary

- Operational docs still guided agents to React 18 + JavaScript/JSX and to `.js/.jsx` files that no longer exist after the JS→TS migration (Aug 2026) and the React 19 upgrade.
- AGENTS.md, CLAUDE.md, `.ai-factory/ARCHITECTURE.md`, `.ai-factory/DESCRIPTION.md`, README.md: stack claims updated to React 19 + TypeScript (strict).
- CLAUDE.md: `routeRegistry.js` → `.ts` (this is the routing SSOT anchor — agents were being pointed at a nonexistent file), `main.jsx`/`App.jsx` → `.tsx`, `LoginFormStyled.jsx` → `.tsx` (the referenced `Login.jsx` never existed post-migration), `interceptors.js` → `.ts`, `Service*.jsx` → `.tsx`, section header JavaScript/React → TypeScript/React.
- ADR-0012: the "strict remains disabled" note (line 142) gets a dated update marker pointing at G8/PR #2598 (strict:true, 0 errors) — historical body preserved.
- `frontend/MIGRATION_PLAN.md`: header marking it as historical planning — the design-system plan was never implemented as written (`unifiedTheme.js`/`unified.css` do not exist), and its `.jsx` references predate the TS migration.
- `docs/PROJECT_AUDIT.md` deliberately NOT changed: it is a dated snapshot (2026-05-09) that was accurate for its time.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main at b46b95ef3, clean worktree
- Clean workspace: 7 doc files, +25/−15 lines, no code
- Branch: fix/docs-post-ts-migration-sync
- Scope gate: allowed the listed doc files; denied code, configs, workflows
- Red-check handling: PR Review Quality Gate failed on short NA reasons — body fixed in this same PR

## Contract Impact

not applicable - documentation-only change; no endpoint, DTO, route, schema, or generated-type surface is modified in any way.

## RBAC / Permissions

not applicable - documentation-only change; no roles, permissions, or auth flows are modified.

## Notification / Realtime

not applicable - documentation-only change; no notifications, websockets, chat, or realtime behavior are modified.

## Frontend Resilience

not applicable - documentation-only change; no UI component, data path, or error state is modified.

## Scope Gate

- Allowed paths: AGENTS.md, CLAUDE.md, README.md, .ai-factory/ARCHITECTURE.md, .ai-factory/DESCRIPTION.md, docs/adr/ADR-0012-typescript-migration.md, frontend/MIGRATION_PLAN.md
- Denied paths: docs/PROJECT_AUDIT.md (dated historical snapshot), all code/config/workflow files
- Migration/docs/test impact: this IS the docs impact; no tests affected
- Rollback note: revert the single commit

## Validation

- Targeted tests or smoke run: repo-wide grep — zero remaining 'React 18' claims in operational docs (AGENTS/CLAUDE/README/.ai-factory/.cursor); every referenced filename verified to exist on disk with the new extension (`routeRegistry.ts`, `LoginFormStyled.tsx`, `interceptors.ts`, `Service*.tsx`, `main.tsx`, `App.tsx`)
- Result: clean grep; all file references resolve
- Not checked: nothing beyond PR CI for a docs-only change