### PR TITLE
fix(ci): k6 install from official .deb asset (install.sh gone 404)

### DIFF
--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -26,9 +26,12 @@ jobs:
       - name: Install k6
         run: |
           # The old apt+keyserver method fails on GitHub runners with
-          # "gpg: keyserver receive failed: No data" (broken for weeks).
-          # Grafana's install script downloads the release binary directly.
-          curl -sL https://raw.githubusercontent.com/grafana/k6/master/install.sh | sudo bash
+          # "gpg: keyserver receive failed: No data" (broken for weeks);
+          # Grafana's master install.sh is gone (404) too. Install the
+          # official .deb from the latest GitHub release.
+          K6_VER=$(curl -s https://api.github.com/repos/grafana/k6/releases/latest | grep -oE '"tag_name": *"[^"]+"' | cut -d'"' -f4)
+          curl -sL -o /tmp/k6.deb "https://github.com/grafana/k6/releases/download/${K6_VER}/k6-${K6_VER}-linux-amd64.deb"
+          sudo dpkg -i /tmp/k6.deb
           k6 version
 
       - name: Check runner type

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -70,9 +70,12 @@ jobs:
         run: |
           # The old apt+keyserver method fails on GitHub runners with
           # "gpg: keyserver receive failed: No data" — this is what kept
-          # release-gate from ever passing. Grafana's install script
-          # downloads the release binary directly, no keyserver involved.
-          curl -sL https://raw.githubusercontent.com/grafana/k6/master/install.sh | sudo bash
+          # release-gate from ever passing. Grafana's master install.sh is
+          # gone (404) too. Install the official .deb from the latest
+          # GitHub release: no keyserver, no removed scripts.
+          K6_VER=$(curl -s https://api.github.com/repos/grafana/k6/releases/latest | grep -oE '"tag_name": *"[^"]+"' | cut -d'"' -f4)
+          curl -sL -o /tmp/k6.deb "https://github.com/grafana/k6/releases/download/${K6_VER}/k6-${K6_VER}-linux-amd64.deb"
+          sudo dpkg -i /tmp/k6.deb
           k6 version
 
       - name: Run k6 load tests (with baseline gate)


### PR DESCRIPTION
## Summary

- Follow-up to #2759 in the same PR series: Grafana's `install.sh` on raw.githubusercontent is gone (404 — removed from grafana/k6 master), so round 1's method failed with `bash: line 1: 404:: command not found`.
- Round 2: download the official `linux-amd64 .deb` asset from the latest k6 GitHub release (`tag_name` via API) and `dpkg -i` it. Deterministic asset, no keyserver, no scripts.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main at c3c1a8646, clean worktree
- Clean workspace: the same two Install k6 steps as #2759
- Branch: fix/ci-k6-deb
- Scope gate: allowed the two Install k6 steps; denied everything else
- Red-check handling: URL verified by an actual 28.9 MB download before push; release-gate re-dispatch on main right after merge is the PASS-side proof (R2)

## Contract Impact

not applicable - CI tool installation only; no API surface is changed.

## RBAC / Permissions

not applicable - ephemeral runner tooling only.

## Notification / Realtime

not applicable - no app realtime behavior changed.

## Frontend Resilience

not applicable - CI tooling only.

## Scope Gate

- Allowed paths: .github/workflows/{load,release-gate}.yml (Install k6 steps)
- Denied paths: everything else
- Migration/docs/test impact: none
- Rollback note: revert the single commit

## Validation

- Targeted tests or smoke run: YAML parse × 2; asset URL verified by real download (28,927,380 bytes, k6-v2.2.0-linux-amd64.deb)
- Result: URL and asset naming confirmed against the GitHub releases API
- Not checked: dpkg install on runner — proven by the release-gate dispatch after merge