### PR TITLE
fix(ci): nightly-health duration via fromdateiso8601

### DIFF
--- a/scripts/nightly-health.sh
+++ b/scripts/nightly-health.sh
@@ -43,8 +43,7 @@ latest_run() {
 # Human duration from run timestamps (n/a on any parse failure).
 run_duration() {
   jq -r '
-    def ts: sub("\\..*"; "") | sub("T"; " ") | sub("Z"; "") | strptime("%Y-%m-%d %H:%M:%S") | mktime;
-    (.updated_at | ts) as $end | (.created_at | ts) as $start
+    (.updated_at | fromdateiso8601) as $end | (.created_at | fromdateiso8601) as $start
     | ($end - $start) as $s
     | if $s >= 3600 then "\($s / 3600 | floor)h \($s % 3600 / 60 | floor)m"
       elif $s >= 60 then "\($s / 60 | floor)m \($s % 60)s"


### PR DESCRIPTION
## Summary

- First live dispatch of the nightly-health collector (run 31897043909) rendered every Duration cell as `n/a` — the hand-rolled strptime chain failed silently on the runner. Replace with jq's built-in `fromdateiso8601`, which parses the Actions API ISO-8601 timestamps directly.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main at cf8113ffd, clean worktree
- Clean workspace: one function in scripts/nightly-health.sh
- Branch: fix/nightly-health-duration
- Scope gate: allowed scripts/nightly-health.sh only
- Red-check handling: post-merge dispatch re-renders the report with durations

## Contract Impact

not applicable - report formatting only.

## RBAC / Permissions

not applicable - no permissions changed.

## Notification / Realtime

not applicable - no realtime behavior changed.

## Frontend Resilience

not applicable - CI observability only.

## Scope Gate

- Allowed paths: scripts/nightly-health.sh
- Denied paths: everything else
- Migration/docs/test impact: none
- Rollback note: revert the single commit

## Validation

- Targeted tests or smoke run: bash -n; jq builtin requires no timestamp pre-processing; post-merge dispatch is the end-to-end proof
- Result: syntax green
- Not checked: pre-merge runner execution (impossible for the same reasons as #2761)