### PR TITLE
feat(ci): nightly health report — R3 observability collector

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -1,0 +1,52 @@
+name: Nightly Health Report
+
+on:
+  schedule:
+    # Daily 05:00 UTC — after all nightlies (mutation 02:00, unified CI 02:00,
+    # security 03:00, gitleaks 03:30, AI safety 02:30).
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  nightly-health:
+    name: 📊 Nightly health evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Collect health metrics
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bash scripts/nightly-health.sh
+
+      - name: Upload health report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-health
+          path: /tmp/nightly-health.md
+          if-no-files-found: error
+
+  # Alert on scheduled-run failures (R1 pattern).
+  notify-failure:
+    name: 🔔 Notify on failure
+    runs-on: ubuntu-latest
+    needs: [nightly-health]
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create failure issue
+        uses: ./.github/actions/notify-failure
+        with:
+          title: 🔴 Nightly health report collection failed
+          detail: |
+            The observability collector (scripts/nightly-health.sh) failed.
+            Without it, nightly health is not observable in one place.

--- a/scripts/nightly-health.sh
+++ b/scripts/nightly-health.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scripts/nightly-health.sh — Reliability R3: nightly health evidence.
+#
+# Collects the minimal observable metric set for the reliability milestone:
+#   mutation backend/frontend, api contract, release gate, security scans,
+#   weekly load/chaos/DR — status, duration, artifact existence, mutation scores.
+#
+# Output: markdown table to stdout and to $GITHUB_STEP_SUMMARY (if set).
+# Exit code: 0 always (observability, not enforcement — R1 handles alerting).
+#
+# Usage (from repo root, GITHUB_TOKEN + GITHUB_REPOSITORY in env):
+#   bash scripts/nightly-health.sh
+set -uo pipefail
+
+REPO="${GITHUB_REPOSITORY:-drsapaev/final}"
+API="https://api.github.com/repos/${REPO}"
+
+api() { curl -sS -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github+json" "$1"; }
+
+# jq is preinstalled on GitHub runners; fail early with a clear message if not.
+command -v jq >/dev/null || { echo "jq is required"; exit 1; }
+
+# workflow_file | display name | required-event filter | cadence | expected artifacts (comma-sep)
+WORKFLOWS=(
+  "mutation.yml|mutation (backend+frontend)|schedule|daily|mutmut-report,stryker-report"
+  "ci-cd-unified.yml|unified CI (incl. api-contract gates)|schedule|daily|-"
+  "security-scan.yml|security scan|schedule|daily|security-reports"
+  "gitleaks.yml|gitleaks|schedule|daily|-"
+  "release-gate.yml|release gate|workflow_dispatch|on-release|-"
+  "ai-safety-guardrails.yml|AI safety guardrails|schedule|daily|-"
+  "dr-drill.yml|DR drill|schedule|weekly|-"
+  "load.yml|load testing|schedule|weekly|-"
+  "chaos.yml|chaos testing|schedule|weekly|-"
+  "weekly-maintenance.yml|weekly maintenance|schedule|weekly|-"
+)
+
+# Latest completed run of a workflow for a given event (empty if none).
+latest_run() {
+  api "${API}/actions/workflows/$1/runs?status=completed&event=$2&per_page=5" \
+    | jq -r '[.workflow_runs[] | select(.head_branch == "main" or .event == "workflow_dispatch")][0] // empty'
+}
+
+# Human duration from run timestamps (n/a on any parse failure).
+run_duration() {
+  jq -r '
+    def ts: sub("\\..*"; "") | sub("T"; " ") | sub("Z"; "") | strptime("%Y-%m-%d %H:%M:%S") | mktime;
+    (.updated_at | ts) as $end | (.created_at | ts) as $start
+    | ($end - $start) as $s
+    | if $s >= 3600 then "\($s / 3600 | floor)h \($s % 3600 / 60 | floor)m"
+      elif $s >= 60 then "\($s / 60 | floor)m \($s % 60)s"
+      else "\($s)s" end
+  ' <<<"$1" 2>/dev/null || echo "n/a"
+}
+
+# Mutation scores, best-effort: parse steps' conclusions + log grep is heavy,
+# so scores come from step names being green plus artifact presence; the exact
+# percentages stay in the run artifacts (linked from the table).
+
+{
+  echo "# Nightly health — $(date -u '+%Y-%m-%d %H:%M UTC')"
+  echo
+  echo "| Workflow | Cadence | Last run (event) | Status | Duration | Artifacts | Link |"
+  echo "|---|---|---|---|---|---|---|"
+
+  for entry in "${WORKFLOWS[@]}"; do
+    IFS='|' read -r file name event cadence artifacts <<<"$entry"
+    run_json="$(latest_run "$file" "$event")"
+    if [ -z "$run_json" ]; then
+      echo "| ${name} | ${cadence} | — | ⚠️ NO COMPLETED RUN | — | — | — |"
+      continue
+    fi
+    conclusion=$(jq -r .conclusion <<<"$run_json")
+    run_number=$(jq -r .run_number <<<"$run_json")
+    run_id=$(jq -r .id <<<"$run_json")
+    created=$(jq -r .created_at <<<"$run_json")
+    duration=$(run_duration <<<"$run_json")
+
+    icon="❓ ${conclusion}"
+    [ "$conclusion" = "success" ] && icon="✅ PASS"
+    [ "$conclusion" = "failure" ] && icon="❌ FAIL"
+    [ "$conclusion" = "cancelled" ] && icon="⛔ cancelled"
+
+    art_cell="—"
+    if [ "$artifacts" != "-" ]; then
+      art_cell=""
+      IFS=',' read -ra expected <<<"$artifacts"
+      got=$(api "${API}/actions/runs/${run_id}/artifacts?per_page=100" | jq -r '.artifacts[].name')
+      for want in "${expected[@]}"; do
+        if grep -qx "$want" <<<"$got"; then art_cell+="✅ ${want}<br>"; else art_cell+="❌ ${want} MISSING<br>"; fi
+      done
+    fi
+
+    echo "| ${name} | ${cadence} | #${run_number} (${created%%T*}, ${event}) | ${icon} | ${duration} | ${art_cell} | [run ${run_id}](https://github.com/${REPO}/actions/runs/${run_id}) |"
+  done
+
+  echo
+  echo "## Mutation score evidence"
+  echo "Exact percentages are recorded in each run's artifacts (\`mutmut-report\`, \`stryker-report\`) and in the parse-step logs of the linked run."
+  echo "Baseline at enforcement start (2026-08-14): backend 34.5% (floor 30, do not raise until several green nightlies), frontend 83.15% (floor 70)."
+  echo
+  echo "## Alerting"
+  echo "Failed scheduled runs open a \`ci-failure\` issue automatically (R1, \`.github/actions/notify-failure\`). This report is observability, not alerting."
+} | tee /tmp/nightly-health.md
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat /tmp/nightly-health.md >> "$GITHUB_STEP_SUMMARY"
+fi


### PR DESCRIPTION
## Summary

- Closes R3 of the Reliability CI Enforcement milestone: the minimal observable metric set in one place — mutation backend+frontend, unified CI (includes both api-contract freshness gates), security scan, gitleaks, release gate, AI safety, weekly load/chaos/DR/maintenance.
- Per workflow the report shows: last completed run (number, date, event — schedule vs dispatch is visible per the milestone rule that dispatch is not nightly-stability evidence), PASS/FAIL/cancelled, duration, expected-artifact existence (mutation: `mutmut-report` + `stryker-report`), and a run link.
- Mutation scores stay evidence-linked: exact percentages live in each run's artifacts and parse-step logs; the report records the enforcement baseline (backend 34.5% / floor 30 — explicitly not raised until several green nightlies, per the milestone decision; frontend 83.15% / floor 70).
- Runs daily 05:00 UTC (after all nightlies) + `workflow_dispatch`; output to job step summary + `nightly-health` artifact; collector self-failure alerts via the R1 notify-failure action.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main at 258be04f1, clean worktree
- Clean workspace: 2 new files (+159), no existing file touched
- Branch: feat/ci-nightly-health
- Scope gate: allowed scripts/nightly-health.sh + .github/workflows/nightly-health.yml; denied everything else
- Red-check handling: PR checks; first dispatch on main right after merge validates the collector end-to-end

## Contract Impact

not applicable - observability reporting only; no API surface is changed.

## RBAC / Permissions

- Roles allowed: workflow GITHUB_TOKEN (read-only Actions API via contents:read-level REST access; the notify job is job-scoped issues:write, same as R1)
- Roles denied: no human permissions changed
- Positive auth proof: workflow-level permissions contents:read only; notify job scoped issues:write
- Negative auth proof: no write surface except the R1-style issue on collector failure

## Notification / Realtime

not applicable - the report itself is the notification surface; no app realtime behavior changed.

## Frontend Resilience

not applicable - CI observability only.

## Scope Gate

- Allowed paths: scripts/nightly-health.sh, .github/workflows/nightly-health.yml
- Denied paths: all existing workflows, app code, docs
- Migration/docs/test impact: none
- Rollback note: delete the two files

## Validation

- Targeted tests or smoke run: `bash -n` syntax check; workflow YAML parse; jq expressions hand-reviewed with two fixes (timestamp T handling, seconds-vs-object comparison) plus n/a fallbacks; artifact-existence logic uses the run artifacts API
- Result: syntax/YAML green; end-to-end proof = post-merge `workflow_dispatch` (new workflows cannot be dispatched from a branch before existing on main)
- Not checked: actual runner execution pre-merge (impossible for new workflows); jq runtime edge cases beyond fallbacks