### PR TITLE
feat(ci): failure alerting for all scheduled workflows (Reliability R1)

### DIFF
--- a/.github/actions/notify-failure/action.yml
+++ b/.github/actions/notify-failure/action.yml
@@ -1,0 +1,44 @@
+name: 'Notify failure (GitHub issue)'
+description: >-
+  Create a GitHub issue describing the failed run. Call from a step or job
+  guarded by `if: failure()` (optionally && github.event_name == 'schedule'
+  for nightly-only alerting). Requires `permissions: issues: write` on the
+  calling job.
+inputs:
+  title:
+    description: Issue title.
+    required: true
+  detail:
+    description: Extra context lines appended to the issue body.
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - name: Create failure issue
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const title = ${{ toJSON(inputs.title) }};
+          const detail = ${{ toJSON(inputs.detail) }};
+          const body = [
+            `**${title}**`,
+            ``,
+            `Workflow **${context.workflow}** failed in run ${context.runId}.`,
+            ``,
+            detail,
+            ``,
+            `**Action required:**`,
+            `1. Open the failed run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            `2. Identify the failing job and step, find the root cause`,
+            `3. Fix before the next scheduled run — a new auto-issue per run means ongoing breakage`,
+            ``,
+            `Run details: event=${context.eventName} ref=${context.ref} sha=${context.sha}`,
+          ].filter((line) => line !== '').join('\n');
+          await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title,
+            body,
+            labels: ['ci-failure', 'auto-generated'],
+          });

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -91,3 +91,21 @@ jobs:
           path: |
             frontend/chaos-output-*.txt
             frontend/chaos-results-*.json
+
+  # Alert on scheduled-run failures: a red nightly is invisible without this
+  # (mutation.yml was red for 4+ nights before anyone noticed).
+  notify-failure:
+    name: 🔔 Notify on failure
+    runs-on: ubuntu-latest
+    needs: [chaos-test]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create failure issue
+        uses: ./.github/actions/notify-failure
+        with:
+          title: "🔴 Weekly chaos testing failed"
+          detail: |
+            Failure-injection + recovery verification via Playwright.

--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -2354,16 +2354,27 @@ jobs:
   notifications:
     name: 📧 Уведомления
     runs-on: ubuntu-latest
-    needs: [deploy-staging, deploy-production]
+    needs: [ci-scope, metadata-checks, code-quality, frontend-lint, frontend-unit-tests, frontend-build, frontend-e2e, backend-tests, architecture-boundary, frontend-backend-parity, security, docker, integration, load-tests-nightly, dast-zap-nightly, docs, telegram-miniapp-release-gate, pr-required-gate, deploy-staging, deploy-production]
     if: always()
-    
+
     steps:
     - name: 📧 Отправка уведомлений
       run: |
         if [ "${{ needs.deploy-staging.result }}" == "success" ] || [ "${{ needs.deploy-production.result }}" == "success" ]; then
           echo "✅ Развертывание успешно завершено"
-          echo "📧 Уведомления отправлены"
         else
-          echo "❌ Развертывание не выполнено"
+          echo "ℹ️ Развертывание не выполнено (обычно для schedule/PR-прогонов)"
         fi
+
+    - name: 🔔 Notify on scheduled failure (issue)
+      if: failure() && github.event_name == 'schedule'
+      uses: ./.github/actions/notify-failure
+      with:
+        title: 🔴 Nightly unified CI failed on main
+        detail: |
+          The scheduled run of the unified CI on main has at least one failed job.
+          Nightly failures are otherwise invisible — this issue is the alert.
+    permissions:
+      issues: write
+      contents: read
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -44,3 +44,21 @@ jobs:
           # gitleaks-action writes to results.sarif in the workspace root
           sarif_file: results.sarif
           category: gitleaks
+
+  # Alert on scheduled-run failures: a red nightly is invisible without this
+  # (mutation.yml was red for 4+ nights before anyone noticed).
+  notify-failure:
+    name: 🔔 Notify on failure
+    runs-on: ubuntu-latest
+    needs: [gitleaks]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create failure issue
+        uses: ./.github/actions/notify-failure
+        with:
+          title: "🔴 Gitleaks nightly failed"
+          detail: |
+            Secret detection over the full history of main.

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -103,3 +103,21 @@ jobs:
         with:
           name: k6-results
           path: tests/load/*-results.json
+
+  # Alert on scheduled-run failures: a red nightly is invisible without this
+  # (mutation.yml was red for 4+ nights before anyone noticed).
+  notify-failure:
+    name: 🔔 Notify on failure
+    runs-on: ubuntu-latest
+    needs: [load-test]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create failure issue
+        uses: ./.github/actions/notify-failure
+        with:
+          title: "🔴 Weekly load testing failed"
+          detail: |
+            k6 load tests with baseline degradation gate (>15% p95 regression fails).

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -144,3 +144,21 @@ jobs:
         with:
           name: stryker-report
           path: frontend/reports/mutation/
+
+  # Alert on scheduled-run failures: a red nightly is invisible without this
+  # (mutation.yml was red for 4+ nights before anyone noticed).
+  notify-failure:
+    name: 🔔 Notify on failure
+    runs-on: ubuntu-latest
+    needs: [backend-mutation, frontend-mutation]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create failure issue
+        uses: ./.github/actions/notify-failure
+        with:
+          title: "🔴 Nightly mutation testing failed"
+          detail: |
+            Guards the mutation-score floors: backend mutmut (4 crud modules, threshold 30) and frontend Stryker (state machines + mappers, threshold 70).

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -82,7 +82,7 @@ jobs:
         echo "=== Итоги ==="
         if [ -f backend/pip-audit-report.json ]; then
           issues=$(python -c "import json;d=json.load(open('backend/pip-audit-report.json'));print(len(d.get('dependencies',[])))" 2>/dev/null || echo "?")
-          echo "pip-audit: $issues зависимостей с vulns (блокирует CI при >0)"
+          echo "pip-audit: $issues зависимостей с vulns (report-only — НЕ блокирует CI)"
         fi
         if [ -f backend/safety-report.json ]; then
           issues=$(python -c "import json;d=json.load(open('backend/safety-report.json'));print(len(d.get('vulnerabilities',[])))" 2>/dev/null || echo "?")
@@ -93,4 +93,22 @@ jobs:
           echo "bandit: $metrics (HIGH+MEDIUM блокируют; LOW report-only)"
         fi
         echo ""
-        echo "✅ Security posture: strict (pip-audit CVEs block CI, bandit MEDIUM+ blocks CI)."
+        echo "🔍 Security posture: bandit MEDIUM+ is the only blocking check; pip-audit/safety are report-only (upstream transitive CVEs)."
+
+  # Alert on scheduled-run failures: a red nightly is invisible without this
+  # (mutation.yml was red for 4+ nights before anyone noticed).
+  notify-failure:
+    name: 🔔 Notify on failure
+    runs-on: ubuntu-latest
+    needs: [security-scan]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create failure issue
+        uses: ./.github/actions/notify-failure
+        with:
+          title: "🔴 Nightly security scan failed"
+          detail: |
+            Blocking surface: bandit MEDIUM+ on backend code. pip-audit and safety run report-only by design.

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -276,3 +276,21 @@ jobs:
           path: maintenance-reports/
           if-no-files-found: warn
           retention-days: 14
+
+  # Alert on scheduled-run failures: a red nightly is invisible without this
+  # (mutation.yml was red for 4+ nights before anyone noticed).
+  notify-failure:
+    name: 🔔 Notify on failure
+    runs-on: ubuntu-latest
+    needs: [maintenance-report]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create failure issue
+        uses: ./.github/actions/notify-failure
+        with:
+          title: "🔴 Weekly maintenance report failed"
+          detail: |
+            Code-quality reports, dependency drift and maintenance checks.


### PR DESCRIPTION
## Summary

- Nine workflows run on schedules; only two alerted on failure (ai-safety-guardrails, dr-drill). Nightly breakage was invisible in practice: mutation was red 4+ nights unnoticed, load/chaos have been red for weeks, and ci-cd-unified's `notifications` job was a stub that only echoes.
- New composite action `.github/actions/notify-failure`: creates a labeled GitHub issue (`ci-failure`, `auto-generated`) with run link, event/ref/sha, and an action checklist. GitHub Issues chosen because the repo has **zero secrets configured** (no Telegram/Slack tokens) — issues need only the built-in GITHUB_TOKEN.
- `notify-failure` job appended to mutation, security-scan, gitleaks, load, chaos, weekly-maintenance: `needs` all other jobs, `if: failure() && github.event_name == 'schedule'`, job-scoped `issues: write`. Dispatch-run failures deliberately do not create issues (they are observed in their own context) — per the milestone rule, workflow_dispatch is not nightly-stability evidence.
- ci-cd-unified: the echo-stub notifications job replaced with the real notifier (needs all 20 other jobs, schedule-gated).
- security-scan: masking audit found the summary falsely claiming "pip-audit CVEs block CI" and "posture: strict" while the pip-audit step is `|| true` + `continue-on-error` (deliberate, per its comment). Summary now states the truth: bandit MEDIUM+ is the only blocking check. Making pip-audit blocking is a policy decision left to the team.

### Masking audit results (R1 requirement)

| Workflow | Verdict |
|---|---|
| mutation | backend pipefail fixed earlier; frontend Stryker `continue-on-error` is safe — the parse step fails on missing report |
| security-scan | pip-audit/safety report-only **by design**; false summary fixed in this PR; bandit blocking |
| load | **red for weeks at 'Install k6'; never reaches tests; no backend service — vacuous even when green** (follow-up) |
| chaos | **red for weeks; no service bootstrapping** (follow-up) |
| ci-cd-unified | one `set +e` with documented manual handling; radon `|| true` is report collection only |
| weekly-maintenance | `set +e` in report generators — report-only by design |

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main at 34ca60424, clean worktree
- Clean workspace: 8 files (1 new action, 7 workflows), +169/−6
- Branch: fix/ci-nightly-failure-alerting
- Scope gate: allowed .github/workflows/{mutation,security-scan,gitleaks,load,chaos,weekly-maintenance,ci-cd-unified}.yml + .github/actions/notify-failure/**; denied app code, migrations, docs content
- Red-check handling: full PR checks; failures fixed in this same PR

## Contract Impact

not applicable - CI notification plumbing only; no endpoint, DTO, route, schema, or generated-type surface is changed in any way.

## RBAC / Permissions

- Roles allowed: GITHUB_TOKEN of the workflow itself (job-scoped issues:write, nothing else elevated)
- Roles denied: no human permissions changed; issue creation is the only new write
- Positive auth proof: job-level `permissions: issues: write` verified in YAML for every notify job
- Negative auth proof: workflow-level permissions untouched (contents: read remains); notify jobs cannot write code or deploy

## Notification / Realtime

not applicable - this PR adds the notification mechanism itself; no app realtime behavior changed.

## Frontend Resilience

not applicable - CI plumbing only; no UI component is changed.

## Scope Gate

- Allowed paths: .github/workflows/{7 listed}.yml, .github/actions/notify-failure/action.yml
- Denied paths: app code, eslint config, load/chaos service bootstrapping (follow-up), k6 install fix (follow-up)
- Migration/docs/test impact: none
- Rollback note: revert the single commit; alerting disappears, everything else unchanged

## Validation

- Targeted tests or smoke run: PyYAML parse of all 7 workflows + the composite action (all OK, job counts verified); notify job semantics verified (`if: failure() && schedule`, needs-graph complete, job-scoped permissions); issue-creation API usage mirrors the proven ai-safety-guardrails/dr-drill pattern
- Result: all YAML valid; first real alert fires on the next scheduled failure (load.yml will alert on Sunday until its k6 install is fixed — that is the mechanism working as intended)
- Not checked: end-to-end issue creation on a real scheduled failure (cannot be forced without waiting for a schedule; the identical github-script pattern is proven in ai-safety-guardrails and dr-drill)