### PR TITLE
fix(ci): k6 install via official script — keyserver method dead on GH runners

### DIFF
--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -25,11 +25,11 @@ jobs:
 
       - name: Install k6
         run: |
-          sudo gpg -k
-          sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A36442D5730B2B1A0669E2A2A
-          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-          sudo apt-get update
-          sudo apt-get install -y k6
+          # The old apt+keyserver method fails on GitHub runners with
+          # "gpg: keyserver receive failed: No data" (broken for weeks).
+          # Grafana's install script downloads the release binary directly.
+          curl -sL https://raw.githubusercontent.com/grafana/k6/master/install.sh | sudo bash
+          k6 version
 
       - name: Check runner type
         id: runner

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -68,11 +68,12 @@ jobs:
       # === 5. Load test with baseline (k6) ===
       - name: Install k6
         run: |
-          sudo gpg -k
-          sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A36442D5730B2B1A0669E2A2A
-          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-          sudo apt-get update
-          sudo apt-get install -y k6
+          # The old apt+keyserver method fails on GitHub runners with
+          # "gpg: keyserver receive failed: No data" — this is what kept
+          # release-gate from ever passing. Grafana's install script
+          # downloads the release binary directly, no keyserver involved.
+          curl -sL https://raw.githubusercontent.com/grafana/k6/master/install.sh | sudo bash
+          k6 version
 
       - name: Run k6 load tests (with baseline gate)
         working-directory: tests/load


### PR DESCRIPTION
## Summary

- `gpg: keyserver receive failed: No data` broke k6 installation on GitHub runners for weeks: `load.yml` never reached its tests (red since 2026-08-02 per run history), and `release-gate.yml` could never pass at all — `Install k6` was the first failing step in its **first-ever run** (R2 baseline dispatch, run 31884892298).
- Replace the apt+keyserver method with Grafana's official install script (direct release-binary download, no keyserver) in both workflows, plus a `k6 version` verification.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main at 1b594386d (post-#2758), clean worktree
- Clean workspace: 2 workflow files, +11/−10
- Branch: fix/ci-k6-install
- Scope gate: allowed the two Install k6 steps; denied load-test logic, thresholds, other steps
- Red-check handling: PR checks; the PASS-side proof for release-gate (R2) re-dispatches on main right after merge

## Contract Impact

not applicable - CI tool installation only; no API surface is changed in any way.

## RBAC / Permissions

not applicable - no auth behavior changed; installs a tool inside the ephemeral runner only.

## Notification / Realtime

not applicable - no app realtime behavior changed.

## Frontend Resilience

not applicable - CI tooling only; no UI component is changed.

## Scope Gate

- Allowed paths: .github/workflows/load.yml, .github/workflows/release-gate.yml (Install k6 steps only)
- Denied paths: k6 test scripts, thresholds, baseline files, other workflow steps
- Migration/docs/test impact: none
- Rollback note: revert the single commit

## Validation

- Targeted tests or smoke run: both workflows YAML-parse; install-script method verified against Grafana docs (`curl … install.sh | sudo bash` installs the latest release binary to /usr/local/bin)
- Result: YAML valid; failure root cause evidenced from run logs (`gpg: keyserver receive failed: No data`, exit 2, weeks of identical load.yml failures)
- Not checked: actual install success on a runner — proven by the release-gate re-dispatch on main immediately after merge (R2 PASS-side evidence)