### PR TITLE
chore(lint): remove 21 orphaned eslint-disable directives

### DIFF
--- a/frontend/src/api/mappers/__tests__/contract/pipeline-contract.test.ts
+++ b/frontend/src/api/mappers/__tests__/contract/pipeline-contract.test.ts
@@ -33,11 +33,9 @@ import type { Patient } from '../../../../types/domain/clinic';
 
 // 1. Zod schema output must be assignable to OpenAPI DTO type.
 //    If OpenAPI adds a required field that zod doesn't have, this fails.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _patientSchemaToDto: PatientDto = null as unknown as z.infer<typeof PatientDtoSchema>;
 
 // 2. Mapper output must be assignable to domain type.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _patientMapperToDomain: Patient = null as unknown as ReturnType<typeof mapPatientDto>;
 
 // Need z.infer — import locally
@@ -122,9 +120,7 @@ import type { AppointmentDto } from '../../../../types/api';
 import type { Appointment } from '../../../../types/domain/clinic';
 
 // Type-level contracts
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _appointmentSchemaToDto: AppointmentDto = null as unknown as z.infer<typeof AppointmentDtoSchema>;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _appointmentMapperToDomain: Appointment = null as unknown as ReturnType<typeof mapAppointmentDto>;
 
 describe('Appointment contract: OpenAPI → zod → mapper → domain', () => {
@@ -187,9 +183,7 @@ import { mapInvoiceDto, mapPaymentDto } from '../../billing';
 import type { Invoice, Payment } from '../../../../types/domain/billing';
 
 // Type-level contracts
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _invoiceMapperToDomain: Invoice = null as unknown as ReturnType<typeof mapInvoiceDto>;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _paymentMapperToDomain: Payment = null as unknown as ReturnType<typeof mapPaymentDto>;
 
 describe('Billing contract: zod → mapper → domain', () => {

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -154,11 +154,9 @@ export function RoleBasedRender({
 /**
  * HOC для ролевых ограничений
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function withRoleAuth(WrappedComponent: ComponentType<any>, authProps: Record<string, unknown> = {}) {
   // TECH-DEBT(role-auth-hoc): props is `any` because this is a generic HOC
   // that wraps any component. The props are passed through opaquely.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function WithRoleAuthComponent(props: any) {
     return (
       <RequireAuth {...authProps}>
@@ -171,11 +169,9 @@ export function withRoleAuth(WrappedComponent: ComponentType<any>, authProps: Re
 /**
  * HOC для ролевого рендеринга
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function withRoleRender(WrappedComponent: ComponentType<any>, renderProps: Record<string, unknown> = {}) {
   // TECH-DEBT(role-render-hoc): props is `any` because this is a generic HOC
   // that wraps any component. The props are passed through opaquely.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function WithRoleRenderComponent(props: any) {
     return (
       <RoleBasedRender {...renderProps}>

--- a/frontend/src/components/cardiology/ECGViewer.tsx
+++ b/frontend/src/components/cardiology/ECGViewer.tsx
@@ -80,7 +80,6 @@ interface AnalysisResult {
 // `any` is used here intentionally to keep the mixed-type access ergonomic;
 // explicit `any` is permitted under noImplicitAny (which only flags inferred
 // any). See ADR-0014 for the rationale on legacy style objects.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const styles: Record<string, any> = {
   root: {
     display: 'grid',

--- a/frontend/src/components/common/RoleGuard.tsx
+++ b/frontend/src/components/common/RoleGuard.tsx
@@ -75,11 +75,9 @@ export function RoleGuard({
 /**
  * HOC для ролевых ограничений
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function withRoleGuard(WrappedComponent: ComponentType<any>, guardProps: Record<string, unknown> = {}) {
   // TECH-DEBT(role-guard-hoc): props is `any` because this is a generic HOC
   // that wraps any component. The props are passed through opaquely.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function WithRoleGuardComponent(props: any) {
     return (
       <RoleGuard {...guardProps}>

--- a/frontend/src/components/emr-v2/sections/VitalsWidget.tsx
+++ b/frontend/src/components/emr-v2/sections/VitalsWidget.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from '@/i18n/useTranslation';
  * - BP Warning/Critical thresholds
  */
 const VitalsWidget = ({ vitals: vitalsRaw = {}, onChange, onFieldTouch, disabled }: { vitals?: Record<string, unknown>; onChange?: (v: Record<string, any>) => void; onFieldTouch?: (field: string) => void; disabled?: boolean }) => {
-  const vitals = vitalsRaw as Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const vitals = vitalsRaw as Record<string, any>;
   const { t: rawT } = useTranslation(); const t = rawT;
     const handleChange = (field: string, value: string) => {
         onChange?.({ ...vitals, [field]: value });

--- a/frontend/src/contexts/ChatContext.tsx
+++ b/frontend/src/contexts/ChatContext.tsx
@@ -759,7 +759,6 @@ export const ChatProvider = ({ children }: ChatProviderProps) => {
     toggleReaction,
     deleteMessage,
     uploadFile
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }), [
     conversations, messages, activeConversation, unreadCount,
     isConnected, isLoading, typingUsers, isChatOpen,

--- a/frontend/src/i18n/useTranslation.ts
+++ b/frontend/src/i18n/useTranslation.ts
@@ -132,7 +132,6 @@ export { ru as TRANSLATIONS };
  * It simply renders its children — no state, no context.
  */
 import React from 'react';
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 
 export function TranslationProvider({ children }: { children: React.ReactNode }) {
   return children;

--- a/frontend/src/pages/CardiologistPanelUnified.tsx
+++ b/frontend/src/pages/CardiologistPanelUnified.tsx
@@ -1739,7 +1739,6 @@ const MacOSCardiologistPanelUnified = (): React.JSX.Element | null => {
     }
   ];
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   // TECH-DEBT(cardio-queue-panel): queuePanel is `any` — QueueIntegration return type inference issue under strict:true
   const queuePanel: any = activeTab === 'queue' ? (
     <QueueIntegration specialty="cardiology" />

--- a/frontend/src/services/panelPrint.ts
+++ b/frontend/src/services/panelPrint.ts
@@ -7,7 +7,7 @@ import {
   normalizeTicketPrintSettings,
   TICKET_PRINT_SETTINGS_DEFAULTS,
 } from '../api/ticketPrintSettings';
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 // Phase 1 — panelPrint.ts has 1140 lines with heterogeneous return shapes.
 // Proper typing requires modeling the full print pipeline (Phase 9 cleanup).
 // Using `any` for return types and some params as a pragmatic measure.

--- a/frontend/src/types/declarations.d.ts
+++ b/frontend/src/types/declarations.d.ts
@@ -132,7 +132,7 @@ interface Window {
 // runtime validators, not TypeScript types — consumers use them as values
 // (e.g. `PropTypes.string.isRequired`), not as type annotations.
 declare module 'prop-types' {
-  /* eslint-disable @typescript-eslint/no-explicit-any */
+
   export const any: any;
   export const string: any;
   export const number: any;
@@ -173,5 +173,4 @@ declare module 'prop-types' {
     exact(shape: Record<string, any>): any;
   };
   export default PropTypes;
-  /* eslint-enable @typescript-eslint/no-explicit-any */
 }

--- a/frontend/src/utils/registrarAggregation.ts
+++ b/frontend/src/utils/registrarAggregation.ts
@@ -175,7 +175,6 @@ const pickPatientGender = (appointment: Record<string, unknown>): string => {
 };
 
 export const aggregatePatientsForAllDepartments = (appointments: Record<string, unknown>[] = []) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- aggregation result has heterogeneous shapes per group; tightening requires modeling the full aggregation pipeline (Phase 9 cleanup)
   const patientGroups: Record<string, any> = {};
 
   const toTime = (value: unknown) => {

--- a/frontend/src/utils/safeJsonParse.ts
+++ b/frontend/src/utils/safeJsonParse.ts
@@ -19,7 +19,6 @@
  * Returns `any` for drop-in compatibility with safeJsonParse.
  */
 // TECH-DEBT(c3-safejsonparse-any): Returns `any` for drop-in JSON.parse compat.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function safeJsonParse(raw: string | null | undefined, fallback: any = null): any {
   if (raw == null || raw === '') return fallback;
   try {


### PR DESCRIPTION
## Summary

- 21 eslint-disable directives across 12 files stopped suppressing anything long ago (eslint reports each as "Unused eslint-disable directive … no problems were reported") — leftovers from the strict-mode and TS migration waves.
- Removed with a script that deletes standalone directive lines (// and /* */ forms) and strips inline trailing comments; removing the block disable in `declarations.d.ts` orphaned its matching `eslint-enable`, removed as well (22 directives total, −22/+3 lines).
- No suppression was active, so no previously hidden problems surface.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main, rebased onto e2add0e80 before push
- Clean workspace: only the 12 files with directive removals
- Branch: fix/lint-remove-orphaned-disables
- Scope gate: allowed only the 12 listed files; denied any other warning category, eslint config, formatting
- Red-check handling: full PR checks; failures fixed in this same PR

## Contract Impact

not applicable - lint comment removal only; no runtime, API, or type surface is changed in any way.

## RBAC / Permissions

not applicable - lint comment removal only; no roles or auth flows are touched.

## Notification / Realtime

not applicable - lint comment removal only; no notification or realtime code is touched.

## Frontend Resilience

not applicable - lint comment removal only; no component behavior is changed.

## Scope Gate

- Allowed paths: the 12 files listed in the commit (11 src files + 1 contract test)
- Denied paths: eslint config, formatting autofixes (2296 auto-fixable warnings — deliberately left for a separate PR), any other warning category
- Migration/docs/test impact: none; assertions untouched (touched contract test passes 19/19)
- Rollback note: revert the single commit

## Validation

- Targeted tests or smoke run: full `eslint src/**/*.{ts,tsx}` before/after — unused directives 21→0, total warnings 3749→3728 (−21 exactly, no new errors); `tsc --noEmit` → 0 errors; vitest on the touched contract test file → 19/19 pass
- Result: zero behavioral delta, warning count consistent to the directive
- Not checked: full vitest suite (comment-only change; covered by CI unit-test job)