### PR TITLE
fix(ci): nightly-health duration — pass run JSON as function argument

### DIFF
--- a/scripts/nightly-health.sh
+++ b/scripts/nightly-health.sh
@@ -79,7 +79,7 @@ run_duration() {
     run_number=$(jq -r .run_number <<<"$run_json")
     run_id=$(jq -r .id <<<"$run_json")
     created=$(jq -r .created_at <<<"$run_json")
-    duration=$(run_duration <<<"$run_json")
+    duration=$(run_duration "$run_json")
 
     icon="❓ ${conclusion}"
     [ "$conclusion" = "success" ] && icon="✅ PASS"


### PR DESCRIPTION
## Summary

- Root cause of every duration rendering `n/a`: `run_duration` was called with a herestring redirect but reads `` — the argument was never passed, and `set -u` aborted the function silently. Both earlier fix attempts (#2762, #2763) treated the wrong layer (jq program, then date arithmetic); the computation was never the problem.
- One-line fix: pass the run JSON as an argument. Verified locally against the live GitHub API with real jq: mutation 9m 38s, release gate 8m 3s, gitleaks 1m 0s.

## Cyclic Execution Evidence

- Fresh main sync: branch from origin/main at 857080ecd, clean worktree; local end-to-end run of the script (live API) is the red-check evidence
- Clean workspace: one line in scripts/nightly-health.sh
- Branch: fix/nightly-health-arg
- Scope gate: allowed scripts/nightly-health.sh only
- Red-check handling: local live-API run green before push

## Contract Impact

not applicable - report formatting only.

## RBAC / Permissions

not applicable - no permissions changed.

## Notification / Realtime

not applicable - no realtime behavior changed.

## Frontend Resilience

not applicable - CI observability only.

## Scope Gate

- Allowed paths: scripts/nightly-health.sh
- Denied paths: everything else
- Migration/docs/test impact: none
- Rollback note: revert the single commit

## Validation

- Targeted tests or smoke run: full local execution of the script against the live API (GITHUB_TOKEN + real jq 1.7.1) — all rows render with durations
- Result: local end-to-end green
- Not checked: runner rendering (same shell semantics; first scheduled run confirms)