### PR TITLE
fix(ci): nightly-health duration via GNU date arithmetic

### DIFF
--- a/scripts/nightly-health.sh
+++ b/scripts/nightly-health.sh
@@ -41,14 +41,21 @@ latest_run() {
 }
 
 # Human duration from run timestamps (n/a on any parse failure).
+# Deliberately plain: single-field jq extracts + GNU date arithmetic — the
+# earlier multi-line jq program failed silently on the runner (rendered n/a).
 run_duration() {
-  jq -r '
-    (.updated_at | fromdateiso8601) as $end | (.created_at | fromdateiso8601) as $start
-    | ($end - $start) as $s
-    | if $s >= 3600 then "\($s / 3600 | floor)h \($s % 3600 / 60 | floor)m"
-      elif $s >= 60 then "\($s / 60 | floor)m \($s % 60)s"
-      else "\($s)s" end
-  ' <<<"$1" 2>/dev/null || echo "n/a"
+  local start end secs
+  start=$(jq -r '.created_at // empty' <<<"$1")
+  end=$(jq -r '.updated_at // empty' <<<"$1")
+  if [ -z "$start" ] || [ -z "$end" ]; then echo "n/a"; return; fi
+  secs=$(( $(date -u -d "$end" +%s) - $(date -u -d "$start" +%s) ))
+  if [ "$secs" -ge 3600 ]; then
+    echo "$(( secs / 3600 ))h $(( (secs % 3600) / 60 ))m"
+  elif [ "$secs" -ge 60 ]; then
+    echo "$(( secs / 60 ))m $(( secs % 60 ))s"
+  else
+    echo "${secs}s"
+  fi
 }
 
 # Mutation scores, best-effort: parse steps' conclusions + log grep is heavy,


### PR DESCRIPTION
## Summary

- Round 2 of the duration fix: the jq `fromdateiso8601` program also rendered `n/a` on the runner (run 31897448265) while single-field jq extracts in the same script work — the multi-line jq program is the common factor. Drop it: extract the two timestamp fields with plain jq and compute seconds with `date -u -d` (GNU date parses Actions ISO-8601 directly).

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main at 200958476, clean worktree
- Clean workspace: one function in scripts/nightly-health.sh
- Branch: fix/nightly-health-duration2
- Scope gate: allowed scripts/nightly-health.sh only
- Red-check handling: post-merge dispatch re-renders the report

## Contract Impact

not applicable - report formatting only.

## RBAC / Permissions

not applicable - no permissions changed.

## Notification / Realtime

not applicable - no realtime behavior changed.

## Frontend Resilience

not applicable - CI observability only.

## Scope Gate

- Allowed paths: scripts/nightly-health.sh
- Denied paths: everything else
- Migration/docs/test impact: none
- Rollback note: revert the single commit

## Validation

- Targeted tests or smoke run: bash -n; arithmetic paths exercised for h/m/s branches by construction; post-merge dispatch is the end-to-end proof
- Result: syntax green
- Not checked: pre-merge runner execution